### PR TITLE
Dholladay00/scaleshift fortran

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if(SINGULARITY_USE_KOKKOS AND SINGULARITY_USE_CUDA)
   set(CMAKE_CXX_COMPILER ${NVCC_WRAPPER_DIR}/nvcc_wrapper CACHE STRING "")
 endif()
 
-project(singularity-eos VERSION 1.3.0)
+project(singularity-eos VERSION 1.4.0)
 
 if(SINGULARITY_USE_FORTRAN)
   enable_language(CXX Fortran)

--- a/eos/eos.hpp
+++ b/eos/eos.hpp
@@ -1489,7 +1489,14 @@ private:
 using EOS = Variant<
     IdealGas, Gruneisen, JWL, DavisReactants, DavisProducts,
     ScaledEOS<IdealGas>, ShiftedEOS<IdealGas>, ShiftedEOS<ScaledEOS<IdealGas>>,
-    RelativisticEOS<IdealGas>
+    ScaledEOS<ShiftedEOS<IdealGas>>, RelativisticEOS<IdealGas>,
+    ScaledEOS<Gruneisen>, ShiftedEOS<Gruneisen>,
+    ScaledEOS<ShiftedEOS<Gruneisen>>,
+    ScaledEOS<JWL>, ShiftedEOS<JWL>, ScaledEOS<ShiftedEOS<JWL>>,
+    ScaledEOS<DavisReactants>, ShiftedEOS<DavisReactants>,
+    ScaledEOS<ShiftedEOS<DavisReactants>>,
+    ScaledEOS<DavisProducts>, ShiftedEOS<DavisProducts>,
+    ScaledEOS<ShiftedEOS<DavisProducts>>
 #ifdef SPINER_USE_HDF
     ,
     SpinerEOSDependsRhoT, SpinerEOSDependsRhoSie,
@@ -1497,6 +1504,8 @@ using EOS = Variant<
     ShiftedEOS<SpinerEOSDependsRhoT>, ShiftedEOS<SpinerEOSDependsRhoSie>,
     ShiftedEOS<ScaledEOS<SpinerEOSDependsRhoT>>,
     ShiftedEOS<ScaledEOS<SpinerEOSDependsRhoSie>>,
+    ScaledEOS<ShiftedEOS<SpinerEOSDependsRhoT>>,
+    ScaledEOS<ShiftedEOS<SpinerEOSDependsRhoSie>>,
     RelativisticEOS<SpinerEOSDependsRhoT>,
     RelativisticEOS<SpinerEOSDependsRhoSie>,
     // TODO(JMM): Might need shifted + relativistic
@@ -1508,7 +1517,8 @@ using EOS = Variant<
 #endif // SPINER_USE_HDF
 #ifdef SINGULARITY_USE_EOSPAC
     ,
-    EOSPAC, ScaledEOS<EOSPAC>, ShiftedEOS<EOSPAC>, ShiftedEOS<ScaledEOS<EOSPAC>>
+    EOSPAC, ScaledEOS<EOSPAC>, ShiftedEOS<EOSPAC>,
+    ShiftedEOS<ScaledEOS<EOSPAC>>, ScaledEOS<ShiftedEOS<EOSPAC>>
 #endif // SINGULARITY_USE_EOSPAC
     >;
 

--- a/eos/eos_builder.hpp
+++ b/eos/eos_builder.hpp
@@ -92,8 +92,8 @@ namespace EOSBuilder {
 
   template<typename T>
   EOS applyShiftAndScale(T&& eos,
-			 bool scaled, bool shifted,
-			 Real scale, Real shift) {
+                         bool scaled, bool shifted,
+                         Real scale, Real shift) {
     if (shifted && scaled) {
       ShiftedEOS<T> a(std::forward<T>(eos),shift);
       ScaledEOS<ShiftedEOS<T>> b(std::move(a),scale);

--- a/eos/eos_builder.hpp
+++ b/eos/eos_builder.hpp
@@ -74,8 +74,8 @@ namespace EOSBuilder {
 
   template<typename T>
   EOS applyScaleAndShift(T&& eos,
-					   bool scaled, bool shifted,
-					   Real scale, Real shift) {
+			 bool scaled, bool shifted,
+			 Real scale, Real shift) {
     if (shifted && scaled) {
       ScaledEOS<T> a(std::move(eos),scale);
       ShiftedEOS<ScaledEOS<T>> b(std::move(a),shift);
@@ -86,6 +86,24 @@ namespace EOSBuilder {
     }
     if (scaled) {
       return ScaledEOS<T>(std::move(eos),scale);
+    }
+    return eos;
+  }
+
+  template<typename T>
+  EOS applyShiftAndScale(T&& eos,
+			 bool scaled, bool shifted,
+			 Real scale, Real shift) {
+    if (shifted && scaled) {
+      ShiftedEOS<T> a(std::forward<T>(eos),shift);
+      ScaledEOS<ShiftedEOS<T>> b(std::move(a),scale);
+      return b;
+    }
+    if (shifted) {
+      return ShiftedEOS<T>(std::forward<T>(eos),shift);
+    }
+    if (scaled) {
+      return ScaledEOS<T>(std::forward<T>(eos),scale);
     }
     return eos;
   }

--- a/eos/singularity_eos.cpp
+++ b/eos/singularity_eos.cpp
@@ -39,6 +39,9 @@ int init_sg_eos(const int nmat, EOS* &eos) {
   EOSBuilder::applyShiftAndScale(A, enabled[0] == 1, enabled[1] == 1,\
                                  vals[0], vals[1])
 
+constexpr const int def_en[2] = {0, 0};
+constexpr const double def_v[2] = {0.0, 0.0};
+
 int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
                      const double Cv,
                      int const * const enabled, double const * const vals) {
@@ -46,6 +49,11 @@ int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
   EOS eos_ = SGAPPLYMOD(IdealGas(gm1, Cv));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
+}
+
+int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
+                     const double Cv) {
+  return init_sg_IdealGas(matindex, eos, gm1, Cv, def_en, def_v);
 }
 
 int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
@@ -59,6 +67,14 @@ int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
   return 0;
 }
 
+int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
+                      const double s1, const double s2, const double s3,
+                      const double G0, const double b, const double rho0,
+                      const double T0, const double P0, const double Cv) {
+  return init_sg_Gruneisen(matindex, eos, C0, s1, s2, s3, G0, b, rho0, T0, P0,
+                           Cv, def_en, def_v);
+}
+
 int init_sg_JWL(const int matindex, EOS* eos, const double A,
                 const double B, const double R1, const double R2,
                 const double w, const double rho0, const double Cv,
@@ -67,6 +83,13 @@ int init_sg_JWL(const int matindex, EOS* eos, const double A,
   EOS eos_ = SGAPPLYMOD(JWL(A, B, R1, R2, w, rho0, Cv));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
+}
+
+int init_sg_JWL(const int matindex, EOS* eos, const double A,
+                const double B, const double R1, const double R2,
+                const double w, const double rho0, const double Cv) {
+  return init_sg_JWL(matindex, eos, A, B, R1, R2, w, rho0, Cv, def_en,
+                     def_v);
 }
 
 int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
@@ -81,6 +104,14 @@ int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
   return 0;
 }
 
+int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
+                          const double b, const double k, const double n,
+                          const double vc, const double pc, const double Cv,
+                          const double E0) {
+  return init_sg_DavisProducts(matindex, eos, a, b, k, n, vc, pc, Cv, E0,
+                               def_en, def_v);
+}
+
 int init_sg_DavisReactants(const int matindex, EOS* eos,
                            const double rho0, const double e0, const double P0,
                            const double T0, const double A, const double B,
@@ -90,9 +121,18 @@ int init_sg_DavisReactants(const int matindex, EOS* eos,
                            double const * const vals) {
   assert(matindex >= 0);
   EOS eos_ =
-    SGAPPLYMOD(DavisReactants(rho0, e0, P0, T0, A, B, C, G0, Z, alpha, Cv0));
+  SGAPPLYMOD(DavisReactants(rho0, e0, P0, T0, A, B, C, G0, Z, alpha, Cv0));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
+}
+
+int init_sg_DavisReactants(const int matindex, EOS* eos,
+                           const double rho0, const double e0, const double P0,
+                           const double T0, const double A, const double B,
+                           const double C, const double G0, const double Z,
+                           const double alpha, const double Cv0) {
+  return init_sg_DavisReactants(matindex, eos, rho0, e0, P0, T0, A, B, C, G0, Z,
+                                alpha, Cv0, def_en, def_v);
 }
 
 #ifdef SPINER_USE_HDF
@@ -106,6 +146,12 @@ int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
   return 0;
 }
 
+int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
+                              const char* filename, const int matid) {
+  return init_sg_SpinerDependsRhoT(matindex, eos, filename, matid, def_en,
+                                   def_v);
+}
+
 int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
                                 const char* filename, const int matid,
                                 int const * const enabled,
@@ -115,6 +161,11 @@ int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
+int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
+                                const char* filename, const int matid) {
+  return init_sg_SpinerDependsRhoSie(matindex, eos, filename, matid, def_en,
+                                     def_v);
+}
 #endif
 
 #ifdef SINGULARITY_USE_EOSPAC
@@ -123,6 +174,10 @@ int init_sg_eospac(const int matindex, EOS* eos, const int id,
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(EOSPAC(id));
   eos[matindex] = eos_.GetOnDevice();
+  return 0;
+}
+int init_sg_eospac(const int matindex, EOS* eos, const int id) {
+  return init_sg_eospac(matindex, eos, id, def_en, def_v); 
 }
 #endif // SINGULARITY_USE_EOSPAC
 

--- a/eos/singularity_eos.cpp
+++ b/eos/singularity_eos.cpp
@@ -13,6 +13,7 @@
 //------------------------------------------------------------------------------
 
 #include "singularity_eos.hpp"
+#include "eos_builder.hpp"
 #include <map>
 #include <algorithm>
 #include <cassert>
@@ -34,10 +35,15 @@ int init_sg_eos(const int nmat, EOS* &eos) {
   return 0;
 }
 
+#define SGAPPLYMOD(A) \
+  EOSBuilder::applyShiftAndScale(A, enabled[0] == 1, enabled[1] == 1,\
+				 vals[0], vals[1])
+
 int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
-                     const double Cv) {
+                     const double Cv,
+		     int const * const enabled, double const * const vals) {
   assert(matindex >= 0);
-  EOS eos_ = IdealGas(gm1, Cv);
+  EOS eos_ = SGAPPLYMOD(IdealGas(gm1, Cv));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
@@ -45,18 +51,20 @@ int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
 int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
                       const double s1, const double s2, const double s3,
                       const double G0, const double b, const double rho0,
-                      const double T0, const double P0, const double Cv) {
+                      const double T0, const double P0, const double Cv,
+		      int const * const enabled, double const * const vals) {
   assert(matindex >= 0);
-  EOS eos_ = Gruneisen(C0, s1, s2, s3, G0, b, rho0, T0, P0, Cv);
+  EOS eos_ = SGAPPLYMOD(Gruneisen(C0, s1, s2, s3, G0, b, rho0, T0, P0, Cv));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 
 int init_sg_JWL(const int matindex, EOS* eos, const double A,
                 const double B, const double R1, const double R2,
-                const double w, const double rho0, const double Cv) {
+                const double w, const double rho0, const double Cv,
+		int const * const enabled, double const * const vals) {
   assert(matindex >= 0);
-  EOS eos_ = JWL(A, B, R1, R2, w, rho0, Cv);
+  EOS eos_ = SGAPPLYMOD(JWL(A, B, R1, R2, w, rho0, Cv));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
@@ -64,9 +72,11 @@ int init_sg_JWL(const int matindex, EOS* eos, const double A,
 int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
                           const double b, const double k, const double n,
                           const double vc, const double pc, const double Cv,
-                          const double E0) {
+                          const double E0,
+			  int const * const enabled,
+			  double const * const vals) {
   assert(matindex >= 0);
-  EOS eos_ = DavisProducts(a, b, k, n, vc, pc, Cv, E0);
+  EOS eos_ = SGAPPLYMOD(DavisProducts(a, b, k, n, vc, pc, Cv, E0));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
@@ -75,38 +85,48 @@ int init_sg_DavisReactants(const int matindex, EOS* eos,
                            const double rho0, const double e0, const double P0,
                            const double T0, const double A, const double B,
                            const double C, const double G0, const double Z,
-                           const double alpha, const double Cv0) {
+                           const double alpha, const double Cv0,
+			   int const * const enabled,
+			   double const * const vals) {
   assert(matindex >= 0);
-  EOS eos_ = DavisReactants(rho0, e0, P0, T0, A, B, C, G0, Z, alpha, Cv0);
+  EOS eos_ =
+    SGAPPLYMOD(DavisReactants(rho0, e0, P0, T0, A, B, C, G0, Z, alpha, Cv0));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 
 #ifdef SPINER_USE_HDF
 int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
-                              const char* filename, const int matid) {
+                              const char* filename, const int matid,
+			      int const * const enabled,
+			      double const * const vals) {
   assert(matindex >= 0);
-  EOS eos_ = SpinerEOSDependsRhoT(std::string(filename), matid);
+  EOS eos_ = SGAPPLYMOD(SpinerEOSDependsRhoT(std::string(filename), matid));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 
 int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
-                                const char* filename, const int matid) {
+                                const char* filename, const int matid,
+				int const * const enabled,
+				double const * const vals) {
   assert(matindex >= 0);
-  EOS eos_ = SpinerEOSDependsRhoSie(std::string(filename), matid);
+  EOS eos_ = SGAPPLYMOD(SpinerEOSDependsRhoSie(std::string(filename), matid));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 #endif
 
 #ifdef SINGULARITY_USE_EOSPAC
-int init_sg_eospac(const int matindex, EOS* eos, const int id) {
+int init_sg_eospac(const int matindex, EOS* eos, const int id,
+		   int const * const enabled, double const * const vals) {
   assert(matindex >= 0);
-  EOS eos_ = EOSPAC(id);
+  EOS eos_ = SGAPPLYMOD(EOSPAC(id));
   eos[matindex] = eos_.GetOnDevice();
 }
 #endif // SINGULARITY_USE_EOSPAC
+
+#undef SGAPPLYMOD
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
 using Lrgt = Kokkos::LayoutRight;

--- a/eos/singularity_eos.cpp
+++ b/eos/singularity_eos.cpp
@@ -37,11 +37,11 @@ int init_sg_eos(const int nmat, EOS* &eos) {
 
 #define SGAPPLYMOD(A) \
   EOSBuilder::applyShiftAndScale(A, enabled[0] == 1, enabled[1] == 1,\
-				 vals[0], vals[1])
+                                 vals[0], vals[1])
 
 int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
                      const double Cv,
-		     int const * const enabled, double const * const vals) {
+                     int const * const enabled, double const * const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(IdealGas(gm1, Cv));
   eos[matindex] = eos_.GetOnDevice();
@@ -52,7 +52,7 @@ int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
                       const double s1, const double s2, const double s3,
                       const double G0, const double b, const double rho0,
                       const double T0, const double P0, const double Cv,
-		      int const * const enabled, double const * const vals) {
+                      int const * const enabled, double const * const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(Gruneisen(C0, s1, s2, s3, G0, b, rho0, T0, P0, Cv));
   eos[matindex] = eos_.GetOnDevice();
@@ -62,7 +62,7 @@ int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
 int init_sg_JWL(const int matindex, EOS* eos, const double A,
                 const double B, const double R1, const double R2,
                 const double w, const double rho0, const double Cv,
-		int const * const enabled, double const * const vals) {
+                int const * const enabled, double const * const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(JWL(A, B, R1, R2, w, rho0, Cv));
   eos[matindex] = eos_.GetOnDevice();
@@ -73,8 +73,8 @@ int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
                           const double b, const double k, const double n,
                           const double vc, const double pc, const double Cv,
                           const double E0,
-			  int const * const enabled,
-			  double const * const vals) {
+                          int const * const enabled,
+                          double const * const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(DavisProducts(a, b, k, n, vc, pc, Cv, E0));
   eos[matindex] = eos_.GetOnDevice();
@@ -86,8 +86,8 @@ int init_sg_DavisReactants(const int matindex, EOS* eos,
                            const double T0, const double A, const double B,
                            const double C, const double G0, const double Z,
                            const double alpha, const double Cv0,
-			   int const * const enabled,
-			   double const * const vals) {
+                           int const * const enabled,
+                           double const * const vals) {
   assert(matindex >= 0);
   EOS eos_ =
     SGAPPLYMOD(DavisReactants(rho0, e0, P0, T0, A, B, C, G0, Z, alpha, Cv0));
@@ -98,8 +98,8 @@ int init_sg_DavisReactants(const int matindex, EOS* eos,
 #ifdef SPINER_USE_HDF
 int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
                               const char* filename, const int matid,
-			      int const * const enabled,
-			      double const * const vals) {
+                              int const * const enabled,
+                              double const * const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(SpinerEOSDependsRhoT(std::string(filename), matid));
   eos[matindex] = eos_.GetOnDevice();
@@ -108,8 +108,8 @@ int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
 
 int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
                                 const char* filename, const int matid,
-				int const * const enabled,
-				double const * const vals) {
+                                int const * const enabled,
+                                double const * const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(SpinerEOSDependsRhoSie(std::string(filename), matid));
   eos[matindex] = eos_.GetOnDevice();
@@ -119,7 +119,7 @@ int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
 
 #ifdef SINGULARITY_USE_EOSPAC
 int init_sg_eospac(const int matindex, EOS* eos, const int id,
-		   int const * const enabled, double const * const vals) {
+                   int const * const enabled, double const * const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(EOSPAC(id));
   eos[matindex] = eos_.GetOnDevice();

--- a/eos/singularity_eos.f90
+++ b/eos/singularity_eos.f90
@@ -56,92 +56,105 @@ module singularity_eos
 
   interface
     integer(kind=c_int) function &
-      init_sg_IdealGas(matindex, eos, gm1, Cv) &
+      init_sg_IdealGas(matindex, eos, gm1, Cv, sg_mods_enabled, &
+                       sg_mods_values) &
       bind(C, name='init_sg_IdealGas')
       import
       integer(c_int), value, intent(in)      :: matindex
       type(c_ptr), value, intent(in)         :: eos
       real(kind=c_double), value, intent(in) :: gm1, Cv
+      type(c_ptr), value, intent(in)         :: sg_mods_enabled, sg_mods_values
     end function init_sg_IdealGas
   end interface
 
   interface
     integer(kind=c_int) function &
       init_sg_Gruneisen(matindex, eos, C0, s1, s2, s3, G0, b, rho0, T0, P0,&
-                        Cv) &
+                        Cv, sg_mods_enabled, sg_mods_values) &
       bind(C, name='init_sg_Gruneisen')
       import
       integer(c_int), value, intent(in)      :: matindex
       type(c_ptr), value, intent(in)         :: eos
       real(kind=c_double), value, intent(in) :: C0, s1, s2, s3, G0, b, rho0
       real(kind=c_double), value, intent(in) :: T0, P0, Cv
+      type(c_ptr), value, intent(in)         :: sg_mods_enabled, sg_mods_values
     end function init_sg_Gruneisen
   end interface
   
   interface
     integer(kind=c_int) function &
-      init_sg_JWL(matindex, eos, A, B, R1, R2, w, rho0, Cv) &
+      init_sg_JWL(matindex, eos, A, B, R1, R2, w, rho0, Cv, sg_mods_enabled, &
+                  sg_mods_values) &
       bind(C, name='init_sg_JWL')
       import
       integer(c_int), value, intent(in)      :: matindex
       type(c_ptr), value, intent(in)         :: eos
       real(kind=c_double), value, intent(in) :: A, B, R1, R2, w, rho0, Cv
+      type(c_ptr), value, intent(in)         :: sg_mods_enabled, sg_mods_values
     end function init_sg_JWL
   end interface
 
   interface
     integer(kind=c_int) function &
-      init_sg_DavisProducts(matindex, eos, a, b, k, n, vc, pc, Cv, E0) &
+      init_sg_DavisProducts(matindex, eos, a, b, k, n, vc, pc, Cv, E0, &
+                            sg_mods_enabled, sg_mods_values) &
       bind(C, name='init_sg_DavisProducts')
       import
       integer(c_int), value, intent(in)      :: matindex
       type(c_ptr), value, intent(in)         :: eos
       real(kind=c_double), value, intent(in) :: a, b, k, n, vc, pc, Cv, E0
+      type(c_ptr), value, intent(in)         :: sg_mods_enabled, sg_mods_values
     end function init_sg_DavisProducts
   end interface
 
   interface
     integer(kind=c_int) function &
       init_sg_DavisReactants(matindex, eos, rho0, e0, P0, T0, A, B, C, G0, Z,&
-                          alpha, Cv0) &
+                             alpha, Cv0, sg_mods_enabled, sg_mods_values) &
       bind(C, name='init_sg_DavisReactants')
       import
       integer(c_int), value, intent(in)      :: matindex
       type(c_ptr), value, intent(in)         :: eos
       real(kind=c_double), value, intent(in) :: rho0, e0, P0, T0, A, B, C, G0,&
                                                 Z, alpha, Cv0
+      type(c_ptr), value, intent(in)         :: sg_mods_enabled, sg_mods_values
     end function init_sg_DavisReactants
   end interface
 
   interface
     integer(kind=c_int) function &
-      init_sg_SpinerDependsRhoT(matindex, eos, filename, id) &
+      init_sg_SpinerDependsRhoT(matindex, eos, filename, id, sg_mods_enabled, &
+                                sg_mods_values) &
       bind(C, name='init_sg_SpinerDependsRhoT')
       import
       integer(c_int), value, intent(in)      :: matindex, id
       type(c_ptr), value, intent(in)         :: eos
       character(kind=c_char), intent(in)     :: filename(*)
+      type(c_ptr), value, intent(in)         :: sg_mods_enabled, sg_mods_values
     end function init_sg_SpinerDependsRhoT
   end interface
 
   interface
     integer(kind=c_int) function &
-      init_sg_SpinerDependsRhoSie(matindex, eos, filename, id) &
+      init_sg_SpinerDependsRhoSie(matindex, eos, filename, id, &
+                                  sg_mods_enabled, sg_mods_values) &
       bind(C, name='init_sg_SpinerDependsRhoSie')
       import
       integer(c_int), value, intent(in)      :: matindex, id
       type(c_ptr), value, intent(in)         :: eos
       character(kind=c_char), intent(in)     :: filename(*)
+      type(c_ptr), value, intent(in)         :: sg_mods_enabled, sg_mods_values
     end function init_sg_SpinerDependsRhoSie
   end interface
 
   interface
     integer(kind=c_int) function &
-      init_sg_eospac(matindex, eos, id) &
+      init_sg_eospac(matindex, eos, id, sg_mods_enabled, sg_mods_values) &
       bind(C, name='init_sg_eospac')
       import
       integer(c_int), value, intent(in) :: matindex, id
       type(c_ptr), value, intent(in)    :: eos
+      type(c_ptr), value, intent(in)    :: sg_mods_enabled, sg_mods_values
     end function init_sg_eospac
   end interface
 
@@ -263,77 +276,114 @@ contains
     err = init_sg_eos(nmat, eos%ptr)
   end function init_sg_eos_f
 
-  integer function init_sg_IdealGas_f(matindex, eos, gm1, Cv) &
+  integer function init_sg_IdealGas_f(matindex, eos, gm1, Cv, &
+                                      sg_mods_enabled, sg_mods_values) &
     result(err)
     integer(c_int), value, intent(in) :: matindex
     type(sg_eos_ary_t), intent(in)    :: eos
     real(kind=8), value, intent(in)   :: gm1, Cv
-    err = init_sg_IdealGas(matindex-1, eos%ptr, gm1, Cv)
+    integer(kind=c_int), dimension(:), target, intent(in) :: sg_mods_enabled
+    real(kind=8), dimension(:), target, intent(in)        :: sg_mods_values
+    err = init_sg_IdealGas(matindex-1, eos%ptr, gm1, Cv, &
+                           c_loc(sg_mods_enabled), c_loc(sg_mods_values))
   end function init_sg_IdealGas_f
 
   integer function init_sg_Gruneisen_f(matindex, eos, C0, s1, s2, s3, G0, b,&
-                                       rho0, T0, P0, Cv) &
+                                       rho0, T0, P0, Cv, sg_mods_enabled, &
+                                       sg_mods_values) &
     result(err)
     integer(c_int), value, intent(in) :: matindex
     type(sg_eos_ary_t), intent(in)    :: eos
     real(kind=8), value, intent(in)   :: C0, s1, s2, s3, G0, b, rho0
     real(kind=8), value, intent(in)   :: T0, P0, Cv
+    integer(kind=c_int), dimension(:), target, intent(in) :: sg_mods_enabled
+    real(kind=8), dimension(:), target, intent(in)        :: sg_mods_values
     err = init_sg_Gruneisen(matindex-1, eos%ptr, C0, s1, s2, s3, G0, b, rho0,&
-                            T0, P0, Cv)
+                            T0, P0, Cv, c_loc(sg_mods_enabled), &
+                            c_loc(sg_mods_values))
   end function init_sg_Gruneisen_f
 
-  integer function init_sg_JWL_f(matindex, eos, A, B, R1, R2, w, rho0, Cv) &
+  integer function init_sg_JWL_f(matindex, eos, A, B, R1, R2, w, rho0, Cv, &
+                                 sg_mods_enabled, sg_mods_values) &
     result(err)
     integer(c_int), value, intent(in) :: matindex
     type(sg_eos_ary_t), intent(in)    :: eos
     real(kind=8), value, intent(in)   :: A, B, R1, R2, w, rho0, Cv
-    err = init_sg_JWL(matindex-1, eos%ptr, A, B, R1, R2, w, rho0, Cv)
+    integer(kind=c_int), dimension(:), target, intent(in) :: sg_mods_enabled
+    real(kind=8), dimension(:), target, intent(in)        :: sg_mods_values
+    err = init_sg_JWL(matindex-1, eos%ptr, A, B, R1, R2, w, rho0, Cv, &
+                      c_loc(sg_mods_enabled), c_loc(sg_mods_values))
   end function init_sg_JWL_f
   
-  integer function init_sg_DavisProducts_f(matindex, eos, a, b, k, n, vc, pc,&
-                                           Cv, E0) &
+  integer function init_sg_DavisProducts_f(matindex, eos, a, b, k, n, vc, pc, &
+                                           Cv, E0, sg_mods_enabled, &
+                                           sg_mods_values) &
     result(err)
     integer(c_int), value, intent(in) :: matindex
     type(sg_eos_ary_t), intent(in)    :: eos
     real(kind=8), value, intent(in)   :: a, b, k, n, vc, pc, Cv, E0
-    err = init_sg_DavisProducts(matindex-1, eos%ptr, a, b, k, n, vc, pc, Cv, E0)
+    integer(kind=c_int), dimension(:), target, intent(in) :: sg_mods_enabled
+    real(kind=8), dimension(:), target, intent(in)        :: sg_mods_values
+    err = init_sg_DavisProducts(matindex-1, eos%ptr, a, b, k, n, vc, pc, Cv, &
+                                E0, c_loc(sg_mods_enabled), &
+                                c_loc(sg_mods_values))
   end function init_sg_DavisProducts_f
 
-  integer function init_sg_DavisReactants_f(matindex, eos, rho0, e0, P0, T0,&
-                                            A, B, C, G0, Z, alpha, Cv0) &
+  integer function init_sg_DavisReactants_f(matindex, eos, rho0, e0, P0, T0, &
+                                            A, B, C, G0, Z, alpha, Cv0, &
+                                            sg_mods_enabled, sg_mods_values) &
     result(err)
     integer(c_int), value, intent(in) :: matindex
     type(sg_eos_ary_t), intent(in)    :: eos
     real(kind=8), value, intent(in)   :: rho0, e0, P0, T0, A, B, C, G0, Z
     real(kind=8), value, intent(in)   :: alpha, Cv0
-    err = init_sg_DavisReactants(matindex-1, eos%ptr, rho0, e0, P0, T0, A, B,&
-                                 C, G0, Z, alpha, Cv0)
+    integer(kind=c_int), dimension(:), target, intent(in) :: sg_mods_enabled
+    real(kind=8), dimension(:), target, intent(in)        :: sg_mods_values
+    err = init_sg_DavisReactants(matindex-1, eos%ptr, rho0, e0, P0, T0, A, B, &
+                                 C, G0, Z, alpha, Cv0, c_loc(sg_mods_enabled), &
+                                 c_loc(sg_mods_values))
   end function init_sg_DavisReactants_f
 
-  integer function init_sg_SpinerDependsRhoT_f(matindex, eos, filename, id) &
+  integer function init_sg_SpinerDependsRhoT_f(matindex, eos, filename, id, &
+                                               sg_mods_enabled, &
+                                               sg_mods_values) &
     result(err)
     integer(c_int), value, intent(in)         :: matindex
     type(sg_eos_ary_t), intent(in)            :: eos
     character(len=*, kind=c_char), intent(in) :: filename
     integer(c_int), intent(inout)             :: id
+    integer(kind=c_int), dimension(:), target, intent(in) :: sg_mods_enabled
+    real(kind=8), dimension(:), target, intent(in)        :: sg_mods_values
     err = init_sg_SpinerDependsRhoT(matindex-1, eos%ptr,&
-                                    trim(filename)//C_NULL_CHAR, id)
+                                    trim(filename)//C_NULL_CHAR, id, &
+                                    c_loc(sg_mods_enabled), &
+                                    c_loc(sg_mods_values))
   end function init_sg_SpinerDependsRhoT_f
 
-  integer function init_sg_SpinerDependsRhoSie_f(matindex, eos, filename, id) &
+  integer function init_sg_SpinerDependsRhoSie_f(matindex, eos, filename, id, &
+                                                 sg_mods_enabled, &
+                                                 sg_mods_values) &
     result(err)
     integer(c_int), value, intent(in)         :: matindex, id
     type(sg_eos_ary_t), intent(in)            :: eos
     character(len=*, kind=c_char), intent(in) :: filename
+    integer(kind=c_int), dimension(:), target, intent(in) :: sg_mods_enabled
+    real(kind=8), dimension(:), target, intent(in)        :: sg_mods_values
     err = init_sg_SpinerDependsRhoSie(matindex-1, eos%ptr,&
-                                      trim(filename)//C_NULL_CHAR, id)
+                                      trim(filename)//C_NULL_CHAR, id, &
+                                      c_loc(sg_mods_enabled), &
+                                      c_loc(sg_mods_values))
   end function init_sg_SpinerDependsRhoSie_f
 
-  integer function init_sg_eospac_f(matindex, eos, id) &
+  integer function init_sg_eospac_f(matindex, eos, id, sg_mods_enabled, &
+                                    sg_mods_values) &
     result(err)
     integer(c_int), value, intent(in) :: matindex, id
     type(sg_eos_ary_t), intent(in)    :: eos
-    err = init_sg_eospac(matindex-1, eos%ptr, id)
+    integer(kind=c_int), dimension(:), target, intent(in) :: sg_mods_enabled
+    real(kind=8), dimension(:), target, intent(in)        :: sg_mods_values
+    err = init_sg_eospac(matindex-1, eos%ptr, id, c_loc(sg_mods_enabled), &
+                         c_loc(sg_mods_values))
   end function init_sg_eospac_f
 
   integer function finalize_sg_eos_f(nmat, eos) &

--- a/eos/singularity_eos.hpp
+++ b/eos/singularity_eos.hpp
@@ -27,39 +27,50 @@ extern "C" {
 int init_sg_eos(const int nmat, EOS* &eos);
 
 int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
-                     const double Cv);
+                     const double Cv,
+		     int const * const enabled, double const * const vals);
 
 int init_sg_JWL(const int matindex, EOS* eos, const double A,
                 const double B, const double R1, const double R2,
-                const double w, const double rho0, const double Cv);
+                const double w, const double rho0, const double Cv,
+		int const * const enabled, double const * const vals);
 
 int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
                       const double s1, const double s2, const double s3,
                       const double G0, const double b, const double rho0,
-                      const double T0, const double P0, const double Cv);
+                      const double T0, const double P0, const double Cv,
+		      int const * const enabled, double const * const vals);
 
 int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
                           const double b, const double k, const double n,
                           const double vc, const double pc, const double Cv,
-                          const double E0);
+                          const double E0,
+			  int const * const enabled, double const * const vals);
 
 int init_sg_DavisReactants(const int matindex, EOS* eos, const double rho0,
                            const double e0, const double P0, const double T0,
                            const double A, const double B, const double C,
                            const double G0, const double Z, const double alpha,
-                           const double Cv0);
+                           const double Cv0,
+			   int const * const enabled,
+			   double const * const vals);
 
 #ifdef SPINER_USE_HDF
 int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
-                              const char* filename, const int id);
+                              const char* filename, const int id,
+			      int const * const enabled,
+			      double const * const vals);
 
 int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
-                                const char* filename, const int id);
+                                const char* filename, const int id,
+				int const * const enabled,
+				double const * const vals);
 #endif
 
 #ifdef SINGULARITY_USE_EOSPAC
  // capitalize? eospaceos Eospac Eospaceos EOSPAC EOSPACeos? 
-int init_sg_eospac(const int matindex, EOS* eos, const int id);
+  int init_sg_eospac(const int matindex, EOS* eos, const int id,
+		     int const * const enabled, double const * const vals);
 #endif // SINGULARITY_USE_EOSPAC
 
 int get_sg_eos(// sizing information

--- a/eos/singularity_eos.hpp
+++ b/eos/singularity_eos.hpp
@@ -28,49 +28,49 @@ int init_sg_eos(const int nmat, EOS* &eos);
 
 int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
                      const double Cv,
-		     int const * const enabled, double const * const vals);
+                     int const * const enabled, double const * const vals);
 
 int init_sg_JWL(const int matindex, EOS* eos, const double A,
                 const double B, const double R1, const double R2,
                 const double w, const double rho0, const double Cv,
-		int const * const enabled, double const * const vals);
+                int const * const enabled, double const * const vals);
 
 int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
                       const double s1, const double s2, const double s3,
                       const double G0, const double b, const double rho0,
                       const double T0, const double P0, const double Cv,
-		      int const * const enabled, double const * const vals);
+                      int const * const enabled, double const * const vals);
 
 int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
                           const double b, const double k, const double n,
                           const double vc, const double pc, const double Cv,
                           const double E0,
-			  int const * const enabled, double const * const vals);
+                          int const * const enabled, double const * const vals);
 
 int init_sg_DavisReactants(const int matindex, EOS* eos, const double rho0,
                            const double e0, const double P0, const double T0,
                            const double A, const double B, const double C,
                            const double G0, const double Z, const double alpha,
                            const double Cv0,
-			   int const * const enabled,
-			   double const * const vals);
+                           int const * const enabled,
+                           double const * const vals);
 
 #ifdef SPINER_USE_HDF
 int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
                               const char* filename, const int id,
-			      int const * const enabled,
-			      double const * const vals);
+                              int const * const enabled,
+                              double const * const vals);
 
 int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
                                 const char* filename, const int id,
-				int const * const enabled,
-				double const * const vals);
+                                int const * const enabled,
+                                double const * const vals);
 #endif
 
 #ifdef SINGULARITY_USE_EOSPAC
- // capitalize? eospaceos Eospac Eospaceos EOSPAC EOSPACeos? 
-  int init_sg_eospac(const int matindex, EOS* eos, const int id,
-		     int const * const enabled, double const * const vals);
+// capitalize? eospaceos Eospac Eospaceos EOSPAC EOSPACeos?
+int init_sg_eospac(const int matindex, EOS* eos, const int id,
+                   int const * const enabled, double const * const vals);
 #endif // SINGULARITY_USE_EOSPAC
 
 int get_sg_eos(// sizing information
@@ -97,5 +97,42 @@ int finalize_sg_eos(const int nmat, EOS* &eos, const int own_kokkos=0);
 #if defined(__cplusplus)
 }
 #endif
+
+// outside of C scope, provide overloads
+int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
+                     const double Cv);
+
+int init_sg_JWL(const int matindex, EOS* eos, const double A,
+                const double B, const double R1, const double R2,
+                const double w, const double rho0, const double Cv);
+
+int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
+                      const double s1, const double s2, const double s3,
+                      const double G0, const double b, const double rho0,
+                      const double T0, const double P0, const double Cv);
+
+int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
+                          const double b, const double k, const double n,
+                          const double vc, const double pc, const double Cv,
+                          const double E0);
+
+int init_sg_DavisReactants(const int matindex, EOS* eos, const double rho0,
+                           const double e0, const double P0, const double T0,
+                           const double A, const double B, const double C,
+                           const double G0, const double Z, const double alpha,
+                           const double Cv0);
+
+#ifdef SPINER_USE_HDF
+int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
+                              const char* filename, const int id);
+
+int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
+                                const char* filename, const int id);
+#endif
+
+#ifdef SINGULARITY_USE_EOSPAC
+// capitalize? eospaceos Eospac Eospaceos EOSPAC EOSPACeos?
+int init_sg_eospac(const int matindex, EOS* eos, const int id);
+#endif // SINGULARITY_USE_EOSPAC
 
 #endif // EOS_SINGULARITY_EOS_HPP_


### PR DESCRIPTION
This MR enables passing scaling and shifting parameters through the higher level API (both c/c++ and fortran). The high level API applies the shift and then the scale if both are present for consistency with host codes. 

I still need to bump version numbers and I'm curious with @Yurlungur thinks about how the params are passed in? Should they be defaulted to `nullptr`, should I explicitly overload such that the current call signatures are still valid? 