### PR TITLE
Separate Out EOSPAC functionalit out of sesame2spiner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ option (SINGULARITY_USE_EOSPAC "Pull in eospac" OFF)
 option (SINGULARITY_USE_CUDA "Enable cuda support" OFF)
 option (SINGULARITY_USE_KOKKOSKERNELS
   "Use kokkos-kernels for linear algebra" OFF)
-option (SINGULARITY_INVERT_AT_SETUP "Use eospacs preinverted tables" OFF)
 option (SINGULARITY_BUILD_TESTS "Compile tests" OFF)
 option (SINGULARITY_BUILD_SESAME2SPINER "Compile sesame2spiner" OFF)
 option (SINGULARITY_BUILD_STELLARCOLLAPSE2SPINER "Compile stellarcollapse2spiner" OFF)
@@ -34,7 +33,6 @@ option (SINGULARITY_SUBMODULE_MODE "Submodule mode" OFF)
 option (SINGULARITY_BUILD_CLOSURE "Mixed cell closure" ON)
 option (SINGULARITY_TEST_SESAME "Test the Sesame table readers" OFF)
 option (SINGULARITY_TEST_STELLAR_COLLAPSE "Test the stellar collapse table readers" OFF)
-option (SINGULARITY_EOS_SKIP_EXTRAP "Turn off eospac extrap checks" OFF)
 option (SINGULARITY_USE_SINGLE_LOGS "Use single precision logs. Can harm accuracy." OFF)
 option (SINGULARITY_FMATH_USE_ORDER_4 "4th order interpolant for fast logs. Default is 7th order." OFF)
 option (SINGULARITY_FMATH_USE_ORDER_5 "5th order interpolant for fast logs. Default is 7th order." OFF)
@@ -261,23 +259,10 @@ else()
 endif()
 
 if (SINGULARITY_USE_EOSPAC)
-  target_compile_definitions(singularity-eos::flags INTERFACE
-                             SINGULARITY_USE_EOSPAC
-                             EOSPAC_WARN)
-  if (SINGULARITY_INVERT_AT_SETUP)
-    target_compile_definitions(singularity-eos::flags INTERFACE
-                               SINGULARITY_INVERT_AT_SETUP)
-  endif ()
-  if (SINGULARITY_EOS_SKIP_EXTRAP)
-    target_compile_definitions(singularity-eos::flags INTERFACE
-                               SINGULARITY_EOS_SKIP_EXTRAP)
-  endif ()
-  if (SINGULARITY_EOSPAC_INSTALL_DIR)
-    list(APPEND CMAKE_PREFIX_PATH "${SINGULARITY_EOSPAC_INSTALL_DIR}")
-    set(EOSPAC_INCLUDE_DIR "${SINGULARITY_EOSPAC_INSTALL_DIR}/include")
-  endif()
-  find_package(EOSPAC)
-  target_link_libraries(singularity-eos::libs INTERFACE EOSPAC::eospac)
+  add_subdirectory(eospac-wrapper)
+  target_link_libraries(singularity-eos::libs
+    INTERFACE
+    singularity-eos::eospac_wrapper)
 endif ()
 
 # fast math
@@ -379,6 +364,12 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/utils/variant"
   DESTINATION "include"
   FILES_MATCHING PATTERN "*.hpp"
   )
+if (SINGULARITY_USE_EOSPAC)
+  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/eospac-wrapper"
+    DESTINATION "include"
+    FILES_MATCHING PATTERN "*.hpp"
+    )
+endif()
 install(CODE
   "execute_process( \
     COMMAND ${CMAKE_COMMAND} -E create_symlink \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,10 @@ if (SINGULARITY_USE_EOSPAC)
   add_subdirectory(eospac-wrapper)
   target_link_libraries(singularity-eos::libs
     INTERFACE
-    singularity-eos::eospac_wrapper)
+    eospac-wrapper)
+  target_compile_definitions(singularity-eos::flags
+    INTERFACE
+    SINGULARITY_USE_EOSPAC)
 endif ()
 
 # fast math
@@ -275,7 +278,7 @@ if (SINGULARITY_FMATH_USE_ORDER_4 AND SINGULARITY_FMATH_USE_ORDER_5)
 endif()
 if (SINGULARITY_FMATH_USE_ORDER_4)
   target_compile_definitions(singularity-eos::flags INTERFACE
-    SINGULAIRTY_FMATH_USE_ORDER_4)
+    SINGULARITY_FMATH_USE_ORDER_4)
 endif()
 if (SINGULARITY_FMATH_USE_ORDER_5)
   target_compile_definitions(singularity-eos::flags INTERFACE

--- a/eospac-wrapper/CMakeLists.txt
+++ b/eospac-wrapper/CMakeLists.txt
@@ -20,19 +20,15 @@ if (SINGULARITY_EOSPAC_INSTALL_DIR)
 endif()
 find_package(EOSPAC)
 
-add_library(singularity-eos::eospac_wrapper
+add_library(eospac-wrapper
   eospac_wrapper.hpp
   eospac_wrapper.cpp
   )
 
-target_compile_definitions(singularity-eos::eospac_wrapper
-  EOSPAC_WARN
-  )
-
 if (SINGULARITY_EOSPAC_SKIP_EXTRAP)
-  target_compile_definitions(singularity-eos::eospac_wrapper
+  target_compile_definitions(eospac-wrapper
     SINGULARITY_EOSPAC_SKIP_EXTRAP
     )
 endif()
 
-target_link_libraries(singularity-eos::eospac_wrapper EOSPAC::eospac)
+target_link_libraries(eospac-wrapper EOSPAC::eospac)

--- a/eospac-wrapper/CMakeLists.txt
+++ b/eospac-wrapper/CMakeLists.txt
@@ -1,0 +1,38 @@
+#------------------------------------------------------------------------------
+# © 2021. Triad National Security, LLC. All rights reserved.  This
+# program was produced under U.S. Government contract 89233218CNA000001
+# for Los Alamos National Laboratory (LANL), which is operated by Triad
+# National Security, LLC for the U.S.  Department of Energy/National
+# Nuclear Security Administration. All rights in the program are
+# reserved by Triad National Security, LLC, and the U.S. Department of
+# Energy/National Nuclear Security Administration. The Government is
+# granted for itself and others acting on its behalf a nonexclusive,
+# paid-up, irrevocable worldwide license in this material to reproduce,
+# prepare derivative works, distribute copies to the public, perform
+# publicly and display publicly, and to permit others to do so.
+#------------------------------------------------------------------------------
+
+option(SINGULARITY_EOSPAC_SKIP_EXTRAP "Skip extrapolation checks" OFF)
+
+if (SINGULARITY_EOSPAC_INSTALL_DIR)
+  list(APPEND CMAKE_PREFIX_PATH "${SINGULARITY_EOSPAC_INSTALL_DIR}")
+  set(EOSPAC_INCLUDE_DIR "${SINGULARITY_EOSPAC_INSTALL_DIR}/include")
+endif()
+find_package(EOSPAC)
+
+add_library(singularity-eos::eospac_wrapper
+  eospac_wrapper.hpp
+  eospac_wrapper.cpp
+  )
+
+target_compile_definitions(singularity-eos::eospac_wrapper
+  EOSPAC_WARN
+  )
+
+if (SINGULARITY_EOSPAC_SKIP_EXTRAP)
+  target_compile_definitions(singularity-eos::eospac_wrapper
+    SINGULARITY_EOSPAC_SKIP_EXTRAP
+    )
+endif()
+
+target_link_libraries(singularity-eos::eospac_wrapper EOSPAC::eospac)

--- a/eospac-wrapper/eospac_wrapper.cpp
+++ b/eospac-wrapper/eospac_wrapper.cpp
@@ -14,8 +14,10 @@
 // publicly and display publicly, and to permit others to do so.
 //======================================================================
 
+#include <array>
 #include <iostream>
 #include <string>
+#include <regex>
 #include <vector>
 
 #include <eos_Interface.h>
@@ -318,13 +320,6 @@ void eosSafeDestroy(int ntables, EOS_INTEGER tableHandles[],
   EOS_INTEGER NTABLES[] = {ntables};
   eos_DestroyTables(NTABLES, tableHandles, &errorCode);
   eosCheckError(errorCode, "eos_DestroyTables", eospacWarn);
-}
-
-void makeInterpPoints(std::vector<EOS_REAL>& v, const Bounds& b) {
-  v.resize(b.grid.nPoints());
-  for (size_t i = 0; i < v.size(); i++) {
-    v[i] = b.i2lin(i);
-  }
 }
 
 std::string getName(std::string comment) {

--- a/eospac-wrapper/eospac_wrapper.cpp
+++ b/eospac-wrapper/eospac_wrapper.cpp
@@ -1,0 +1,342 @@
+//======================================================================
+// sesame2spiner tool for converting eospac to spiner
+// Author: Jonah Miller (jonahm@lanl.gov)
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//======================================================================
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <eos_Interface.h>
+#include "eospac_wrapper.hpp"
+
+namespace EospacWrapper {
+
+void eosGetMetadata(int matid, SesameMetadata& metadata,
+                    Verbosity eospacWarn) {
+  constexpr int NT = 2;
+  EOS_INTEGER tableHandle[NT];
+  EOS_INTEGER tableType[NT] = {EOS_Info, EOS_Ut_DT};
+
+  EOS_INTEGER commentsHandle[1];
+  EOS_INTEGER commentsType[1] = {EOS_Comment};
+
+  constexpr int numInfoTables = 2;
+  constexpr int NI[] = {5, 11};
+  std::array<std::vector<EOS_INTEGER>,numInfoTables> infoItems = 
+    {
+      std::vector<EOS_INTEGER>{EOS_Exchange_Coeff,
+                               EOS_Mean_Atomic_Mass,
+                               EOS_Mean_Atomic_Num,
+                               EOS_Modulus,
+                               EOS_Normal_Density},
+      std::vector<EOS_INTEGER>{ EOS_Rmin, EOS_Rmax,
+                                EOS_Tmin, EOS_Tmax,
+                                EOS_Fmin, EOS_Fmax,
+                                EOS_NR,   EOS_NT,
+                                EOS_X_Convert_Factor,
+                                EOS_Y_Convert_Factor,
+                                EOS_F_Convert_Factor}
+    };
+  std::vector<EOS_REAL> infoVals[numInfoTables];
+  for (int i = 0; i < numInfoTables; i++) {
+    infoVals[i].resize(NI[i]);
+    for (int j = 0; j < NI[i]; j++) {
+      infoVals[i][j] = 0;
+    }
+  }
+
+  eosSafeLoad(NT, matid, tableType, tableHandle,
+              {"EOS_Info", "EOS_Ut_DT"},
+              eospacWarn);
+
+  for (int i = 0; i < numInfoTables; i++) {
+    eosSafeTableInfo(&(tableHandle[i]), NI[i],
+                     infoItems[i].data(),
+                     infoVals[i].data(),
+                     eospacWarn);
+  }
+  metadata.matid = matid;
+  metadata.exchangeCoefficient = infoVals[0][0];
+  metadata.meanAtomicMass      = infoVals[0][1];
+  metadata.meanAtomicNumber    = infoVals[0][2];
+  metadata.solidBulkModulus    = bulkModulusFromSesame(infoVals[0][3]);
+  metadata.normalDensity       = densityFromSesame(infoVals[0][4]);
+  metadata.rhoMin              = densityFromSesame(infoVals[1][0]);
+  metadata.rhoMax              = densityFromSesame(infoVals[1][1]);
+  metadata.TMin                = temperatureFromSesame(infoVals[1][2]);
+  metadata.TMax                = temperatureFromSesame(infoVals[1][3]);
+  metadata.sieMin              = sieFromSesame(infoVals[1][4]);
+  metadata.sieMax              = sieFromSesame(infoVals[1][5]);
+  metadata.numRho              = static_cast<int>(infoVals[1][6]);
+  metadata.numT                = static_cast<int>(infoVals[1][7]);
+  metadata.rhoConversionFactor = infoVals[1][8];
+  metadata.TConversionFactor   = infoVals[1][9];
+  metadata.sieConversionFactor = infoVals[1][10];
+
+  eosSafeDestroy(NT, tableHandle, eospacWarn);
+
+  EOS_INTEGER errorCode = eosSafeLoad(1, matid,
+                                      commentsType,
+                                      commentsHandle,
+                                      {"EOS_Comments"},
+                                      eospacWarn);
+  EOS_INTEGER eospacComments = commentsHandle[0];
+
+  if (errorCode == EOS_OK) {
+    std::vector<EOS_CHAR> comments;
+    EOS_REAL commentLen;
+    EOS_INTEGER commentItem = EOS_Cmnt_Len;
+    eosSafeTableInfo(commentsHandle, 1,
+                     &commentItem, &commentLen,
+                     eospacWarn);
+
+    comments.resize(static_cast<int>(commentLen));
+    metadata.comments.resize(comments.size());
+    eosSafeTableCmnts(&eospacComments, comments.data(), eospacWarn);
+    for (size_t i = 0; i < comments.size(); i++) {
+      metadata.comments[i] = comments[i];
+    }
+    metadata.name = getName(metadata.comments);
+    
+    eosSafeDestroy(1, commentsHandle, eospacWarn);
+  } else {
+    std::string matid_str = std::to_string(matid);
+    if (eospacWarn != Verbosity::Quiet) {
+      std::cerr << "eos_GetMetadata: failed to get comments table. "
+                << "Using default comments and name fields."
+                << std::endl;
+    }
+    metadata.name = "No name for matid " + matid_str;
+    metadata.comments = "Comment unavailable for matid " + matid_str;
+  }
+}
+
+EOS_INTEGER eosSafeLoad(int ntables, int matid,
+                        EOS_INTEGER tableType[],
+                        EOS_INTEGER tableHandle[],
+                        Verbosity eospacWarn,
+			bool invert_at_setup) {
+  std::vector<std::string> empty;
+  return eosSafeLoad(ntables,matid,tableType,tableHandle,empty,
+		     eospacWarn,invert_at_setup);
+}
+
+EOS_INTEGER eosSafeLoad(int ntables, int matid,
+                        EOS_INTEGER tableType[],
+                        EOS_INTEGER tableHandle[],
+                        const std::vector<std::string>& table_names,
+                        Verbosity eospacWarn,
+			bool invert_at_setup) {
+  EOS_INTEGER NTABLES[] = {ntables};
+  std::vector<EOS_INTEGER> MATID(ntables,matid);
+  
+  EOS_INTEGER errorCode = EOS_OK;
+  EOS_INTEGER tableHandleErrorCode = EOS_OK;
+  EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
+
+  eos_CreateTables(NTABLES, tableType, MATID.data(), tableHandle, &errorCode);
+
+  if (invert_at_setup) {
+    EOS_INTEGER options[] = {EOS_INVERT_AT_SETUP, EOS_INSERT_DATA};
+    EOS_REAL values[] = {1., 4.};
+    for (int i = 0; i < ntables; i++) {
+      if (tableType[i] == EOS_T_DUt) {
+	eos_SetOption(&(tableHandle[i]),&(options[0]),&(values[0]),&errorCode);
+	eos_SetOption(&(tableHandle[i]),&(options[1]),&(values[1]),&errorCode);
+      }
+    }
+  }
+
+#ifdef SINGULARITY_EOSPAC_SKIP_EXTRAP
+  for (int i = 0; i < ntables; i++) {
+    eos_SetOption(&(tableHandle[i]),&EOS_SKIP_EXTRAP_CHECK,NULL,&errorCode);
+  }
+#endif // SINGULARITY_EOSPAC_SKIP_EXTRAP
+
+  eos_LoadTables(&ntables, tableHandle, &errorCode);
+  if ( errorCode != EOS_OK && eospacWarn != Verbosity::Quiet ) {
+    for (int i = 0; i < ntables; i++) {
+      eos_GetErrorCode(&tableHandle[i], &tableHandleErrorCode);
+      eos_GetErrorMessage(&tableHandleErrorCode, errorMessage);
+      std::cerr << "eos_CreateTables ERROR "
+                << tableHandleErrorCode;
+      if ( table_names.size() > 0 ) {
+        std::cerr << " for table names\n\t{";
+        for (auto & name : table_names) {
+          std::cerr << name << ", ";
+        }
+        std::cerr << "}";
+      }
+      std::cerr << ":\n\t"
+                << errorMessage
+                << std::endl;
+    }
+  }
+  return errorCode;
+}
+
+bool eosSafeInterpolate(EOS_INTEGER *table,
+                        EOS_INTEGER nxypairs,
+                        EOS_REAL xVals[],
+                        EOS_REAL yVals[],
+                        EOS_REAL var[],
+                        EOS_REAL dx[],
+                        EOS_REAL dy[],
+                        const char tablename[],
+                        Verbosity eospacWarn) {
+  EOS_INTEGER errorCode = EOS_OK;
+  EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
+  
+  eos_Interpolate(table, &nxypairs,
+                  xVals, yVals, var, dx, dy,
+                  &errorCode);
+#ifndef SINGULARITY_EOSPAC_SKIP_EXTRAP
+  if (errorCode != EOS_OK && eospacWarn == Verbosity::Debug) {   
+    eos_GetErrorMessage(&errorCode, errorMessage);
+    std::cerr << "Table " << tablename << ":" << std::endl;
+    std::cerr << "eos_Interpolate ERROR "
+	      << errorCode
+	      << ": "
+	      << errorMessage
+	      << std::endl;
+    std::vector<EOS_INTEGER> xyBounds(nxypairs);
+    eos_CheckExtrap(table, &nxypairs,
+		    xVals, yVals, xyBounds.data(),
+		    &errorCode);
+    for (size_t i = 0; i < xyBounds.size(); i++) {
+      std::string status = eosErrorString(xyBounds[i]);
+      std::cerr << "var " << i << ": " << status << std::endl;
+      std::cerr << "x = " << xVals[i] << std::endl;
+      std::cerr << "y = " << yVals[i] << std::endl;
+    }
+  }
+#endif // SINGULARITY_EOSPAC_SKIP_EXTRAP
+  return (errorCode == EOS_OK); // 1 for no erros. 0 for errors.
+}
+
+void eosSafeTableInfo(EOS_INTEGER* table,
+                      EOS_INTEGER numInfoItems,
+                      EOS_INTEGER infoItems[],
+                      EOS_REAL infoVals[],
+                      Verbosity eospacWarn) {
+  EOS_INTEGER errorCode = EOS_OK;
+  //EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
+  EOS_INTEGER NITEMS[] = {numInfoItems};
+  eos_GetTableInfo(table,NITEMS,infoItems,infoVals,&errorCode);
+  eosCheckError(errorCode, "eos_GetTableInfo", eospacWarn);
+}
+
+void eosSafeTableCmnts(EOS_INTEGER* table, EOS_CHAR* comments,
+                       Verbosity eospacWarn) {
+  EOS_INTEGER errorCode = EOS_OK;
+  eos_GetTableCmnts(table,comments,&errorCode);
+  eosCheckError(errorCode,"eos_GetTableCmnts", eospacWarn);
+}
+
+void eosCheckError(EOS_INTEGER errorCode,
+                   const std::string& name,
+                   Verbosity eospacWarn) {
+  EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
+  if (errorCode != EOS_OK && eospacWarn != Verbosity::Quiet) {
+    eos_GetErrorMessage(&errorCode, errorMessage);
+    std::cerr << name << " ERROR "
+              << errorCode << ":\n\t"
+              << errorMessage
+              << std::endl;
+  }
+}
+
+std::string eosErrorString(EOS_INTEGER errorCode) {
+  // Algorithmicallly generated by parsing the EOSPAC docs
+  // I'm sorry. It's gross. ~JMM
+  switch (errorCode) { 
+  case EOS_OK: return "EOS_OK";
+  case EOS_BAD_DATA_TYPE: return "EOS_BAD_DATA_TYPE";
+  case EOS_BAD_DERIVATIVE_FLAG: return "EOS_BAD_DERIVATIVE_FLAG";
+  case EOS_BAD_INTERPOLATION_FLAG: return "EOS_BAD_INTERPOLATION_FLAG";
+  case EOS_BAD_MATERIAL_ID: return "EOS_BAD_MATERIAL_ID";
+  case EOS_CANT_INVERT_DATA: return "EOS_CANT_INVERT_DATA";
+  case EOS_CANT_MAKE_MONOTONIC: return "EOS_CANT_MAKE_MONOTONIC";
+  case EOS_CONVERGENCE_FAILED: return "EOS_CONVERGENCE_FAILED";
+  case EOS_DATA_TYPE_NOT_FOUND: return "EOS_DATA_TYPE_NOT_FOUND";
+  case EOS_DATA_TYPE_NO_MATCH: return "EOS_DATA_TYPE_NO_MATCH";
+  case EOS_FAILED: return "EOS_FAILED";
+  case EOS_INTEGRATION_FAILED: return "EOS_INTEGRATION_FAILED";
+  case EOS_INTERP_EXTRAPOLATED: return "EOS_INTERP_EXTRAPOLATED";
+  case EOS_INTERP_EXTRAP_PBAL: return "EOS_INTERP_EXTRAP_PBAL";
+  case EOS_INTERP_EXTRAP_TBAL: return "EOS_INTERP_EXTRAP_TBAL";
+  case EOS_INVALID_CONC_SUM: return "EOS_INVALID_CONC_SUM";
+  case EOS_INVALID_DATA_TYPE: return "EOS_INVALID_DATA_TYPE";
+  case EOS_INVALID_INFO_FLAG: return "EOS_INVALID_INFO_FLAG";
+  case EOS_INVALID_OPTION_FLAG: return "EOS_INVALID_OPTION_FLAG";
+  case EOS_INVALID_SUBTABLE_INDEX: return "EOS_INVALID_SUBTABLE_INDEX";
+  case EOS_INVALID_TABLE_HANDLE: return "EOS_INVALID_TABLE_HANDLE";
+  case EOS_MATERIAL_NOT_FOUND: return "EOS_MATERIAL_NOT_FOUND";
+  case EOS_MEM_ALLOCATION_FAILED: return "EOS_MEM_ALLOCATION_FAILED";
+  case EOS_NOT_ALLOCATED: return "EOS_NOT_ALLOCATED";
+  case EOS_NOT_INITIALIZED: return "EOS_NOT_INITIALIZED";
+  case EOS_NO_COMMENTS: return "EOS_NO_COMMENTS";
+  case EOS_NO_DATA_TABLE: return "EOS_NO_DATA_TABLE";
+  case EOS_NO_SESAME_FILES: return "EOS_NO_SESAME_FILES";
+  case EOS_OPEN_SESAME_FILE_FAILED: return "EOS_OPEN_SESAME_FILE_FAILED";
+  case EOS_READ_DATA_FAILED: return "EOS_READ_DATA_FAILED";
+  case EOS_READ_FILE_VERSION_FAILED: return "EOS_READ_FILE_VERSION_FAILED";
+  case EOS_READ_MASTER_DIR_FAILED: return "EOS_READ_MASTER_DIR_FAILED";
+  case EOS_READ_MATERIAL_DIR_FAILED: return "EOS_READ_MATERIAL_DIR_FAILED";
+  case EOS_READ_TOTAL_MATERIALS_FAILED: return "EOS_READ_TOTAL_MATERIALS_FAILED";
+  case EOS_SPLIT_FAILED: return "EOS_SPLIT_FAILED";
+  case EOS_xHi_yHi: return "EOS_xHi_yHi";
+  case EOS_xHi_yOk: return "EOS_xHI_yOk";
+  case EOS_xHi_yLo: return "EOS_xHi_yLo";
+  case EOS_xOk_yLo: return "EOS_xOk_yLo";
+  case EOS_xLo_yLo: return "EOS_xLo_yLo";
+  case EOS_xLo_yOk: return "EOS_xLo_yOk";
+  case EOS_xLo_yHi: return "EOS_xLo_yHi";
+  case EOS_xOk_yHi: return "EOS_xOk_yHi";
+  case EOS_WARNING: return "EOS_WARNING";
+  case EOS_UNDEFINED: return "EOS_UNDEFINED";
+  default: return "UNKNOWN ERROR: " + std::to_string(errorCode);
+  }
+}
+
+void eosSafeDestroy(int ntables, EOS_INTEGER tableHandles[],
+                    Verbosity eospacWarn) {
+  EOS_INTEGER errorCode = EOS_OK;
+  //EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
+  EOS_INTEGER NTABLES[] = {ntables};
+  eos_DestroyTables(NTABLES, tableHandles, &errorCode);
+  eosCheckError(errorCode, "eos_DestroyTables", eospacWarn);
+}
+
+void makeInterpPoints(std::vector<EOS_REAL>& v, const Bounds& b) {
+  v.resize(b.grid.nPoints());
+  for (size_t i = 0; i < v.size(); i++) {
+    v[i] = b.i2lin(i);
+  }
+}
+
+std::string getName(std::string comment) {
+  // required because lookbehinds not supported
+  //constexpr int startPos=15; 
+  std::regex r("101: material. (.*)(?=\\s+\\(z)");
+  std::smatch match;
+  if (std::regex_search(comment, match, r)) {
+    return std::string(match[0]).substr(15);
+  }
+  std::string badstring("-1");
+  return badstring;
+}
+
+} // namespace EospacWrapper

--- a/eospac-wrapper/eospac_wrapper.hpp
+++ b/eospac-wrapper/eospac_wrapper.hpp
@@ -1,0 +1,127 @@
+//======================================================================
+// sesame2spiner tool for converting eospac to spiner
+// Author: Jonah Miller (jonahm@lanl.gov)
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//======================================================================
+
+#ifndef _EOSPAC_WRAPPER_EOSPAC_WRAPPER_HPP_
+#define _EOSPAC_WRAPPER_EOSPAC_WRAPPER_HPP_
+
+#include <string>
+#include <iostream>
+
+#include <eos_Interface.h> // eospac API
+
+namespace EospacWrapper {
+
+inline Real densityToSesame(const Real CodeTemp) { return CodeTemp;}
+inline Real densityFromSesame(const Real sesTemp) { return sesTemp;}
+inline Real temperatureToSesame(const Real CodeTemp) { return CodeTemp;}
+inline Real temperatureFromSesame(const Real SesTemp) { return SesTemp;}
+inline Real pressureFromSesame(const Real SesPress) { return 1e10*SesPress;}
+inline Real pressureToSesame(const Real CodePress) { return 1e-10*CodePress;}
+inline Real sieToSesame(const Real CodeSie) { return 1e-10*CodeSie;}
+inline Real sieFromSesame(const Real SesSie) { return 1e10*SesSie;}
+inline Real cvFromSesame(const Real SesCv) { return 1e10*SesCv;}
+inline Real bulkModulusFromSesame(const Real SesBmod) { return 1e10*SesBmod;}
+inline Real getBulkModulus(const Real rho, const Real P,
+                           const Real DPDR_T, const Real DPDE_R,
+                           const Real DEDR_T) {
+  return rho*DPDR_T + DPDE_R*((P/rho) - rho*DEDR_T);
+}
+
+enum class Verbosity { Quiet, Verbose, Debug };
+
+class SesameMetadata {
+public:
+  int matid;
+  Real exchangeCoefficient;
+  Real meanAtomicMass;
+  Real meanAtomicNumber;
+  Real solidBulkModulus;
+  Real normalDensity;
+  Real rhoMin, rhoMax;
+  Real TMin, TMax;
+  Real sieMin, sieMax;
+  Real rhoConversionFactor;
+  Real TConversionFactor;
+  Real sieConversionFactor;
+  int numRho, numT;
+  std::string comments;
+  std::string name;
+  friend std::ostream& operator<< (std::ostream& os, const SesameMetadata& m) {
+    os << "MATID: "  << m.matid << "\n"
+       << "\tname: " << m.name << "\n"
+       << "\texchange coefficient  = " << m.exchangeCoefficient << "\n"
+       << "\tmean atomic mass      = " << m.meanAtomicMass      << "\n"
+       << "\tsolid bulk modulus    = " << m.solidBulkModulus    << "\n"
+       << "\tnormal density        = " << m.normalDensity       << "\n"
+       << "\t[rho min, rho max]    = "
+       << "[" << m.rhoMin << ", " << m.rhoMax << "]" << "\n"
+       << "\t[T min, T max]        = "
+       << "[" << m.TMin << ", " << m.TMax << "]" << "\n"
+       << "\t[sie min, sie max]    = "
+       << "[" << m.sieMin << ", " << m.sieMax << "]" << "\n"
+       << "\tnum rho               = " << m.numRho  << "\n"
+       << "\tnum T                 = " << m.numT    << "\n"
+       << "\tComments:\n"
+       << m.comments << "\n";
+    return os;
+  }
+};
+
+void eosGetMetadata(int matid, SesameMetadata& metadata,
+                    Verbosity eospacWarn = Verbosity::Quiet);
+
+EOS_INTEGER eosSafeLoad(int ntables, int matid,
+                        EOS_INTEGER tableType[],
+                        EOS_INTEGER tableHandle[],
+                        Verbosity eospacWarn,
+			bool invert_at_setup=false);
+EOS_INTEGER eosSafeLoad(int ntables, int matid,
+                        EOS_INTEGER tableType[],
+                        EOS_INTEGER tableHandle[],
+                        const std::vector<std::string>& table_names,
+                        Verbosity eospacWarn,
+			bool invert_at_setup=false);
+
+// output is boolean mask. 1 for no errors. 0 for errors.
+bool eosSafeInterpolate(EOS_INTEGER *table,
+			EOS_INTEGER nxypairs,
+			EOS_REAL xVals[],
+			EOS_REAL yVals[],
+			EOS_REAL var[],
+			EOS_REAL dx[],
+			EOS_REAL dy[],
+			const char tablename[],
+			Verbosity eospacWarn);
+
+void eosSafeTableInfo(EOS_INTEGER* table,
+                      EOS_INTEGER numInfoItems,
+                      EOS_INTEGER infoItems[],
+                      EOS_REAL infoVals[],
+                      Verbosity eospacWarn);
+
+void eosSafeTableCmnts(EOS_INTEGER* table, EOS_CHAR* comments,
+                       Verbosity eospacWarn);
+
+void eosCheckError(EOS_INTEGER errorCode, const std::string& name,
+                   Verbosity eospacWarn);
+std::string eosErrorString(EOS_INTEGER errorCode);
+void eosSafeDestroy(int ntables, EOS_INTEGER tableHandles[],
+                    Verbosity eospacWarn);
+std::string getName(std::string comment);
+
+} // namespace EospacWrapper
+
+#endif // _EOSPAC_WRAPPER_EOSPAC_WRAPPER_HPP_

--- a/eospac-wrapper/eospac_wrapper.hpp
+++ b/eospac-wrapper/eospac_wrapper.hpp
@@ -24,19 +24,19 @@
 
 namespace EospacWrapper {
 
-inline Real densityToSesame(const Real CodeTemp) { return CodeTemp;}
-inline Real densityFromSesame(const Real sesTemp) { return sesTemp;}
-inline Real temperatureToSesame(const Real CodeTemp) { return CodeTemp;}
-inline Real temperatureFromSesame(const Real SesTemp) { return SesTemp;}
-inline Real pressureFromSesame(const Real SesPress) { return 1e10*SesPress;}
-inline Real pressureToSesame(const Real CodePress) { return 1e-10*CodePress;}
-inline Real sieToSesame(const Real CodeSie) { return 1e-10*CodeSie;}
-inline Real sieFromSesame(const Real SesSie) { return 1e10*SesSie;}
-inline Real cvFromSesame(const Real SesCv) { return 1e10*SesCv;}
-inline Real bulkModulusFromSesame(const Real SesBmod) { return 1e10*SesBmod;}
-inline Real getBulkModulus(const Real rho, const Real P,
-                           const Real DPDR_T, const Real DPDE_R,
-                           const Real DEDR_T) {
+inline double densityToSesame(const double CodeTemp) { return CodeTemp;}
+inline double densityFromSesame(const double sesTemp) { return sesTemp;}
+inline double temperatureToSesame(const double CodeTemp) { return CodeTemp;}
+inline double temperatureFromSesame(const double SesTemp) { return SesTemp;}
+inline double pressureFromSesame(const double SesPress) { return 1e10*SesPress;}
+inline double pressureToSesame(const double CodePress) { return 1e-10*CodePress;}
+inline double sieToSesame(const double CodeSie) { return 1e-10*CodeSie;}
+inline double sieFromSesame(const double SesSie) { return 1e10*SesSie;}
+inline double cvFromSesame(const double SesCv) { return 1e10*SesCv;}
+inline double bulkModulusFromSesame(const double SesBmod) { return 1e10*SesBmod;}
+inline double getBulkModulus(const double rho, const double P,
+                           const double DPDR_T, const double DPDE_R,
+                           const double DEDR_T) {
   return rho*DPDR_T + DPDE_R*((P/rho) - rho*DEDR_T);
 }
 
@@ -45,17 +45,17 @@ enum class Verbosity { Quiet, Verbose, Debug };
 class SesameMetadata {
 public:
   int matid;
-  Real exchangeCoefficient;
-  Real meanAtomicMass;
-  Real meanAtomicNumber;
-  Real solidBulkModulus;
-  Real normalDensity;
-  Real rhoMin, rhoMax;
-  Real TMin, TMax;
-  Real sieMin, sieMax;
-  Real rhoConversionFactor;
-  Real TConversionFactor;
-  Real sieConversionFactor;
+  double exchangeCoefficient;
+  double meanAtomicMass;
+  double meanAtomicNumber;
+  double solidBulkModulus;
+  double normalDensity;
+  double rhoMin, rhoMax;
+  double TMin, TMax;
+  double sieMin, sieMax;
+  double rhoConversionFactor;
+  double TConversionFactor;
+  double sieConversionFactor;
   int numRho, numT;
   std::string comments;
   std::string name;

--- a/sesame2spiner/generate_files.cpp
+++ b/sesame2spiner/generate_files.cpp
@@ -26,6 +26,8 @@
 #error "HDF5 must be enabled"
 #endif // SPINER_USE_HDF
 
+#include <eospac-wrapper/eospac_wrapper.hpp>
+
 #include <spiner/ports-of-call/portability.hpp>
 #include <sp5/singularity_eos_sp5.hpp>
 #include <spiner/databox.hpp>
@@ -36,6 +38,8 @@
 #include "generate_files.hpp"
 #include "parse_cli.hpp"
 #include "parser.hpp"
+
+using namespace EospacWrapper;
 
 herr_t saveMaterial(hid_t loc,
 		    const SesameMetadata& metadata,

--- a/sesame2spiner/generate_files.hpp
+++ b/sesame2spiner/generate_files.hpp
@@ -23,8 +23,12 @@
 #include <hdf5.h>
 #include <hdf5_hl.h>
 
+#include <eospac-wrapper/eospac_wrapper.hpp>
+
 #include "parser.hpp"
 #include "io_eospac.hpp"
+
+using namespace EospacWrapper;
 
 constexpr int PPD_DEFAULT = 50;
 constexpr Real STRICTLY_POS_MIN = 1e-9;

--- a/sesame2spiner/io_eospac.cpp
+++ b/sesame2spiner/io_eospac.cpp
@@ -21,107 +21,10 @@
 #include <array>
 #include <vector>
 #include <regex>
+
+#include <eospac-wrapper/eospac_wrapper.hpp>
+
 #include "io_eospac.hpp"
-
-void eosGetMetadata(int matid, SesameMetadata& metadata,
-                    Verbosity eospacWarn) {
-  constexpr int NT = 2;
-  EOS_INTEGER tableHandle[NT];
-  EOS_INTEGER tableType[NT] = {EOS_Info, EOS_Ut_DT};
-
-  EOS_INTEGER commentsHandle[1];
-  EOS_INTEGER commentsType[1] = {EOS_Comment};
-
-  constexpr int numInfoTables = 2;
-  constexpr int NI[] = {5, 11};
-  std::array<std::vector<EOS_INTEGER>,numInfoTables> infoItems = 
-    {
-      std::vector<EOS_INTEGER>{EOS_Exchange_Coeff,
-                               EOS_Mean_Atomic_Mass,
-                               EOS_Mean_Atomic_Num,
-                               EOS_Modulus,
-                               EOS_Normal_Density},
-      std::vector<EOS_INTEGER>{ EOS_Rmin, EOS_Rmax,
-                                EOS_Tmin, EOS_Tmax,
-                                EOS_Fmin, EOS_Fmax,
-                                EOS_NR,   EOS_NT,
-                                EOS_X_Convert_Factor,
-                                EOS_Y_Convert_Factor,
-                                EOS_F_Convert_Factor}
-    };
-  std::vector<EOS_REAL> infoVals[numInfoTables];
-  for (int i = 0; i < numInfoTables; i++) {
-    infoVals[i].resize(NI[i]);
-    for (int j = 0; j < NI[i]; j++) {
-      infoVals[i][j] = 0;
-    }
-  }
-
-  eosSafeLoad(NT, matid, tableType, tableHandle,
-              {"EOS_Info", "EOS_Ut_DT"},
-              eospacWarn);
-
-  for (int i = 0; i < numInfoTables; i++) {
-    eosSafeTableInfo(&(tableHandle[i]), NI[i],
-                     infoItems[i].data(),
-                     infoVals[i].data(),
-                     eospacWarn);
-  }
-  metadata.matid = matid;
-  metadata.exchangeCoefficient = infoVals[0][0];
-  metadata.meanAtomicMass      = infoVals[0][1];
-  metadata.meanAtomicNumber    = infoVals[0][2];
-  metadata.solidBulkModulus    = bulkModulusFromSesame(infoVals[0][3]);
-  metadata.normalDensity       = densityFromSesame(infoVals[0][4]);
-  metadata.rhoMin              = densityFromSesame(infoVals[1][0]);
-  metadata.rhoMax              = densityFromSesame(infoVals[1][1]);
-  metadata.TMin                = temperatureFromSesame(infoVals[1][2]);
-  metadata.TMax                = temperatureFromSesame(infoVals[1][3]);
-  metadata.sieMin              = sieFromSesame(infoVals[1][4]);
-  metadata.sieMax              = sieFromSesame(infoVals[1][5]);
-  metadata.numRho              = static_cast<int>(infoVals[1][6]);
-  metadata.numT                = static_cast<int>(infoVals[1][7]);
-  metadata.rhoConversionFactor = infoVals[1][8];
-  metadata.TConversionFactor   = infoVals[1][9];
-  metadata.sieConversionFactor = infoVals[1][10];
-
-  eosSafeDestroy(NT, tableHandle, eospacWarn);
-
-  EOS_INTEGER errorCode = eosSafeLoad(1, matid,
-                                      commentsType,
-                                      commentsHandle,
-                                      {"EOS_Comments"},
-                                      eospacWarn);
-  EOS_INTEGER eospacComments = commentsHandle[0];
-
-  if (errorCode == EOS_OK) {
-    std::vector<EOS_CHAR> comments;
-    EOS_REAL commentLen;
-    EOS_INTEGER commentItem = EOS_Cmnt_Len;
-    eosSafeTableInfo(commentsHandle, 1,
-                     &commentItem, &commentLen,
-                     eospacWarn);
-
-    comments.resize(static_cast<int>(commentLen));
-    metadata.comments.resize(comments.size());
-    eosSafeTableCmnts(&eospacComments, comments.data(), eospacWarn);
-    for (size_t i = 0; i < comments.size(); i++) {
-      metadata.comments[i] = comments[i];
-    }
-    metadata.name = getName(metadata.comments);
-    
-    eosSafeDestroy(1, commentsHandle, eospacWarn);
-  } else {
-    std::string matid_str = std::to_string(matid);
-    if (eospacWarn != Verbosity::Quiet) {
-      std::cerr << "eos_GetMetadata: failed to get comments table. "
-                << "Using default comments and name fields."
-                << std::endl;
-    }
-    metadata.name = "No name for matid " + matid_str;
-    metadata.comments = "Comment unavailable for matid " + matid_str;
-  }
-}
 
 // TODO: more error checking of bounds?
 void eosDataOfRhoSie(int matid,
@@ -138,6 +41,7 @@ void eosDataOfRhoSie(int matid,
                      DataBox& mask,
                      Verbosity eospacWarn
                      ) {
+  using namespace EospacWrapper;
   
   constexpr int NT = 3;
   constexpr EOS_INTEGER nXYPairs = 1;
@@ -238,6 +142,7 @@ void eosDataOfRhoT(int matid,
                    DataBox& mask,
                    Verbosity eospacWarn
                    ) {
+  using namespace EospacWrapper;
 
   constexpr int NT = 3;
   constexpr EOS_INTEGER nXYPairs = 1;
@@ -330,6 +235,7 @@ void eosColdCurves(int matid,
                    DataBox& mask,
                    Verbosity eospacWarn
                    ) {
+  using namespace EospacWrapper;
 
   constexpr int NT = 2;
   constexpr EOS_INTEGER nXYPairs = 1;
@@ -397,7 +303,7 @@ void eosColdCurveMask(int matid,
                       DataBox& mask,
                       Verbosity eospacWarn
                       ) {
-
+  using namespace EospacWrapper;
 
   constexpr int NT = 1;
   constexpr EOS_INTEGER nXYPairs = 1;
@@ -445,216 +351,4 @@ void eosColdCurveMask(int matid,
     }
   }
   eosSafeDestroy(NT, tableHandle, eospacWarn);
-}
-
-EOS_INTEGER eosSafeLoad(int ntables, int matid,
-                        EOS_INTEGER tableType[],
-                        EOS_INTEGER tableHandle[],
-                        Verbosity eospacWarn) {
-  std::vector<std::string> empty;
-  return eosSafeLoad(ntables,matid,tableType,tableHandle,empty,eospacWarn);
-}
-
-EOS_INTEGER eosSafeLoad(int ntables, int matid,
-                        EOS_INTEGER tableType[],
-                        EOS_INTEGER tableHandle[],
-                        const std::vector<std::string>& table_names,
-                        Verbosity eospacWarn) {
-
-  EOS_INTEGER NTABLES[] = {ntables};
-  std::vector<EOS_INTEGER> MATID(ntables,matid);
-  
-  EOS_INTEGER errorCode = EOS_OK;
-  EOS_INTEGER tableHandleErrorCode = EOS_OK;
-  EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
-
-  eos_CreateTables(NTABLES, tableType, MATID.data(), tableHandle, &errorCode);
-
-  #ifdef SINGULARITY_INVERT_AT_SETUP
-  EOS_INTEGER options[] = {EOS_INVERT_AT_SETUP, EOS_INSERT_DATA};
-  EOS_REAL values[] = {1., 4.};
-  for (int i = 0; i < ntables; i++) {
-    eos_SetOption(&(tableHandle[i]),&(options[0]),&(values[0]),&errorCode);
-    eos_SetOption(&(tableHandle[i]),&(options[1]),&(values[1]),&errorCode);
-  }
-  #endif
-
-  #ifdef SINGULARITY_EOS_SKIP_EXTRAP
-  for (int i = 0; i < ntables; i++) {
-    eos_SetOption(&(tableHandle[i]),&EOS_SKIP_EXTRAP_CHECK,NULL,&errorCode);
-  }
-  #endif
-
-  eos_LoadTables(&ntables, tableHandle, &errorCode);
-  if ( errorCode != EOS_OK && eospacWarn != Verbosity::Quiet ) {
-    for (int i = 0; i < ntables; i++) {
-      eos_GetErrorCode(&tableHandle[i], &tableHandleErrorCode);
-      eos_GetErrorMessage(&tableHandleErrorCode, errorMessage);
-      std::cerr << "eos_CreateTables ERROR "
-                << tableHandleErrorCode;
-      if ( table_names.size() > 0 ) {
-        std::cerr << " for table names\n\t{";
-        for (auto & name : table_names) {
-          std::cerr << name << ", ";
-        }
-        std::cerr << "}";
-      }
-      std::cerr << ":\n\t"
-                << errorMessage
-                << std::endl;
-    }
-  }
-  return errorCode;
-}
-
-bool eosSafeInterpolate(EOS_INTEGER *table,
-                        EOS_INTEGER nxypairs,
-                        EOS_REAL xVals[],
-                        EOS_REAL yVals[],
-                        EOS_REAL var[],
-                        EOS_REAL dx[],
-                        EOS_REAL dy[],
-                        const char tablename[],
-                        Verbosity eospacWarn) {
-  EOS_INTEGER errorCode = EOS_OK;
-  EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
-  
-  eos_Interpolate(table, &nxypairs,
-                  xVals, yVals, var, dx, dy,
-                  &errorCode);
-  #ifndef SINGULARITY_EOS_SKIP_EXTRAP
-  if (errorCode != EOS_OK && eospacWarn == Verbosity::Debug) {   
-    eos_GetErrorMessage(&errorCode, errorMessage);
-    std::cerr << "Table " << tablename << ":" << std::endl;
-    std::cerr << "eos_Interpolate ERROR "
-              << errorCode
-              << ": "
-              << errorMessage
-              << std::endl;
-    std::vector<EOS_INTEGER> xyBounds(nxypairs);
-    eos_CheckExtrap(table, &nxypairs,
-                    xVals, yVals, xyBounds.data(),
-                    &errorCode);
-    for (size_t i = 0; i < xyBounds.size(); i++) {
-      std::string status = eosErrorString(xyBounds[i]);
-      std::cerr << "var " << i << ": " << status << std::endl;
-      std::cerr << "x = " << xVals[i] << std::endl;
-      std::cerr << "y = " << yVals[i] << std::endl;
-    }
-  }
-  #endif
-  return (errorCode == EOS_OK); // 1 for no erros. 0 for errors.
-}
-
-void eosSafeTableInfo(EOS_INTEGER* table,
-                      EOS_INTEGER numInfoItems,
-                      EOS_INTEGER infoItems[],
-                      EOS_REAL infoVals[],
-                      Verbosity eospacWarn) {
-  EOS_INTEGER errorCode = EOS_OK;
-  //EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
-  EOS_INTEGER NITEMS[] = {numInfoItems};
-  eos_GetTableInfo(table,NITEMS,infoItems,infoVals,&errorCode);
-  eosCheckError(errorCode, "eos_GetTableInfo", eospacWarn);
-}
-
-void eosSafeTableCmnts(EOS_INTEGER* table, EOS_CHAR* comments,
-                       Verbosity eospacWarn) {
-  EOS_INTEGER errorCode = EOS_OK;
-  eos_GetTableCmnts(table,comments,&errorCode);
-  eosCheckError(errorCode,"eos_GetTableCmnts", eospacWarn);
-}
-
-void eosCheckError(EOS_INTEGER errorCode,
-                   const std::string& name,
-                   Verbosity eospacWarn) {
-  EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
-  if (errorCode != EOS_OK && eospacWarn != Verbosity::Quiet) {
-    eos_GetErrorMessage(&errorCode, errorMessage);
-    std::cerr << name << " ERROR "
-              << errorCode << ":\n\t"
-              << errorMessage
-              << std::endl;
-  }
-}
-
-std::string eosErrorString(EOS_INTEGER errorCode) {
-  // Algorithmicallly generated by parsing the EOSPAC docs
-  // I'm sorry. It's gross. ~JMM
-  switch (errorCode) { 
-  case EOS_OK: return "EOS_OK";
-  case EOS_BAD_DATA_TYPE: return "EOS_BAD_DATA_TYPE";
-  case EOS_BAD_DERIVATIVE_FLAG: return "EOS_BAD_DERIVATIVE_FLAG";
-  case EOS_BAD_INTERPOLATION_FLAG: return "EOS_BAD_INTERPOLATION_FLAG";
-  case EOS_BAD_MATERIAL_ID: return "EOS_BAD_MATERIAL_ID";
-  case EOS_CANT_INVERT_DATA: return "EOS_CANT_INVERT_DATA";
-  case EOS_CANT_MAKE_MONOTONIC: return "EOS_CANT_MAKE_MONOTONIC";
-  case EOS_CONVERGENCE_FAILED: return "EOS_CONVERGENCE_FAILED";
-  case EOS_DATA_TYPE_NOT_FOUND: return "EOS_DATA_TYPE_NOT_FOUND";
-  case EOS_DATA_TYPE_NO_MATCH: return "EOS_DATA_TYPE_NO_MATCH";
-  case EOS_FAILED: return "EOS_FAILED";
-  case EOS_INTEGRATION_FAILED: return "EOS_INTEGRATION_FAILED";
-  case EOS_INTERP_EXTRAPOLATED: return "EOS_INTERP_EXTRAPOLATED";
-  case EOS_INTERP_EXTRAP_PBAL: return "EOS_INTERP_EXTRAP_PBAL";
-  case EOS_INTERP_EXTRAP_TBAL: return "EOS_INTERP_EXTRAP_TBAL";
-  case EOS_INVALID_CONC_SUM: return "EOS_INVALID_CONC_SUM";
-  case EOS_INVALID_DATA_TYPE: return "EOS_INVALID_DATA_TYPE";
-  case EOS_INVALID_INFO_FLAG: return "EOS_INVALID_INFO_FLAG";
-  case EOS_INVALID_OPTION_FLAG: return "EOS_INVALID_OPTION_FLAG";
-  case EOS_INVALID_SUBTABLE_INDEX: return "EOS_INVALID_SUBTABLE_INDEX";
-  case EOS_INVALID_TABLE_HANDLE: return "EOS_INVALID_TABLE_HANDLE";
-  case EOS_MATERIAL_NOT_FOUND: return "EOS_MATERIAL_NOT_FOUND";
-  case EOS_MEM_ALLOCATION_FAILED: return "EOS_MEM_ALLOCATION_FAILED";
-  case EOS_NOT_ALLOCATED: return "EOS_NOT_ALLOCATED";
-  case EOS_NOT_INITIALIZED: return "EOS_NOT_INITIALIZED";
-  case EOS_NO_COMMENTS: return "EOS_NO_COMMENTS";
-  case EOS_NO_DATA_TABLE: return "EOS_NO_DATA_TABLE";
-  case EOS_NO_SESAME_FILES: return "EOS_NO_SESAME_FILES";
-  case EOS_OPEN_SESAME_FILE_FAILED: return "EOS_OPEN_SESAME_FILE_FAILED";
-  case EOS_READ_DATA_FAILED: return "EOS_READ_DATA_FAILED";
-  case EOS_READ_FILE_VERSION_FAILED: return "EOS_READ_FILE_VERSION_FAILED";
-  case EOS_READ_MASTER_DIR_FAILED: return "EOS_READ_MASTER_DIR_FAILED";
-  case EOS_READ_MATERIAL_DIR_FAILED: return "EOS_READ_MATERIAL_DIR_FAILED";
-  case EOS_READ_TOTAL_MATERIALS_FAILED: return "EOS_READ_TOTAL_MATERIALS_FAILED";
-  case EOS_SPLIT_FAILED: return "EOS_SPLIT_FAILED";
-  case EOS_xHi_yHi: return "EOS_xHi_yHi";
-  case EOS_xHi_yOk: return "EOS_xHI_yOk";
-  case EOS_xHi_yLo: return "EOS_xHi_yLo";
-  case EOS_xOk_yLo: return "EOS_xOk_yLo";
-  case EOS_xLo_yLo: return "EOS_xLo_yLo";
-  case EOS_xLo_yOk: return "EOS_xLo_yOk";
-  case EOS_xLo_yHi: return "EOS_xLo_yHi";
-  case EOS_xOk_yHi: return "EOS_xOk_yHi";
-  case EOS_WARNING: return "EOS_WARNING";
-  case EOS_UNDEFINED: return "EOS_UNDEFINED";
-  default: return "UNKNOWN ERROR: " + std::to_string(errorCode);
-  }
-}
-
-void eosSafeDestroy(int ntables, EOS_INTEGER tableHandles[],
-                    Verbosity eospacWarn) {
-  EOS_INTEGER errorCode = EOS_OK;
-  //EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
-  EOS_INTEGER NTABLES[] = {ntables};
-  eos_DestroyTables(NTABLES, tableHandles, &errorCode);
-  eosCheckError(errorCode, "eos_DestroyTables", eospacWarn);
-}
-
-void makeInterpPoints(std::vector<EOS_REAL>& v, const Bounds& b) {
-  v.resize(b.grid.nPoints());
-  for (size_t i = 0; i < v.size(); i++) {
-    v[i] = b.i2lin(i);
-  }
-}
-
-std::string getName(std::string comment) {
-  // required because lookbehinds not supported
-  //constexpr int startPos=15; 
-  std::regex r("101: material. (.*)(?=\\s+\\(z)");
-  std::smatch match;
-  if (std::regex_search(comment, match, r)) {
-    return std::string(match[0]).substr(15);
-  }
-  std::string badstring("-1");
-  return badstring;
 }

--- a/sesame2spiner/io_eospac.cpp
+++ b/sesame2spiner/io_eospac.cpp
@@ -352,3 +352,11 @@ void eosColdCurveMask(int matid,
   }
   eosSafeDestroy(NT, tableHandle, eospacWarn);
 }
+
+
+void makeInterpPoints(std::vector<EOS_REAL>& v, const Bounds& b) {
+  v.resize(b.grid.nPoints());
+  for (size_t i = 0; i < v.size(); i++) {
+    v[i] = b.i2lin(i);
+  }
+}

--- a/sesame2spiner/io_eospac.hpp
+++ b/sesame2spiner/io_eospac.hpp
@@ -34,26 +34,11 @@
 #include <spiner/interpolation.hpp>
 #include <fast-math/logs.hpp>
 
+#include <eospac-wrapper/eospac_wrapper.hpp>
+
 using Spiner::DataBox;
 using Spiner::RegularGrid1D;
-
-inline Real densityToSesame(const Real CodeTemp) { return CodeTemp;}
-inline Real densityFromSesame(const Real sesTemp) { return sesTemp;}
-inline Real temperatureToSesame(const Real CodeTemp) { return CodeTemp;}
-inline Real temperatureFromSesame(const Real SesTemp) { return SesTemp;}
-inline Real pressureFromSesame(const Real SesPress) { return 1e10*SesPress;}
-inline Real pressureToSesame(const Real CodePress) { return 1e-10*CodePress;}
-inline Real sieToSesame(const Real CodeSie) { return 1e-10*CodeSie;}
-inline Real sieFromSesame(const Real SesSie) { return 1e10*SesSie;}
-inline Real cvFromSesame(const Real SesCv) { return 1e10*SesCv;}
-inline Real bulkModulusFromSesame(const Real SesBmod) { return 1e10*SesBmod;}
-inline Real getBulkModulus(const Real rho, const Real P,
-                           const Real DPDR_T, const Real DPDE_R,
-                           const Real DEDR_T) {
-  return rho*DPDR_T + DPDE_R*((P/rho) - rho*DEDR_T);
-}
-
-enum class Verbosity { Quiet, Verbose, Debug };
+using EospacWrapper::Verbosity;
 
 // For logarithmic interpolation, quantities may be negative.
 // If they are, use offset to ensure negative values make sense.
@@ -130,47 +115,6 @@ public:
   Real offset;
 };
 
-class SesameMetadata {
-public:
-  int matid;
-  Real exchangeCoefficient;
-  Real meanAtomicMass;
-  Real meanAtomicNumber;
-  Real solidBulkModulus;
-  Real normalDensity;
-  Real rhoMin, rhoMax;
-  Real TMin, TMax;
-  Real sieMin, sieMax;
-  Real rhoConversionFactor;
-  Real TConversionFactor;
-  Real sieConversionFactor;
-  int numRho, numT;
-  std::string comments;
-  std::string name;
-  friend std::ostream& operator<< (std::ostream& os, const SesameMetadata& m) {
-    os << "MATID: "  << m.matid << "\n"
-       << "\tname: " << m.name << "\n"
-       << "\texchange coefficient  = " << m.exchangeCoefficient << "\n"
-       << "\tmean atomic mass      = " << m.meanAtomicMass      << "\n"
-       << "\tsolid bulk modulus    = " << m.solidBulkModulus    << "\n"
-       << "\tnormal density        = " << m.normalDensity       << "\n"
-       << "\t[rho min, rho max]    = "
-       << "[" << m.rhoMin << ", " << m.rhoMax << "]" << "\n"
-       << "\t[T min, T max]        = "
-       << "[" << m.TMin << ", " << m.TMax << "]" << "\n"
-       << "\t[sie min, sie max]    = "
-       << "[" << m.sieMin << ", " << m.sieMax << "]" << "\n"
-       << "\tnum rho               = " << m.numRho  << "\n"
-       << "\tnum T                 = " << m.numT    << "\n"
-       << "\tComments:\n"
-       << m.comments << "\n";
-    return os;
-  }
-};
-
-void eosGetMetadata(int matid, SesameMetadata& metadata,
-                    Verbosity eospacWarn = Verbosity::Quiet);
-
 void eosDataOfRhoSie(int matid,
                      const Bounds& lRhoBounds,
                      const Bounds& leBounds,
@@ -221,43 +165,6 @@ void eosColdCurveMask(int matid,
                       Verbosity eospacWarn = Verbosity::Quiet
                       );
 
-EOS_INTEGER eosSafeLoad(int ntables, int matid,
-                        EOS_INTEGER tableType[],
-                        EOS_INTEGER tableHandle[],
-                        Verbosity eospacWarn);
-EOS_INTEGER eosSafeLoad(int ntables, int matid,
-                        EOS_INTEGER tableType[],
-                        EOS_INTEGER tableHandle[],
-                        const std::vector<std::string>& table_names,
-                        Verbosity eospacWarn);
-
-// output is boolean mask. 1 for no errors. 0 for errors.
-bool eosSafeInterpolate(EOS_INTEGER *table,
-			EOS_INTEGER nxypairs,
-			EOS_REAL xVals[],
-			EOS_REAL yVals[],
-			EOS_REAL var[],
-			EOS_REAL dx[],
-			EOS_REAL dy[],
-			const char tablename[],
-			Verbosity eospacWarn);
-
-void eosSafeTableInfo(EOS_INTEGER* table,
-                      EOS_INTEGER numInfoItems,
-                      EOS_INTEGER infoItems[],
-                      EOS_REAL infoVals[],
-                      Verbosity eospacWarn);
-
-void eosSafeTableCmnts(EOS_INTEGER* table, EOS_CHAR* comments,
-                       Verbosity eospacWarn);
-
-void eosCheckError(EOS_INTEGER errorCode, const std::string& name,
-                   Verbosity eospacWarn);
-std::string eosErrorString(EOS_INTEGER errorCode);
-void eosSafeDestroy(int ntables, EOS_INTEGER tableHandles[],
-                    Verbosity eospacWarn);
-
 void makeInterpPoints(std::vector<EOS_REAL>& v, const Bounds& b);
-std::string getName(std::string comment);
 
 #endif // _SESAME2SPINER_IO_EOSPAC_HPP_

--- a/singularity-eos/eos/eos.hpp
+++ b/singularity-eos/eos/eos.hpp
@@ -1399,7 +1399,7 @@ private:
 class EOSPAC {
 public:
   EOSPAC() = default;
-  EOSPAC(int matid);
+  EOSPAC(int matid, bool invert_at_setup=false);
   EOSPAC GetOnDevice() { return *this; }
   PORTABLE_FUNCTION Real TemperatureFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,8 +24,7 @@ target_link_libraries(eos_unit_tests Catch2::Catch2 eos singularity-eos::libs si
 
 if(SINGULARITY_USE_EOSPAC AND SINGULARITY_USE_HDF5 AND SINGULARITY_TEST_SESAME)
   add_executable(compare_to_eospac
-                 compare_to_eospac.cpp
-                 ${CMAKE_SOURCE_DIR}/sesame2spiner/io_eospac.cpp)
+                 compare_to_eospac.cpp)
   target_link_libraries(compare_to_eospac Catch2::Catch2 eos singularity-eos::libs singularity-eos::flags)
   target_include_directories(compare_to_eospac PUBLIC
                              ${CMAKE_SOURCE_DIR}/utils/spiner

--- a/test/compare_on_data.cpp
+++ b/test/compare_on_data.cpp
@@ -34,8 +34,6 @@
 #include <hdf5.h>
 #include <hdf5_hl.h>
 
-#include <eos_Interface.h> // eospac API
-
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
 
@@ -45,9 +43,10 @@
 #include <singularity-eos/eos/eos.hpp>
 #include <singularity-eos/eos/eos_builder.hpp>
 
-#include <sesame2spiner/io_eospac.hpp>
+#include <eospac-wrapper/eospac_wrapper.hpp>
 
 using namespace singularity;
+using namespace EospacWrapper;
 
 using duration = std::chrono::duration<long double>;
 using dvec = std::vector<double>;

--- a/test/compare_on_dataset.cpp
+++ b/test/compare_on_dataset.cpp
@@ -35,8 +35,6 @@
 #include <hdf5.h>
 #include <hdf5_hl.h>
 
-#include <eos_Interface.h> // eospac API
-
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
 
@@ -45,9 +43,10 @@
 
 #include <singularity-eos/eos/eos.hpp>
 
-#include <singularity-eos/sesame2spiner/io_eospac.hpp>
+#include <eospac-wrapper/eospac_wrapper.hpp>
 
 using namespace singularity;
+using namespace EospacWrapper;
 
 using duration = std::chrono::duration<long double>;
 using dvec = std::vector<double>;

--- a/test/compare_to_eospac.cpp
+++ b/test/compare_to_eospac.cpp
@@ -34,8 +34,6 @@
 #include <hdf5.h>
 #include <hdf5_hl.h>
 
-#include <eos_Interface.h> // eospac API
-
 #include <ports-of-call/portability.hpp>
 #include <sp5/singularity_eos_sp5.hpp>
 #include <spiner/spiner_types.hpp>
@@ -49,6 +47,9 @@
 
 #include <singularity-eos/eos/eos.hpp>
 
+#include <sesame2spiner/io_eospac.hpp>
+
+using namespace Spiner;
 using namespace singularity;
 using namespace EospacWrapper;
 

--- a/test/compare_to_eospac.cpp
+++ b/test/compare_to_eospac.cpp
@@ -43,13 +43,14 @@
 #include <spiner/databox.hpp>
 #include <spiner/interpolation.hpp>
 
-#include <sesame2spiner/io_eospac.hpp>
+#include <eospac-wrapper/eospac_wrapper.hpp>
 
 #include <ports-of-call/portability.hpp>
 
 #include <singularity-eos/eos/eos.hpp>
 
 using namespace singularity;
+using namespace EospacWrapper;
 
 using duration = std::chrono::microseconds;
 constexpr char diffFileName[] = "diffs.sp5";


### PR DESCRIPTION
A little bit of cleanup requested by @dholladay00 . Moves the "eospac" wrappers that I wrote for `sesame2spiner` into a separate directory. This lets us use different build/link flags for the eospac-specific stuff, and it also more cleanly separates the pieces of machinery that are used outside `sesame2spiner`.