### PR TITLE
clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+ColumnLimit: 90
+IndentWidth: 2
+AccessModifierOffset: -1
+
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortIfStatementsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ make -j
 make test
 ```
 
+## Formatting
+
+This project is formatted with `clang-format` using `clang-format`
+version 10.0.0. If contributing, please run clang-format on the files
+you modify.
+
+For now, we will periodically run clang-format on the repo to
+synchronize it. An automated solution will be forth coming.
+
 ## Copyright
 
 © 2021. Triad National Security, LLC. All rights reserved.  This

--- a/sesame2spiner/generate_files.hpp
+++ b/sesame2spiner/generate_files.hpp
@@ -23,36 +23,25 @@
 #include <hdf5.h>
 #include <hdf5_hl.h>
 
-#include "parser.hpp"
 #include "io_eospac.hpp"
+#include "parser.hpp"
 
 constexpr int PPD_DEFAULT = 50;
 constexpr Real STRICTLY_POS_MIN = 1e-9;
 
-herr_t saveMaterial(hid_t loc,
-                    const SesameMetadata& metadata,
-                    const Bounds& lRhoBounds,
-                    const Bounds& lTBounds,
-                    const Bounds& leBounds,
-                    const std::string& name,
-                    Verbosity eospacWarn = Verbosity::Quiet);
+herr_t saveMaterial(hid_t loc, const SesameMetadata &metadata, const Bounds &lRhoBounds,
+                    const Bounds &lTBounds, const Bounds &leBounds,
+                    const std::string &name, Verbosity eospacWarn = Verbosity::Quiet);
 
-herr_t saveAllMaterials(const std::string& savename,
-			const std::vector<std::string>& filenames,
-                        bool printMetadata,
+herr_t saveAllMaterials(const std::string &savename,
+                        const std::vector<std::string> &filenames, bool printMetadata,
                         Verbosity eospacWarn);
 
-void getMatBounds(int i,
-                  int matid,
-                  const SesameMetadata& metadata,
-		  const Params& params,
-                  Bounds& lRhoBounds,
-                  Bounds& lTBounds,
-                  Bounds& leBounds);
+void getMatBounds(int i, int matid, const SesameMetadata &metadata, const Params &params,
+                  Bounds &lRhoBounds, Bounds &lTBounds, Bounds &leBounds);
 
-bool checkValInMatBounds(int matid,
-                         const std::string& name,
-                         Real val, Real vmin, Real vmax);
+bool checkValInMatBounds(int matid, const std::string &name, Real val, Real vmin,
+                         Real vmax);
 
 int getNumPointsFromPPD(Real min, Real max, int ppd);
 

--- a/sesame2spiner/io_eospac.cpp
+++ b/sesame2spiner/io_eospac.cpp
@@ -14,17 +14,15 @@
 // publicly and display publicly, and to permit others to do so.
 //======================================================================
 
-#include <iostream>
-#include <vector>
-#include <algorithm>
-#include <string>
-#include <array>
-#include <vector>
-#include <regex>
 #include "io_eospac.hpp"
+#include <algorithm>
+#include <array>
+#include <iostream>
+#include <regex>
+#include <string>
+#include <vector>
 
-void eosGetMetadata(int matid, SesameMetadata& metadata,
-                    Verbosity eospacWarn) {
+void eosGetMetadata(int matid, SesameMetadata &metadata, Verbosity eospacWarn) {
   constexpr int NT = 2;
   EOS_INTEGER tableHandle[NT];
   EOS_INTEGER tableType[NT] = {EOS_Info, EOS_Ut_DT};
@@ -34,21 +32,12 @@ void eosGetMetadata(int matid, SesameMetadata& metadata,
 
   constexpr int numInfoTables = 2;
   constexpr int NI[] = {5, 11};
-  std::array<std::vector<EOS_INTEGER>,numInfoTables> infoItems = 
-    {
-      std::vector<EOS_INTEGER>{EOS_Exchange_Coeff,
-                               EOS_Mean_Atomic_Mass,
-                               EOS_Mean_Atomic_Num,
-                               EOS_Modulus,
-                               EOS_Normal_Density},
-      std::vector<EOS_INTEGER>{ EOS_Rmin, EOS_Rmax,
-                                EOS_Tmin, EOS_Tmax,
-                                EOS_Fmin, EOS_Fmax,
-                                EOS_NR,   EOS_NT,
-                                EOS_X_Convert_Factor,
-                                EOS_Y_Convert_Factor,
-                                EOS_F_Convert_Factor}
-    };
+  std::array<std::vector<EOS_INTEGER>, numInfoTables> infoItems = {
+      std::vector<EOS_INTEGER>{EOS_Exchange_Coeff, EOS_Mean_Atomic_Mass,
+                               EOS_Mean_Atomic_Num, EOS_Modulus, EOS_Normal_Density},
+      std::vector<EOS_INTEGER>{EOS_Rmin, EOS_Rmax, EOS_Tmin, EOS_Tmax, EOS_Fmin, EOS_Fmax,
+                               EOS_NR, EOS_NT, EOS_X_Convert_Factor, EOS_Y_Convert_Factor,
+                               EOS_F_Convert_Factor}};
   std::vector<EOS_REAL> infoVals[numInfoTables];
   for (int i = 0; i < numInfoTables; i++) {
     infoVals[i].resize(NI[i]);
@@ -57,50 +46,41 @@ void eosGetMetadata(int matid, SesameMetadata& metadata,
     }
   }
 
-  eosSafeLoad(NT, matid, tableType, tableHandle,
-              {"EOS_Info", "EOS_Ut_DT"},
-              eospacWarn);
+  eosSafeLoad(NT, matid, tableType, tableHandle, {"EOS_Info", "EOS_Ut_DT"}, eospacWarn);
 
   for (int i = 0; i < numInfoTables; i++) {
-    eosSafeTableInfo(&(tableHandle[i]), NI[i],
-                     infoItems[i].data(),
-                     infoVals[i].data(),
+    eosSafeTableInfo(&(tableHandle[i]), NI[i], infoItems[i].data(), infoVals[i].data(),
                      eospacWarn);
   }
   metadata.matid = matid;
   metadata.exchangeCoefficient = infoVals[0][0];
-  metadata.meanAtomicMass      = infoVals[0][1];
-  metadata.meanAtomicNumber    = infoVals[0][2];
-  metadata.solidBulkModulus    = bulkModulusFromSesame(infoVals[0][3]);
-  metadata.normalDensity       = densityFromSesame(infoVals[0][4]);
-  metadata.rhoMin              = densityFromSesame(infoVals[1][0]);
-  metadata.rhoMax              = densityFromSesame(infoVals[1][1]);
-  metadata.TMin                = temperatureFromSesame(infoVals[1][2]);
-  metadata.TMax                = temperatureFromSesame(infoVals[1][3]);
-  metadata.sieMin              = sieFromSesame(infoVals[1][4]);
-  metadata.sieMax              = sieFromSesame(infoVals[1][5]);
-  metadata.numRho              = static_cast<int>(infoVals[1][6]);
-  metadata.numT                = static_cast<int>(infoVals[1][7]);
+  metadata.meanAtomicMass = infoVals[0][1];
+  metadata.meanAtomicNumber = infoVals[0][2];
+  metadata.solidBulkModulus = bulkModulusFromSesame(infoVals[0][3]);
+  metadata.normalDensity = densityFromSesame(infoVals[0][4]);
+  metadata.rhoMin = densityFromSesame(infoVals[1][0]);
+  metadata.rhoMax = densityFromSesame(infoVals[1][1]);
+  metadata.TMin = temperatureFromSesame(infoVals[1][2]);
+  metadata.TMax = temperatureFromSesame(infoVals[1][3]);
+  metadata.sieMin = sieFromSesame(infoVals[1][4]);
+  metadata.sieMax = sieFromSesame(infoVals[1][5]);
+  metadata.numRho = static_cast<int>(infoVals[1][6]);
+  metadata.numT = static_cast<int>(infoVals[1][7]);
   metadata.rhoConversionFactor = infoVals[1][8];
-  metadata.TConversionFactor   = infoVals[1][9];
+  metadata.TConversionFactor = infoVals[1][9];
   metadata.sieConversionFactor = infoVals[1][10];
 
   eosSafeDestroy(NT, tableHandle, eospacWarn);
 
-  EOS_INTEGER errorCode = eosSafeLoad(1, matid,
-                                      commentsType,
-                                      commentsHandle,
-                                      {"EOS_Comments"},
-                                      eospacWarn);
+  EOS_INTEGER errorCode =
+      eosSafeLoad(1, matid, commentsType, commentsHandle, {"EOS_Comments"}, eospacWarn);
   EOS_INTEGER eospacComments = commentsHandle[0];
 
   if (errorCode == EOS_OK) {
     std::vector<EOS_CHAR> comments;
     EOS_REAL commentLen;
     EOS_INTEGER commentItem = EOS_Cmnt_Len;
-    eosSafeTableInfo(commentsHandle, 1,
-                     &commentItem, &commentLen,
-                     eospacWarn);
+    eosSafeTableInfo(commentsHandle, 1, &commentItem, &commentLen, eospacWarn);
 
     comments.resize(static_cast<int>(commentLen));
     metadata.comments.resize(comments.size());
@@ -109,14 +89,13 @@ void eosGetMetadata(int matid, SesameMetadata& metadata,
       metadata.comments[i] = comments[i];
     }
     metadata.name = getName(metadata.comments);
-    
+
     eosSafeDestroy(1, commentsHandle, eospacWarn);
   } else {
     std::string matid_str = std::to_string(matid);
     if (eospacWarn != Verbosity::Quiet) {
       std::cerr << "eos_GetMetadata: failed to get comments table. "
-                << "Using default comments and name fields."
-                << std::endl;
+                << "Using default comments and name fields." << std::endl;
     }
     metadata.name = "No name for matid " + matid_str;
     metadata.comments = "Comment unavailable for matid " + matid_str;
@@ -124,21 +103,11 @@ void eosGetMetadata(int matid, SesameMetadata& metadata,
 }
 
 // TODO: more error checking of bounds?
-void eosDataOfRhoSie(int matid,
-                     const Bounds& lRhoBounds,
-                     const Bounds& leBounds,
-                     DataBox& Ps,
-                     DataBox& Ts,
-                     DataBox& bMods,
-                     DataBox& dPdRho,
-                     DataBox& dPde,
-                     DataBox& dTdRho,
-                     DataBox& dTde,
-                     DataBox& dEdRho,
-                     DataBox& mask,
-                     Verbosity eospacWarn
-                     ) {
-  
+void eosDataOfRhoSie(int matid, const Bounds &lRhoBounds, const Bounds &leBounds,
+                     DataBox &Ps, DataBox &Ts, DataBox &bMods, DataBox &dPdRho,
+                     DataBox &dPde, DataBox &dTdRho, DataBox &dTde, DataBox &dEdRho,
+                     DataBox &mask, Verbosity eospacWarn) {
+
   constexpr int NT = 3;
   constexpr EOS_INTEGER nXYPairs = 1;
   EOS_INTEGER tableHandle[NT];
@@ -154,8 +123,7 @@ void eosDataOfRhoSie(int matid,
   makeInterpPoints(sies, leBounds);
 
   // Load tables
-  eosSafeLoad(NT, matid, tableType, tableHandle,
-              {"EOS_Pt_DT","EOS_T_DUt","EOS_Ut_DT"},
+  eosSafeLoad(NT, matid, tableType, tableHandle, {"EOS_Pt_DT", "EOS_T_DUt", "EOS_Ut_DT"},
               eospacWarn);
   eospacPofRT = tableHandle[0];
   eospacTofRE = tableHandle[1];
@@ -164,8 +132,8 @@ void eosDataOfRhoSie(int matid,
   // Make sie faster moving index, for easy inversion
   // TODO: is this right?
   Ps.resize(rhos.size(), sies.size());
-  Ps.setRange(0,leBounds.grid);
-  Ps.setRange(1,lRhoBounds.grid);
+  Ps.setRange(0, leBounds.grid);
+  Ps.setRange(1, lRhoBounds.grid);
   Ts.copyMetadata(Ps);
   bMods.copyMetadata(Ps);
   dPdRho.copyMetadata(Ps);
@@ -183,61 +151,44 @@ void eosDataOfRhoSie(int matid,
       Real sie = sieToSesame(sies[i]);
       // T
       bool no_errors = true;
-      no_errors = no_errors && eosSafeInterpolate(&eospacTofRE, nXYPairs,
-						  &rho, &sie, var, dx, dy,
-						  "TofRE",
-						  eospacWarn);
+      no_errors = no_errors && eosSafeInterpolate(&eospacTofRE, nXYPairs, &rho, &sie, var,
+                                                  dx, dy, "TofRE", eospacWarn);
       Real T = var[0];
       Real DTDR_E = dx[0];
       Real DTDE_R = dy[0];
       // P
-      no_errors = no_errors && eosSafeInterpolate(&eospacPofRT, nXYPairs,
-						  &rho, &T, var, dx, dy,
-						  "PofRT",
-						  eospacWarn);
+      no_errors = no_errors && eosSafeInterpolate(&eospacPofRT, nXYPairs, &rho, &T, var,
+                                                  dx, dy, "PofRT", eospacWarn);
       Real P = var[0];
       Real DPDR_T = dx[0];
       Real DPDT_R = dy[0];
       // Bulk modulus
-      no_errors = no_errors && eosSafeInterpolate(&eospacEofRT, nXYPairs,
-						  &rho, &T, var, dx, dy,
-						  "EofRT",
-						  eospacWarn);
+      no_errors = no_errors && eosSafeInterpolate(&eospacEofRT, nXYPairs, &rho, &T, var,
+                                                  dx, dy, "EofRT", eospacWarn);
       Real DEDR_T = dx[0];
       Real DEDT_R = dy[0];
-      Real DPDE_R = DPDT_R/DEDT_R;
-      Real bMod = getBulkModulus(rho,P,DPDR_T,DPDE_R,DEDR_T);
+      Real DPDE_R = DPDT_R / DEDT_R;
+      Real bMod = getBulkModulus(rho, P, DPDR_T, DPDE_R, DEDR_T);
       // Fill DataBoxes
-      Ts(j,i)     = temperatureFromSesame(T);
-      Ps(j,i)     = pressureFromSesame(P);
-      bMods(j,i)  = bulkModulusFromSesame(std::max(bMod,0.0));
-      dPdRho(j,i) = pressureFromSesame(DPDR_T + DTDR_E*DPDT_R);
-      dPde(j,i)   = sieToSesame(pressureFromSesame(DPDT_R*DTDE_R));
-      dTdRho(j,i) = temperatureFromSesame(DTDR_E);
-      dTde(j,i)   = sieToSesame(temperatureFromSesame(DTDE_R));
-      dEdRho(j,i) = densityToSesame(sieFromSesame(DEDR_T));
-      mask(j,i)   = no_errors ? 1.0 : 0.0;
+      Ts(j, i) = temperatureFromSesame(T);
+      Ps(j, i) = pressureFromSesame(P);
+      bMods(j, i) = bulkModulusFromSesame(std::max(bMod, 0.0));
+      dPdRho(j, i) = pressureFromSesame(DPDR_T + DTDR_E * DPDT_R);
+      dPde(j, i) = sieToSesame(pressureFromSesame(DPDT_R * DTDE_R));
+      dTdRho(j, i) = temperatureFromSesame(DTDR_E);
+      dTde(j, i) = sieToSesame(temperatureFromSesame(DTDE_R));
+      dEdRho(j, i) = densityToSesame(sieFromSesame(DEDR_T));
+      mask(j, i) = no_errors ? 1.0 : 0.0;
     }
   }
 
   eosSafeDestroy(NT, tableHandle, eospacWarn);
 }
 
-void eosDataOfRhoT(int matid,
-                   const Bounds& lRhoBounds,
-                   const Bounds& lTBounds,
-                   DataBox& Ps,
-                   DataBox& sies,
-                   DataBox& bMods,
-                   DataBox& dPdRho,
-                   DataBox& dPdE,
-                   DataBox& dTdRho,
-                   DataBox& dTde,
-                   DataBox& dEdRho,
-                   DataBox& dEdT,
-                   DataBox& mask,
-                   Verbosity eospacWarn
-                   ) {
+void eosDataOfRhoT(int matid, const Bounds &lRhoBounds, const Bounds &lTBounds,
+                   DataBox &Ps, DataBox &sies, DataBox &bMods, DataBox &dPdRho,
+                   DataBox &dPdE, DataBox &dTdRho, DataBox &dTde, DataBox &dEdRho,
+                   DataBox &dEdT, DataBox &mask, Verbosity eospacWarn) {
 
   constexpr int NT = 3;
   constexpr EOS_INTEGER nXYPairs = 1;
@@ -254,8 +205,7 @@ void eosDataOfRhoT(int matid,
   makeInterpPoints(Ts, lTBounds);
 
   // Load tables
-  eosSafeLoad(NT, matid, tableType, tableHandle,
-              {"EOS_Pt_DT","EOS_T_DUt","EOS_Ut_DT"},
+  eosSafeLoad(NT, matid, tableType, tableHandle, {"EOS_Pt_DT", "EOS_T_DUt", "EOS_Ut_DT"},
               eospacWarn);
   eospacPofRT = tableHandle[0];
   eospacTofRE = tableHandle[1];
@@ -263,8 +213,8 @@ void eosDataOfRhoT(int matid,
 
   // Make T faster moving index, for easy inversion
   Ps.resize(rhos.size(), Ts.size());
-  Ps.setRange(0,lTBounds.grid);
-  Ps.setRange(1,lRhoBounds.grid);
+  Ps.setRange(0, lTBounds.grid);
+  Ps.setRange(1, lRhoBounds.grid);
   sies.copyMetadata(Ps);
   bMods.copyMetadata(Ps);
   dPdRho.copyMetadata(Ps);
@@ -283,53 +233,43 @@ void eosDataOfRhoT(int matid,
       Real T = temperatureToSesame(Ts[i]);
       bool no_errors = true;
       // Pressure
-      no_errors = no_errors && eosSafeInterpolate(&eospacPofRT, nXYPairs,
-						  &rho, &T, var, dx, dy,
-						  "PofRT", eospacWarn);
+      no_errors = no_errors && eosSafeInterpolate(&eospacPofRT, nXYPairs, &rho, &T, var,
+                                                  dx, dy, "PofRT", eospacWarn);
       Real P = var[0];
       Real DPDR_T = dx[0];
       Real DPDT_R = dy[0];
       // Energy
-      no_errors = no_errors && eosSafeInterpolate(&eospacEofRT, nXYPairs,
-						  &rho, &T, var, dx, dy,
-						  "EofRT", eospacWarn);
+      no_errors = no_errors && eosSafeInterpolate(&eospacEofRT, nXYPairs, &rho, &T, var,
+                                                  dx, dy, "EofRT", eospacWarn);
       Real E = var[0];
       Real DEDR_T = dx[0];
       Real DEDT_R = dy[0];
       // T derivatives
-      no_errors = no_errors && eosSafeInterpolate(&eospacTofRE, nXYPairs,
-						  &rho, &E, var, dx, dy,
-						  "TofRE", eospacWarn);
+      no_errors = no_errors && eosSafeInterpolate(&eospacTofRE, nXYPairs, &rho, &E, var,
+                                                  dx, dy, "TofRE", eospacWarn);
       Real DTDR_E = dx[0];
       Real DTDE_R = dy[0];
-      Real DPDE_R = DPDT_R/DEDT_R;
-      Real bMod = getBulkModulus(rho,P,DPDR_T,DPDE_R,DEDR_T);
+      Real DPDE_R = DPDT_R / DEDT_R;
+      Real bMod = getBulkModulus(rho, P, DPDR_T, DPDE_R, DEDR_T);
       // Fill DataBoxes
-      Ps(j,i)     = pressureFromSesame(P);
-      sies(j,i)   = sieFromSesame(E);
-      bMods(j,i)  = bulkModulusFromSesame(std::max(bMod,0.0));
-      dPdRho(j,i) = pressureFromSesame(DPDR_T + DTDR_E*DPDT_R);
-      dPdE(j,i)   = sieToSesame(pressureFromSesame(DPDT_R*DTDE_R));
-      dTdRho(j,i) = temperatureFromSesame(DTDR_E);
-      dTde(j,i)   = sieToSesame(temperatureFromSesame(DTDE_R));
-      dEdRho(j,i) = densityToSesame(sieFromSesame(DEDR_T));
-      dEdT(j,i)   = sieFromSesame(temperatureToSesame(DEDT_R));
-      mask(j,i)   = no_errors ? 1.0 : 0.0;
+      Ps(j, i) = pressureFromSesame(P);
+      sies(j, i) = sieFromSesame(E);
+      bMods(j, i) = bulkModulusFromSesame(std::max(bMod, 0.0));
+      dPdRho(j, i) = pressureFromSesame(DPDR_T + DTDR_E * DPDT_R);
+      dPdE(j, i) = sieToSesame(pressureFromSesame(DPDT_R * DTDE_R));
+      dTdRho(j, i) = temperatureFromSesame(DTDR_E);
+      dTde(j, i) = sieToSesame(temperatureFromSesame(DTDE_R));
+      dEdRho(j, i) = densityToSesame(sieFromSesame(DEDR_T));
+      dEdT(j, i) = sieFromSesame(temperatureToSesame(DEDT_R));
+      mask(j, i) = no_errors ? 1.0 : 0.0;
     }
   }
   eosSafeDestroy(NT, tableHandle, eospacWarn);
 }
 
-void eosColdCurves(int matid,
-                   const Bounds& lRhoBounds,
-                   DataBox& Ps,
-                   DataBox& sies,
-                   DataBox& dPdRho,
-                   DataBox& dEdRho,
-                   DataBox& bMods,
-                   DataBox& mask,
-                   Verbosity eospacWarn
-                   ) {
+void eosColdCurves(int matid, const Bounds &lRhoBounds, DataBox &Ps, DataBox &sies,
+                   DataBox &dPdRho, DataBox &dEdRho, DataBox &bMods, DataBox &mask,
+                   Verbosity eospacWarn) {
 
   constexpr int NT = 2;
   constexpr EOS_INTEGER nXYPairs = 1;
@@ -345,15 +285,13 @@ void eosColdCurves(int matid,
   makeInterpPoints(rhos, lRhoBounds);
 
   // Load tables
-  eosSafeLoad(NT, matid, tableType, tableHandle,
-              {"EOS_Pc_D","EOS_Uc_D"},
-              eospacWarn);
+  eosSafeLoad(NT, matid, tableType, tableHandle, {"EOS_Pc_D", "EOS_Uc_D"}, eospacWarn);
   eospacPColdCurve = tableHandle[0];
   eospacSieColdCurve = tableHandle[1];
 
   // vars
   Ps.resize(rhos.size());
-  Ps.setRange(0,lRhoBounds.grid);
+  Ps.setRange(0, lRhoBounds.grid);
   sies.copyMetadata(Ps);
   dPdRho.copyMetadata(Ps);
   dEdRho.copyMetadata(Ps);
@@ -367,37 +305,29 @@ void eosColdCurves(int matid,
     Real T = temperatureToSesame(0);
     bool no_errors = true;
     // pressure cold curve
-    no_errors = no_errors && eosSafeInterpolate(&eospacPColdCurve, nXYPairs,
-                                                &rho, &T, var, dx, dy,
-                                                "PCold", eospacWarn);
+    no_errors = no_errors && eosSafeInterpolate(&eospacPColdCurve, nXYPairs, &rho, &T,
+                                                var, dx, dy, "PCold", eospacWarn);
     Real P = var[0];
     Real DPDR_T = dx[0];
     // energy cold curve
-    no_errors = no_errors && eosSafeInterpolate(&eospacSieColdCurve, nXYPairs,
-                                                &rho, &T, var, dx, dy,
-                                                "sieCold", eospacWarn);
+    no_errors = no_errors && eosSafeInterpolate(&eospacSieColdCurve, nXYPairs, &rho, &T,
+                                                var, dx, dy, "sieCold", eospacWarn);
     Real sie = var[0];
     Real DEDR_T = dx[0];
     // bulk modulus cold curev
-    Real bMod = getBulkModulus(rho,P,DPDR_T,0,0);
+    Real bMod = getBulkModulus(rho, P, DPDR_T, 0, 0);
     // fill DataBoxes
     Ps(i) = pressureFromSesame(P);
     sies(i) = sieFromSesame(sie);
-    bMods(i) = bulkModulusFromSesame(std::max(bMod,0.0));
+    bMods(i) = bulkModulusFromSesame(std::max(bMod, 0.0));
     dPdRho(i) = pressureFromSesame(DPDR_T); // on cold curve DTDR_E = 0
     dEdRho(i) = sieFromSesame(DEDR_T);
     mask(i) = no_errors ? 1.0 : 0.0;
   }
 }
 
-void eosColdCurveMask(int matid,
-                      const Bounds& lRhoBounds,
-                      const int numSie,
-                      const DataBox& sieColdCurve,
-                      DataBox& mask,
-                      Verbosity eospacWarn
-                      ) {
-
+void eosColdCurveMask(int matid, const Bounds &lRhoBounds, const int numSie,
+                      const DataBox &sieColdCurve, DataBox &mask, Verbosity eospacWarn) {
 
   constexpr int NT = 1;
   constexpr EOS_INTEGER nXYPairs = 1;
@@ -406,9 +336,7 @@ void eosColdCurveMask(int matid,
   EOS_INTEGER tableType[NT] = {EOS_T_DUt};
 
   // Load tables
-  eosSafeLoad(NT, matid, tableType, tableHandle,
-              {"EOS_T_DUt"},
-              eospacWarn);
+  eosSafeLoad(NT, matid, tableType, tableHandle, {"EOS_T_DUt"}, eospacWarn);
   eospacTofRE = tableHandle[0];
 
   // Interpolatable vars
@@ -420,121 +348,98 @@ void eosColdCurveMask(int matid,
 
   // vars
   mask.resize(rhos.size(), numSie);
-  mask.setRange(1,lRhoBounds.grid);
+  mask.setRange(1, lRhoBounds.grid);
 
   // sie
-  Bounds coldBounds(-1,1,numSie,false);
-  mask.setRange(0,coldBounds.grid);
+  Bounds coldBounds(-1, 1, numSie, false);
+  mask.setRange(0, coldBounds.grid);
 
   // loop and fill dummy variable just to see if EOSPAC errors out
   for (size_t j = 0; j < rhos.size(); j++) {
     Real rho = densityToSesame(rhos[j]);
     Real sieCold = sieColdCurve(j);
     Real sieColdAbs = std::abs(sieCold);
-    Bounds sieBounds(sieCold - sieColdAbs,
-                     sieCold + sieColdAbs,
-                     numSie, false);
+    Bounds sieBounds(sieCold - sieColdAbs, sieCold + sieColdAbs, numSie, false);
     for (int i = 0; i < numSie; i++) {
       Real sie = sieToSesame(sieBounds.grid.x(i));
       // T
-      bool no_errors = eosSafeInterpolate(&eospacTofRE, nXYPairs,
-                                          &rho, &sie, var, dx, dy,
-                                          "TofRE",
-                                          eospacWarn);
-      mask(j,i) = no_errors ? 1.0 : 0.0;
+      bool no_errors = eosSafeInterpolate(&eospacTofRE, nXYPairs, &rho, &sie, var, dx, dy,
+                                          "TofRE", eospacWarn);
+      mask(j, i) = no_errors ? 1.0 : 0.0;
     }
   }
   eosSafeDestroy(NT, tableHandle, eospacWarn);
 }
 
-EOS_INTEGER eosSafeLoad(int ntables, int matid,
-                        EOS_INTEGER tableType[],
-                        EOS_INTEGER tableHandle[],
-                        Verbosity eospacWarn) {
+EOS_INTEGER eosSafeLoad(int ntables, int matid, EOS_INTEGER tableType[],
+                        EOS_INTEGER tableHandle[], Verbosity eospacWarn) {
   std::vector<std::string> empty;
-  return eosSafeLoad(ntables,matid,tableType,tableHandle,empty,eospacWarn);
+  return eosSafeLoad(ntables, matid, tableType, tableHandle, empty, eospacWarn);
 }
 
-EOS_INTEGER eosSafeLoad(int ntables, int matid,
-                        EOS_INTEGER tableType[],
+EOS_INTEGER eosSafeLoad(int ntables, int matid, EOS_INTEGER tableType[],
                         EOS_INTEGER tableHandle[],
-                        const std::vector<std::string>& table_names,
+                        const std::vector<std::string> &table_names,
                         Verbosity eospacWarn) {
 
   EOS_INTEGER NTABLES[] = {ntables};
-  std::vector<EOS_INTEGER> MATID(ntables,matid);
-  
+  std::vector<EOS_INTEGER> MATID(ntables, matid);
+
   EOS_INTEGER errorCode = EOS_OK;
   EOS_INTEGER tableHandleErrorCode = EOS_OK;
   EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
 
   eos_CreateTables(NTABLES, tableType, MATID.data(), tableHandle, &errorCode);
 
-  #ifdef SINGULARITY_INVERT_AT_SETUP
+#ifdef SINGULARITY_INVERT_AT_SETUP
   EOS_INTEGER options[] = {EOS_INVERT_AT_SETUP, EOS_INSERT_DATA};
   EOS_REAL values[] = {1., 4.};
   for (int i = 0; i < ntables; i++) {
-    eos_SetOption(&(tableHandle[i]),&(options[0]),&(values[0]),&errorCode);
-    eos_SetOption(&(tableHandle[i]),&(options[1]),&(values[1]),&errorCode);
+    eos_SetOption(&(tableHandle[i]), &(options[0]), &(values[0]), &errorCode);
+    eos_SetOption(&(tableHandle[i]), &(options[1]), &(values[1]), &errorCode);
   }
-  #endif
+#endif
 
-  #ifdef SINGULARITY_EOS_SKIP_EXTRAP
+#ifdef SINGULARITY_EOS_SKIP_EXTRAP
   for (int i = 0; i < ntables; i++) {
-    eos_SetOption(&(tableHandle[i]),&EOS_SKIP_EXTRAP_CHECK,NULL,&errorCode);
+    eos_SetOption(&(tableHandle[i]), &EOS_SKIP_EXTRAP_CHECK, NULL, &errorCode);
   }
-  #endif
+#endif
 
   eos_LoadTables(&ntables, tableHandle, &errorCode);
-  if ( errorCode != EOS_OK && eospacWarn != Verbosity::Quiet ) {
+  if (errorCode != EOS_OK && eospacWarn != Verbosity::Quiet) {
     for (int i = 0; i < ntables; i++) {
       eos_GetErrorCode(&tableHandle[i], &tableHandleErrorCode);
       eos_GetErrorMessage(&tableHandleErrorCode, errorMessage);
-      std::cerr << "eos_CreateTables ERROR "
-                << tableHandleErrorCode;
-      if ( table_names.size() > 0 ) {
+      std::cerr << "eos_CreateTables ERROR " << tableHandleErrorCode;
+      if (table_names.size() > 0) {
         std::cerr << " for table names\n\t{";
-        for (auto & name : table_names) {
+        for (auto &name : table_names) {
           std::cerr << name << ", ";
         }
         std::cerr << "}";
       }
-      std::cerr << ":\n\t"
-                << errorMessage
-                << std::endl;
+      std::cerr << ":\n\t" << errorMessage << std::endl;
     }
   }
   return errorCode;
 }
 
-bool eosSafeInterpolate(EOS_INTEGER *table,
-                        EOS_INTEGER nxypairs,
-                        EOS_REAL xVals[],
-                        EOS_REAL yVals[],
-                        EOS_REAL var[],
-                        EOS_REAL dx[],
-                        EOS_REAL dy[],
-                        const char tablename[],
-                        Verbosity eospacWarn) {
+bool eosSafeInterpolate(EOS_INTEGER *table, EOS_INTEGER nxypairs, EOS_REAL xVals[],
+                        EOS_REAL yVals[], EOS_REAL var[], EOS_REAL dx[], EOS_REAL dy[],
+                        const char tablename[], Verbosity eospacWarn) {
   EOS_INTEGER errorCode = EOS_OK;
   EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
-  
-  eos_Interpolate(table, &nxypairs,
-                  xVals, yVals, var, dx, dy,
-                  &errorCode);
-  #ifndef SINGULARITY_EOS_SKIP_EXTRAP
-  if (errorCode != EOS_OK && eospacWarn == Verbosity::Debug) {   
+
+  eos_Interpolate(table, &nxypairs, xVals, yVals, var, dx, dy, &errorCode);
+#ifndef SINGULARITY_EOS_SKIP_EXTRAP
+  if (errorCode != EOS_OK && eospacWarn == Verbosity::Debug) {
     eos_GetErrorMessage(&errorCode, errorMessage);
     std::cerr << "Table " << tablename << ":" << std::endl;
-    std::cerr << "eos_Interpolate ERROR "
-              << errorCode
-              << ": "
-              << errorMessage
+    std::cerr << "eos_Interpolate ERROR " << errorCode << ": " << errorMessage
               << std::endl;
     std::vector<EOS_INTEGER> xyBounds(nxypairs);
-    eos_CheckExtrap(table, &nxypairs,
-                    xVals, yVals, xyBounds.data(),
-                    &errorCode);
+    eos_CheckExtrap(table, &nxypairs, xVals, yVals, xyBounds.data(), &errorCode);
     for (size_t i = 0; i < xyBounds.size(); i++) {
       std::string status = eosErrorString(xyBounds[i]);
       std::cerr << "var " << i << ": " << status << std::endl;
@@ -542,105 +447,142 @@ bool eosSafeInterpolate(EOS_INTEGER *table,
       std::cerr << "y = " << yVals[i] << std::endl;
     }
   }
-  #endif
+#endif
   return (errorCode == EOS_OK); // 1 for no erros. 0 for errors.
 }
 
-void eosSafeTableInfo(EOS_INTEGER* table,
-                      EOS_INTEGER numInfoItems,
-                      EOS_INTEGER infoItems[],
-                      EOS_REAL infoVals[],
+void eosSafeTableInfo(EOS_INTEGER *table, EOS_INTEGER numInfoItems,
+                      EOS_INTEGER infoItems[], EOS_REAL infoVals[],
                       Verbosity eospacWarn) {
   EOS_INTEGER errorCode = EOS_OK;
-  //EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
+  // EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
   EOS_INTEGER NITEMS[] = {numInfoItems};
-  eos_GetTableInfo(table,NITEMS,infoItems,infoVals,&errorCode);
+  eos_GetTableInfo(table, NITEMS, infoItems, infoVals, &errorCode);
   eosCheckError(errorCode, "eos_GetTableInfo", eospacWarn);
 }
 
-void eosSafeTableCmnts(EOS_INTEGER* table, EOS_CHAR* comments,
-                       Verbosity eospacWarn) {
+void eosSafeTableCmnts(EOS_INTEGER *table, EOS_CHAR *comments, Verbosity eospacWarn) {
   EOS_INTEGER errorCode = EOS_OK;
-  eos_GetTableCmnts(table,comments,&errorCode);
-  eosCheckError(errorCode,"eos_GetTableCmnts", eospacWarn);
+  eos_GetTableCmnts(table, comments, &errorCode);
+  eosCheckError(errorCode, "eos_GetTableCmnts", eospacWarn);
 }
 
-void eosCheckError(EOS_INTEGER errorCode,
-                   const std::string& name,
-                   Verbosity eospacWarn) {
+void eosCheckError(EOS_INTEGER errorCode, const std::string &name, Verbosity eospacWarn) {
   EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
   if (errorCode != EOS_OK && eospacWarn != Verbosity::Quiet) {
     eos_GetErrorMessage(&errorCode, errorMessage);
-    std::cerr << name << " ERROR "
-              << errorCode << ":\n\t"
-              << errorMessage
-              << std::endl;
+    std::cerr << name << " ERROR " << errorCode << ":\n\t" << errorMessage << std::endl;
   }
 }
 
 std::string eosErrorString(EOS_INTEGER errorCode) {
   // Algorithmicallly generated by parsing the EOSPAC docs
   // I'm sorry. It's gross. ~JMM
-  switch (errorCode) { 
-  case EOS_OK: return "EOS_OK";
-  case EOS_BAD_DATA_TYPE: return "EOS_BAD_DATA_TYPE";
-  case EOS_BAD_DERIVATIVE_FLAG: return "EOS_BAD_DERIVATIVE_FLAG";
-  case EOS_BAD_INTERPOLATION_FLAG: return "EOS_BAD_INTERPOLATION_FLAG";
-  case EOS_BAD_MATERIAL_ID: return "EOS_BAD_MATERIAL_ID";
-  case EOS_CANT_INVERT_DATA: return "EOS_CANT_INVERT_DATA";
-  case EOS_CANT_MAKE_MONOTONIC: return "EOS_CANT_MAKE_MONOTONIC";
-  case EOS_CONVERGENCE_FAILED: return "EOS_CONVERGENCE_FAILED";
-  case EOS_DATA_TYPE_NOT_FOUND: return "EOS_DATA_TYPE_NOT_FOUND";
-  case EOS_DATA_TYPE_NO_MATCH: return "EOS_DATA_TYPE_NO_MATCH";
-  case EOS_FAILED: return "EOS_FAILED";
-  case EOS_INTEGRATION_FAILED: return "EOS_INTEGRATION_FAILED";
-  case EOS_INTERP_EXTRAPOLATED: return "EOS_INTERP_EXTRAPOLATED";
-  case EOS_INTERP_EXTRAP_PBAL: return "EOS_INTERP_EXTRAP_PBAL";
-  case EOS_INTERP_EXTRAP_TBAL: return "EOS_INTERP_EXTRAP_TBAL";
-  case EOS_INVALID_CONC_SUM: return "EOS_INVALID_CONC_SUM";
-  case EOS_INVALID_DATA_TYPE: return "EOS_INVALID_DATA_TYPE";
-  case EOS_INVALID_INFO_FLAG: return "EOS_INVALID_INFO_FLAG";
-  case EOS_INVALID_OPTION_FLAG: return "EOS_INVALID_OPTION_FLAG";
-  case EOS_INVALID_SUBTABLE_INDEX: return "EOS_INVALID_SUBTABLE_INDEX";
-  case EOS_INVALID_TABLE_HANDLE: return "EOS_INVALID_TABLE_HANDLE";
-  case EOS_MATERIAL_NOT_FOUND: return "EOS_MATERIAL_NOT_FOUND";
-  case EOS_MEM_ALLOCATION_FAILED: return "EOS_MEM_ALLOCATION_FAILED";
-  case EOS_NOT_ALLOCATED: return "EOS_NOT_ALLOCATED";
-  case EOS_NOT_INITIALIZED: return "EOS_NOT_INITIALIZED";
-  case EOS_NO_COMMENTS: return "EOS_NO_COMMENTS";
-  case EOS_NO_DATA_TABLE: return "EOS_NO_DATA_TABLE";
-  case EOS_NO_SESAME_FILES: return "EOS_NO_SESAME_FILES";
-  case EOS_OPEN_SESAME_FILE_FAILED: return "EOS_OPEN_SESAME_FILE_FAILED";
-  case EOS_READ_DATA_FAILED: return "EOS_READ_DATA_FAILED";
-  case EOS_READ_FILE_VERSION_FAILED: return "EOS_READ_FILE_VERSION_FAILED";
-  case EOS_READ_MASTER_DIR_FAILED: return "EOS_READ_MASTER_DIR_FAILED";
-  case EOS_READ_MATERIAL_DIR_FAILED: return "EOS_READ_MATERIAL_DIR_FAILED";
-  case EOS_READ_TOTAL_MATERIALS_FAILED: return "EOS_READ_TOTAL_MATERIALS_FAILED";
-  case EOS_SPLIT_FAILED: return "EOS_SPLIT_FAILED";
-  case EOS_xHi_yHi: return "EOS_xHi_yHi";
-  case EOS_xHi_yOk: return "EOS_xHI_yOk";
-  case EOS_xHi_yLo: return "EOS_xHi_yLo";
-  case EOS_xOk_yLo: return "EOS_xOk_yLo";
-  case EOS_xLo_yLo: return "EOS_xLo_yLo";
-  case EOS_xLo_yOk: return "EOS_xLo_yOk";
-  case EOS_xLo_yHi: return "EOS_xLo_yHi";
-  case EOS_xOk_yHi: return "EOS_xOk_yHi";
-  case EOS_WARNING: return "EOS_WARNING";
-  case EOS_UNDEFINED: return "EOS_UNDEFINED";
-  default: return "UNKNOWN ERROR: " + std::to_string(errorCode);
+  switch (errorCode) {
+  case EOS_OK:
+    return "EOS_OK";
+  case EOS_BAD_DATA_TYPE:
+    return "EOS_BAD_DATA_TYPE";
+  case EOS_BAD_DERIVATIVE_FLAG:
+    return "EOS_BAD_DERIVATIVE_FLAG";
+  case EOS_BAD_INTERPOLATION_FLAG:
+    return "EOS_BAD_INTERPOLATION_FLAG";
+  case EOS_BAD_MATERIAL_ID:
+    return "EOS_BAD_MATERIAL_ID";
+  case EOS_CANT_INVERT_DATA:
+    return "EOS_CANT_INVERT_DATA";
+  case EOS_CANT_MAKE_MONOTONIC:
+    return "EOS_CANT_MAKE_MONOTONIC";
+  case EOS_CONVERGENCE_FAILED:
+    return "EOS_CONVERGENCE_FAILED";
+  case EOS_DATA_TYPE_NOT_FOUND:
+    return "EOS_DATA_TYPE_NOT_FOUND";
+  case EOS_DATA_TYPE_NO_MATCH:
+    return "EOS_DATA_TYPE_NO_MATCH";
+  case EOS_FAILED:
+    return "EOS_FAILED";
+  case EOS_INTEGRATION_FAILED:
+    return "EOS_INTEGRATION_FAILED";
+  case EOS_INTERP_EXTRAPOLATED:
+    return "EOS_INTERP_EXTRAPOLATED";
+  case EOS_INTERP_EXTRAP_PBAL:
+    return "EOS_INTERP_EXTRAP_PBAL";
+  case EOS_INTERP_EXTRAP_TBAL:
+    return "EOS_INTERP_EXTRAP_TBAL";
+  case EOS_INVALID_CONC_SUM:
+    return "EOS_INVALID_CONC_SUM";
+  case EOS_INVALID_DATA_TYPE:
+    return "EOS_INVALID_DATA_TYPE";
+  case EOS_INVALID_INFO_FLAG:
+    return "EOS_INVALID_INFO_FLAG";
+  case EOS_INVALID_OPTION_FLAG:
+    return "EOS_INVALID_OPTION_FLAG";
+  case EOS_INVALID_SUBTABLE_INDEX:
+    return "EOS_INVALID_SUBTABLE_INDEX";
+  case EOS_INVALID_TABLE_HANDLE:
+    return "EOS_INVALID_TABLE_HANDLE";
+  case EOS_MATERIAL_NOT_FOUND:
+    return "EOS_MATERIAL_NOT_FOUND";
+  case EOS_MEM_ALLOCATION_FAILED:
+    return "EOS_MEM_ALLOCATION_FAILED";
+  case EOS_NOT_ALLOCATED:
+    return "EOS_NOT_ALLOCATED";
+  case EOS_NOT_INITIALIZED:
+    return "EOS_NOT_INITIALIZED";
+  case EOS_NO_COMMENTS:
+    return "EOS_NO_COMMENTS";
+  case EOS_NO_DATA_TABLE:
+    return "EOS_NO_DATA_TABLE";
+  case EOS_NO_SESAME_FILES:
+    return "EOS_NO_SESAME_FILES";
+  case EOS_OPEN_SESAME_FILE_FAILED:
+    return "EOS_OPEN_SESAME_FILE_FAILED";
+  case EOS_READ_DATA_FAILED:
+    return "EOS_READ_DATA_FAILED";
+  case EOS_READ_FILE_VERSION_FAILED:
+    return "EOS_READ_FILE_VERSION_FAILED";
+  case EOS_READ_MASTER_DIR_FAILED:
+    return "EOS_READ_MASTER_DIR_FAILED";
+  case EOS_READ_MATERIAL_DIR_FAILED:
+    return "EOS_READ_MATERIAL_DIR_FAILED";
+  case EOS_READ_TOTAL_MATERIALS_FAILED:
+    return "EOS_READ_TOTAL_MATERIALS_FAILED";
+  case EOS_SPLIT_FAILED:
+    return "EOS_SPLIT_FAILED";
+  case EOS_xHi_yHi:
+    return "EOS_xHi_yHi";
+  case EOS_xHi_yOk:
+    return "EOS_xHI_yOk";
+  case EOS_xHi_yLo:
+    return "EOS_xHi_yLo";
+  case EOS_xOk_yLo:
+    return "EOS_xOk_yLo";
+  case EOS_xLo_yLo:
+    return "EOS_xLo_yLo";
+  case EOS_xLo_yOk:
+    return "EOS_xLo_yOk";
+  case EOS_xLo_yHi:
+    return "EOS_xLo_yHi";
+  case EOS_xOk_yHi:
+    return "EOS_xOk_yHi";
+  case EOS_WARNING:
+    return "EOS_WARNING";
+  case EOS_UNDEFINED:
+    return "EOS_UNDEFINED";
+  default:
+    return "UNKNOWN ERROR: " + std::to_string(errorCode);
   }
 }
 
-void eosSafeDestroy(int ntables, EOS_INTEGER tableHandles[],
-                    Verbosity eospacWarn) {
+void eosSafeDestroy(int ntables, EOS_INTEGER tableHandles[], Verbosity eospacWarn) {
   EOS_INTEGER errorCode = EOS_OK;
-  //EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
+  // EOS_CHAR errorMessage[EOS_MaxErrMsgLen];
   EOS_INTEGER NTABLES[] = {ntables};
   eos_DestroyTables(NTABLES, tableHandles, &errorCode);
   eosCheckError(errorCode, "eos_DestroyTables", eospacWarn);
 }
 
-void makeInterpPoints(std::vector<EOS_REAL>& v, const Bounds& b) {
+void makeInterpPoints(std::vector<EOS_REAL> &v, const Bounds &b) {
   v.resize(b.grid.nPoints());
   for (size_t i = 0; i < v.size(); i++) {
     v[i] = b.i2lin(i);
@@ -649,7 +591,7 @@ void makeInterpPoints(std::vector<EOS_REAL>& v, const Bounds& b) {
 
 std::string getName(std::string comment) {
   // required because lookbehinds not supported
-  //constexpr int startPos=15; 
+  // constexpr int startPos=15;
   std::regex r("101: material. (.*)(?=\\s+\\(z)");
   std::smatch match;
   if (std::regex_search(comment, match, r)) {

--- a/sesame2spiner/io_eospac.hpp
+++ b/sesame2spiner/io_eospac.hpp
@@ -18,9 +18,9 @@
 #define _SESAME2SPINER_IO_EOSPAC_HPP_
 
 #include <cmath>
-#include <string>
 #include <iostream>
 #include <limits>
+#include <string>
 #include <vector>
 
 #include <eos_Interface.h> // eospac API
@@ -29,28 +29,27 @@
 #error "HDF5 must be enabled"
 #endif
 
-#include <spiner/ports-of-call/portability.hpp>
+#include <fast-math/logs.hpp>
 #include <spiner/databox.hpp>
 #include <spiner/interpolation.hpp>
-#include <fast-math/logs.hpp>
+#include <spiner/ports-of-call/portability.hpp>
 
 using Spiner::DataBox;
 using Spiner::RegularGrid1D;
 
-inline Real densityToSesame(const Real CodeTemp) { return CodeTemp;}
-inline Real densityFromSesame(const Real sesTemp) { return sesTemp;}
-inline Real temperatureToSesame(const Real CodeTemp) { return CodeTemp;}
-inline Real temperatureFromSesame(const Real SesTemp) { return SesTemp;}
-inline Real pressureFromSesame(const Real SesPress) { return 1e10*SesPress;}
-inline Real pressureToSesame(const Real CodePress) { return 1e-10*CodePress;}
-inline Real sieToSesame(const Real CodeSie) { return 1e-10*CodeSie;}
-inline Real sieFromSesame(const Real SesSie) { return 1e10*SesSie;}
-inline Real cvFromSesame(const Real SesCv) { return 1e10*SesCv;}
-inline Real bulkModulusFromSesame(const Real SesBmod) { return 1e10*SesBmod;}
-inline Real getBulkModulus(const Real rho, const Real P,
-                           const Real DPDR_T, const Real DPDE_R,
-                           const Real DEDR_T) {
-  return rho*DPDR_T + DPDE_R*((P/rho) - rho*DEDR_T);
+inline Real densityToSesame(const Real CodeTemp) { return CodeTemp; }
+inline Real densityFromSesame(const Real sesTemp) { return sesTemp; }
+inline Real temperatureToSesame(const Real CodeTemp) { return CodeTemp; }
+inline Real temperatureFromSesame(const Real SesTemp) { return SesTemp; }
+inline Real pressureFromSesame(const Real SesPress) { return 1e10 * SesPress; }
+inline Real pressureToSesame(const Real CodePress) { return 1e-10 * CodePress; }
+inline Real sieToSesame(const Real CodeSie) { return 1e-10 * CodeSie; }
+inline Real sieFromSesame(const Real SesSie) { return 1e10 * SesSie; }
+inline Real cvFromSesame(const Real SesCv) { return 1e10 * SesCv; }
+inline Real bulkModulusFromSesame(const Real SesBmod) { return 1e10 * SesBmod; }
+inline Real getBulkModulus(const Real rho, const Real P, const Real DPDR_T,
+                           const Real DPDE_R, const Real DEDR_T) {
+  return rho * DPDR_T + DPDE_R * ((P / rho) - rho * DEDR_T);
 }
 
 enum class Verbosity { Quiet, Verbose, Debug };
@@ -58,28 +57,24 @@ enum class Verbosity { Quiet, Verbose, Debug };
 // For logarithmic interpolation, quantities may be negative.
 // If they are, use offset to ensure negative values make sense.
 class Bounds {
-public:
+ public:
   Bounds() {}
-  
-  Bounds(Real min, Real max, int N, Real offset)
-    : grid(RegularGrid1D(min,max,N))
-    , offset(offset)
-  {}
 
-  Bounds(Real min, Real max, int N,
-         bool convertToLog = false,
-         Real shrinkRange = 0,
+  Bounds(Real min, Real max, int N, Real offset)
+      : grid(RegularGrid1D(min, max, N)), offset(offset) {}
+
+  Bounds(Real min, Real max, int N, bool convertToLog = false, Real shrinkRange = 0,
          Real anchor_point = std::numeric_limits<Real>::signaling_NaN())
-    : offset(0) {    
+      : offset(0) {
     if (convertToLog) {
       // Log scales can't handle negative numbers or exactly zero. To
       // deal with that, we offset.
       constexpr Real epsilon = std::numeric_limits<float>::epsilon();
-      const Real min_offset = 10*std::abs(epsilon);
+      const Real min_offset = 10 * std::abs(epsilon);
       // 1.1 so that the y-intercept isn't identically zero
       // when min < 0.
       // min_offset to handle the case where min=0
-      if (min <= 0) offset = 1.1*std::abs(min) + min_offset;
+      if (min <= 0) offset = 1.1 * std::abs(min) + min_offset;
 
       min += offset;
       max += offset;
@@ -87,9 +82,9 @@ public:
       min = std::log10(std::abs(min));
       max = std::log10(std::abs(max));
       Real delta = max - min;
-      min += 0.5*shrinkRange*delta;
-      max -= 0.5*shrinkRange*delta;
-      
+      min += 0.5 * shrinkRange * delta;
+      max -= 0.5 * shrinkRange * delta;
+
       if (!(std::isnan(anchor_point))) {
         anchor_point += offset;
         anchor_point = std::log10(std::abs(anchor_point));
@@ -98,26 +93,22 @@ public:
 
     if (!(std::isnan(anchor_point))) {
       if (min < anchor_point && anchor_point < max) {
-        Real dxguess = (max-min)/((Real)N-1);
-        int Nmax = static_cast<int>((max - min)/dxguess);
-        int Nanchor = static_cast<int>((anchor_point - min)/dxguess);
-        Real dx = (anchor_point - min)/static_cast<Real>(Nanchor+1);
-        max = dx*(Nmax) + min;
+        Real dxguess = (max - min) / ((Real)N - 1);
+        int Nmax = static_cast<int>((max - min) / dxguess);
+        int Nanchor = static_cast<int>((anchor_point - min) / dxguess);
+        Real dx = (anchor_point - min) / static_cast<Real>(Nanchor + 1);
+        max = dx * (Nmax) + min;
         N += 1;
       }
     }
-    
-    grid = RegularGrid1D(min,max,N);
+
+    grid = RegularGrid1D(min, max, N);
   }
 
-  inline Real log2lin(Real xl) const {
-    return pow(10.,xl) - offset;
-  }
-  inline Real i2lin(int i) const {
-    return log2lin(grid.x(i));
-  }
+  inline Real log2lin(Real xl) const { return pow(10., xl) - offset; }
+  inline Real i2lin(int i) const { return log2lin(grid.x(i)); }
 
-  friend std::ostream& operator<< (std::ostream& os, const Bounds& b) {
+  friend std::ostream &operator<<(std::ostream &os, const Bounds &b) {
     os << "Bounds: [" << b.grid.min() << ", " << b.grid.max() << "]"
        << " + " << b.offset << ", "
        << "[N,dx] = [" << b.grid.nPoints() << ", " << b.grid.dx() << "]"
@@ -125,13 +116,13 @@ public:
     return os;
   }
 
-public:
+ public:
   RegularGrid1D grid;
   Real offset;
 };
 
 class SesameMetadata {
-public:
+ public:
   int matid;
   Real exchangeCoefficient;
   Real meanAtomicMass;
@@ -147,117 +138,73 @@ public:
   int numRho, numT;
   std::string comments;
   std::string name;
-  friend std::ostream& operator<< (std::ostream& os, const SesameMetadata& m) {
-    os << "MATID: "  << m.matid << "\n"
+  friend std::ostream &operator<<(std::ostream &os, const SesameMetadata &m) {
+    os << "MATID: " << m.matid << "\n"
        << "\tname: " << m.name << "\n"
        << "\texchange coefficient  = " << m.exchangeCoefficient << "\n"
-       << "\tmean atomic mass      = " << m.meanAtomicMass      << "\n"
-       << "\tsolid bulk modulus    = " << m.solidBulkModulus    << "\n"
-       << "\tnormal density        = " << m.normalDensity       << "\n"
+       << "\tmean atomic mass      = " << m.meanAtomicMass << "\n"
+       << "\tsolid bulk modulus    = " << m.solidBulkModulus << "\n"
+       << "\tnormal density        = " << m.normalDensity << "\n"
        << "\t[rho min, rho max]    = "
-       << "[" << m.rhoMin << ", " << m.rhoMax << "]" << "\n"
+       << "[" << m.rhoMin << ", " << m.rhoMax << "]"
+       << "\n"
        << "\t[T min, T max]        = "
-       << "[" << m.TMin << ", " << m.TMax << "]" << "\n"
+       << "[" << m.TMin << ", " << m.TMax << "]"
+       << "\n"
        << "\t[sie min, sie max]    = "
-       << "[" << m.sieMin << ", " << m.sieMax << "]" << "\n"
-       << "\tnum rho               = " << m.numRho  << "\n"
-       << "\tnum T                 = " << m.numT    << "\n"
+       << "[" << m.sieMin << ", " << m.sieMax << "]"
+       << "\n"
+       << "\tnum rho               = " << m.numRho << "\n"
+       << "\tnum T                 = " << m.numT << "\n"
        << "\tComments:\n"
        << m.comments << "\n";
     return os;
   }
 };
 
-void eosGetMetadata(int matid, SesameMetadata& metadata,
+void eosGetMetadata(int matid, SesameMetadata &metadata,
                     Verbosity eospacWarn = Verbosity::Quiet);
 
-void eosDataOfRhoSie(int matid,
-                     const Bounds& lRhoBounds,
-                     const Bounds& leBounds,
-                     DataBox& P,
-                     DataBox& T,
-                     DataBox& bMods,
-                     DataBox& dPdRho,
-                     DataBox& dPdE,
-                     DataBox& dTdRho,
-                     DataBox& dTdE,
-                     DataBox& dEdRho,
-                     DataBox& mask,
-                     Verbosity eospacWarn = Verbosity::Quiet
-                     );
+void eosDataOfRhoSie(int matid, const Bounds &lRhoBounds, const Bounds &leBounds,
+                     DataBox &P, DataBox &T, DataBox &bMods, DataBox &dPdRho,
+                     DataBox &dPdE, DataBox &dTdRho, DataBox &dTdE, DataBox &dEdRho,
+                     DataBox &mask, Verbosity eospacWarn = Verbosity::Quiet);
 
-void eosDataOfRhoT(int matid,
-                   const Bounds& lRhoBounds,
-                   const Bounds& lTBounds,
-                   DataBox& Ps,
-                   DataBox& sies,
-                   DataBox& bMods,
-                   DataBox& dPdRho,
-                   DataBox& dPdE,
-                   DataBox& dTdRho,
-                   DataBox& dTdE,
-                   DataBox& dEdRho,
-                   DataBox& dEdT,
-                   DataBox& mask,
-                   Verbosity eospacWarn = Verbosity::Quiet
-                   );
+void eosDataOfRhoT(int matid, const Bounds &lRhoBounds, const Bounds &lTBounds,
+                   DataBox &Ps, DataBox &sies, DataBox &bMods, DataBox &dPdRho,
+                   DataBox &dPdE, DataBox &dTdRho, DataBox &dTdE, DataBox &dEdRho,
+                   DataBox &dEdT, DataBox &mask, Verbosity eospacWarn = Verbosity::Quiet);
 
-void eosColdCurves(int matid,
-                   const Bounds& lRhoBounds,
-                   DataBox& Ps,
-                   DataBox& sies,
-                   DataBox& dPdRho,
-                   DataBox& dEdRho,
-                   DataBox& bMod,
-                   DataBox& mask,
-                   Verbosity eospacWarn = Verbosity::Quiet
-                   );
+void eosColdCurves(int matid, const Bounds &lRhoBounds, DataBox &Ps, DataBox &sies,
+                   DataBox &dPdRho, DataBox &dEdRho, DataBox &bMod, DataBox &mask,
+                   Verbosity eospacWarn = Verbosity::Quiet);
 
-void eosColdCurveMask(int matid,
-                      const Bounds& lRhoBounds,
-                      const int numSie,
-                      const DataBox& sieColdCurve,
-                      DataBox& mask,
-                      Verbosity eospacWarn = Verbosity::Quiet
-                      );
+void eosColdCurveMask(int matid, const Bounds &lRhoBounds, const int numSie,
+                      const DataBox &sieColdCurve, DataBox &mask,
+                      Verbosity eospacWarn = Verbosity::Quiet);
 
-EOS_INTEGER eosSafeLoad(int ntables, int matid,
-                        EOS_INTEGER tableType[],
+EOS_INTEGER eosSafeLoad(int ntables, int matid, EOS_INTEGER tableType[],
+                        EOS_INTEGER tableHandle[], Verbosity eospacWarn);
+EOS_INTEGER eosSafeLoad(int ntables, int matid, EOS_INTEGER tableType[],
                         EOS_INTEGER tableHandle[],
-                        Verbosity eospacWarn);
-EOS_INTEGER eosSafeLoad(int ntables, int matid,
-                        EOS_INTEGER tableType[],
-                        EOS_INTEGER tableHandle[],
-                        const std::vector<std::string>& table_names,
+                        const std::vector<std::string> &table_names,
                         Verbosity eospacWarn);
 
 // output is boolean mask. 1 for no errors. 0 for errors.
-bool eosSafeInterpolate(EOS_INTEGER *table,
-			EOS_INTEGER nxypairs,
-			EOS_REAL xVals[],
-			EOS_REAL yVals[],
-			EOS_REAL var[],
-			EOS_REAL dx[],
-			EOS_REAL dy[],
-			const char tablename[],
-			Verbosity eospacWarn);
+bool eosSafeInterpolate(EOS_INTEGER *table, EOS_INTEGER nxypairs, EOS_REAL xVals[],
+                        EOS_REAL yVals[], EOS_REAL var[], EOS_REAL dx[], EOS_REAL dy[],
+                        const char tablename[], Verbosity eospacWarn);
 
-void eosSafeTableInfo(EOS_INTEGER* table,
-                      EOS_INTEGER numInfoItems,
-                      EOS_INTEGER infoItems[],
-                      EOS_REAL infoVals[],
-                      Verbosity eospacWarn);
+void eosSafeTableInfo(EOS_INTEGER *table, EOS_INTEGER numInfoItems,
+                      EOS_INTEGER infoItems[], EOS_REAL infoVals[], Verbosity eospacWarn);
 
-void eosSafeTableCmnts(EOS_INTEGER* table, EOS_CHAR* comments,
-                       Verbosity eospacWarn);
+void eosSafeTableCmnts(EOS_INTEGER *table, EOS_CHAR *comments, Verbosity eospacWarn);
 
-void eosCheckError(EOS_INTEGER errorCode, const std::string& name,
-                   Verbosity eospacWarn);
+void eosCheckError(EOS_INTEGER errorCode, const std::string &name, Verbosity eospacWarn);
 std::string eosErrorString(EOS_INTEGER errorCode);
-void eosSafeDestroy(int ntables, EOS_INTEGER tableHandles[],
-                    Verbosity eospacWarn);
+void eosSafeDestroy(int ntables, EOS_INTEGER tableHandles[], Verbosity eospacWarn);
 
-void makeInterpPoints(std::vector<EOS_REAL>& v, const Bounds& b);
+void makeInterpPoints(std::vector<EOS_REAL> &v, const Bounds &b);
 std::string getName(std::string comment);
 
 #endif // _SESAME2SPINER_IO_EOSPAC_HPP_

--- a/sesame2spiner/main.cpp
+++ b/sesame2spiner/main.cpp
@@ -14,12 +14,12 @@
 // publicly and display publicly, and to permit others to do so.
 //======================================================================
 
-#include <iostream>
-#include <string>
-#include <sstream>
-#include <cstring>
-#include <cstdlib>
 #include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <string>
 #include <vector>
 
 #include <hdf5.h>
@@ -33,11 +33,11 @@
 #include <spiner/ports-of-call/portability.hpp>
 #include <spiner/sp5.hpp>
 
-#include "io_eospac.hpp"
 #include "generate_files.hpp"
+#include "io_eospac.hpp"
 #include "parse_cli.hpp"
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
   std::vector<std::string> filenames;
   std::string savename, helpMessage;
   Verbosity eospacWarn = Verbosity::Quiet;
@@ -47,10 +47,10 @@ int main(int argc, char* argv[]) {
   parseCLI(argc, argv, savename, filenames, printMetadata, eospacWarn, helpMessage);
 
   std::cout << "sesame2spiner                            \n"
-	    << "-----------------------------------------\n"
-    	    << "Author: Jonah Miller (jonahm@lanl.gov)   \n"
-	    << "-----------------------------------------\n"
-	    << std::endl;
+            << "-----------------------------------------\n"
+            << "Author: Jonah Miller (jonahm@lanl.gov)   \n"
+            << "-----------------------------------------\n"
+            << std::endl;
 
   status = saveAllMaterials(savename, filenames, printMetadata, eospacWarn);
 

--- a/sesame2spiner/parse_cli.cpp
+++ b/sesame2spiner/parse_cli.cpp
@@ -14,42 +14,39 @@
 // publicly and display publicly, and to permit others to do so.
 //======================================================================
 
-#include <string>
-#include <sstream>
-#include <cstring>
-#include <iostream>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
 #include <vector>
 
-#include "parse_cli.hpp"
 #include "io_eospac.hpp"
+#include "parse_cli.hpp"
 
-void parseCLI(int argc, char* argv[],
-	      std::string& savename,
-	      std::vector<std::string>& filenames,
-	      bool& printMetadata,
-	      Verbosity& eospacWarn,
-	      std::string& helpMessage) {
+void parseCLI(int argc, char *argv[], std::string &savename,
+              std::vector<std::string> &filenames, bool &printMetadata,
+              Verbosity &eospacWarn, std::string &helpMessage) {
 
   filenames.clear();
 
   std::stringstream helpStream;
-  helpStream << "Usage: " << argv[0] << "[-p] [-w] [-h] [-v] [-vv] [-d] <savename> <parameter files>\n\n"
-	     << "\t <savename>: filename to save to\n"
-	     << "\t <parameter files>: input files, one per material\n"
-	     << "\t-p:  print metadata associated with materials "
-	     << "in parameter files\n"
-	     << "\t-v:  print eospac warnings\n"
-	     << "\t-vv: print debug information\n"
-	     << "\t-w:  same as -v\n"
-	     << "\t-d:  same as -vv\n"
-	     << "\t-h:  print this message\n"
-	     << "\n"
-	     << "Several example input files:\n"
-	     << EXAMPLESTRING
-	     << "\n"
-	     << std::endl;
+  helpStream << "Usage: " << argv[0]
+             << "[-p] [-w] [-h] [-v] [-vv] [-d] <savename> <parameter files>\n\n"
+             << "\t <savename>: filename to save to\n"
+             << "\t <parameter files>: input files, one per material\n"
+             << "\t-p:  print metadata associated with materials "
+             << "in parameter files\n"
+             << "\t-v:  print eospac warnings\n"
+             << "\t-vv: print debug information\n"
+             << "\t-w:  same as -v\n"
+             << "\t-d:  same as -vv\n"
+             << "\t-h:  print this message\n"
+             << "\n"
+             << "Several example input files:\n"
+             << EXAMPLESTRING << "\n"
+             << std::endl;
   helpMessage = helpStream.str();
 
   bool savename_set = false;
@@ -58,31 +55,28 @@ void parseCLI(int argc, char* argv[],
     std::cerr << helpMessage << std::endl;
     std::exit(1);
   }
-  if ( argc == 2 && std::strcmp(argv[1],"-h") == 0 ) {
+  if (argc == 2 && std::strcmp(argv[1], "-h") == 0) {
     std::cout << helpMessage << std::endl;
     std::exit(0);
   }
   for (int i = 1; i < argc; i++) {
-    if ( std::strcmp(argv[i],"-h") == 0 ) {
+    if (std::strcmp(argv[i], "-h") == 0) {
       std::cout << helpMessage << std::endl;
       std::exit(0);
-    }
-    else if ( std::strcmp(argv[i],"-p") == 0 ) {
+    } else if (std::strcmp(argv[i], "-p") == 0) {
       printMetadata = true;
-    } else if ( (std::strcmp(argv[i],"-w") == 0 ||
-                 std::strcmp(argv[i],"-v") == 0 )
-                && eospacWarn == Verbosity::Quiet) {
+    } else if ((std::strcmp(argv[i], "-w") == 0 || std::strcmp(argv[i], "-v") == 0) &&
+               eospacWarn == Verbosity::Quiet) {
       eospacWarn = Verbosity::Verbose;
-    } else if ( (std::strcmp(argv[i],"-d") == 0 ||
-                 std::strcmp(argv[i],"-vv") == 0 )
-                && eospacWarn != Verbosity::Debug) {
+    } else if ((std::strcmp(argv[i], "-d") == 0 || std::strcmp(argv[i], "-vv") == 0) &&
+               eospacWarn != Verbosity::Debug) {
       eospacWarn = Verbosity::Debug;
     } else {
       if (!savename_set) {
-	savename = argv[i];
-	savename_set = true;
+        savename = argv[i];
+        savename_set = true;
       } else {
-	filenames.push_back(std::string(argv[i]));
+        filenames.push_back(std::string(argv[i]));
       }
     }
   }

--- a/sesame2spiner/parse_cli.hpp
+++ b/sesame2spiner/parse_cli.hpp
@@ -17,9 +17,9 @@
 #ifndef _SESAME2SPINER_PARSER_HPP_
 #define _SESAME2SPINER_PARSER_HPP_
 
+#include "io_eospac.hpp"
 #include <string>
 #include <vector>
-#include "io_eospac.hpp"
 
 const std::string EXAMPLESTRING = R"(
 # air.dat
@@ -63,11 +63,8 @@ shrinklTBounds = 0.15
 shrinkleBounds = 0.5
 )";
 
-void parseCLI(int argc, char* argv[],
-	      std::string& savename,
-	      std::vector<std::string>& filenames,
-	      bool& printMetadata,
-	      Verbosity& eospacWarn,
-	      std::string& helpMessage);
+void parseCLI(int argc, char *argv[], std::string &savename,
+              std::vector<std::string> &filenames, bool &printMetadata,
+              Verbosity &eospacWarn, std::string &helpMessage);
 
 #endif // _SESAME2SPINER_PARSER_HPP_

--- a/sesame2spiner/parser.cpp
+++ b/sesame2spiner/parser.cpp
@@ -35,8 +35,7 @@ void Params::Parse(std::istream &s) {
   std::string line;
   while (getline(s, line)) {
     line.erase(std::remove_if(line.begin(), line.end(), isspace), line.end());
-    if (line[0] == '#' || line.empty())
-      continue;
+    if (line[0] == '#' || line.empty()) continue;
     auto delimiter_pos = line.find("=");
     auto name = line.substr(0, delimiter_pos);
     auto value = line.substr(delimiter_pos + 1);
@@ -44,23 +43,28 @@ void Params::Parse(std::istream &s) {
   }
 }
 
-template <> std::string Params::Get(const std::string &key) const {
+template <>
+std::string Params::Get(const std::string &key) const {
   return params_.at(key);
 }
 
-template <> int Params::Get(const std::string &key) const {
+template <>
+int Params::Get(const std::string &key) const {
   return std::stoi(params_.at(key));
 }
 
-template <> double Params::Get(const std::string &key) const {
+template <>
+double Params::Get(const std::string &key) const {
   return std::stod(params_.at(key));
 }
 
-template <> float Params::Get(const std::string &key) const {
+template <>
+float Params::Get(const std::string &key) const {
   return std::stof(params_.at(key));
 }
 
-template <> bool Params::Get(const std::string &key) const {
+template <>
+bool Params::Get(const std::string &key) const {
   std::string val = params_.at(key);
   if ((val == "true") || (val == "1")) {
     return true;

--- a/sesame2spiner/parser.hpp
+++ b/sesame2spiner/parser.hpp
@@ -23,17 +23,19 @@
 // Parse a simple parameter file with
 // "#" denoting comments.
 class Params {
-public:
+ public:
   Params(const std::string &input_file);
   Params(std::stringstream &input) { Parse(input); }
 
   bool Contains(const std::string &key) const { return params_.count(key); }
-  template <typename T> T Get(const std::string &key) const;
-  template <typename T> T Get(const std::string &key, T default_value) const {
+  template <typename T>
+  T Get(const std::string &key) const;
+  template <typename T>
+  T Get(const std::string &key, T default_value) const {
     return Contains(key) ? Get<T>(key) : default_value;
   }
 
-private:
+ private:
   void Parse(std::istream &s);
   std::unordered_map<std::string, std::string> params_;
 };

--- a/sesame2spiner/test.cpp
+++ b/sesame2spiner/test.cpp
@@ -15,8 +15,8 @@
 //======================================================================
 
 #include <cmath>
-#include <string>
 #include <iostream>
+#include <string>
 
 #include <hdf5.h>
 #include <hdf5_hl.h>
@@ -29,56 +29,52 @@
 #endif
 
 #include <sp5/singularity_eos_sp5.hpp>
-#include <spiner/spiner_types.hpp>
-#include <spiner/ports-of-call/portability.hpp>
 #include <spiner/databox.hpp>
 #include <spiner/interpolation.hpp>
+#include <spiner/ports-of-call/portability.hpp>
 #include <spiner/sp5.hpp>
+#include <spiner/spiner_types.hpp>
 
-#include "io_eospac.hpp"
 #include "generate_files.hpp"
+#include "io_eospac.hpp"
 #include "parser.hpp"
 
 using Spiner::DataBox;
 using Spiner::RegularGrid1D;
 
-constexpr int matid  = 5030; // dry air
+constexpr int matid = 5030;  // dry air
 constexpr int matid2 = 4272; // stainless steel
 constexpr int NRHO = 64;
 constexpr int NUMT = 32;
 constexpr int NUME = NUMT;
 constexpr Real EPS = 1e-5;
 
-inline bool isClose(Real a, Real b) {
-  return fabs((b - a)/(a+b+1e-20)) <= EPS;
-}
+inline bool isClose(Real a, Real b) { return fabs((b - a) / (a + b + 1e-20)) <= EPS; }
 
-SCENARIO( "Reading metadata for air through eospac",
-	  "[eospac],[eosGetMetadata]" ) {
+SCENARIO("Reading metadata for air through eospac", "[eospac],[eosGetMetadata]") {
   SesameMetadata m;
 
-  GIVEN( "Metadata is read in via eospac" ) {
+  GIVEN("Metadata is read in via eospac") {
     eosGetMetadata(matid, m, Verbosity::Verbose);
-    THEN( "Known quantities are as expected" ) {
-      REQUIRE( isClose(m.exchangeCoefficient, 0.0) );
-      REQUIRE( isClose(m.meanAtomicMass, 1.480303959999998e1) );
-      REQUIRE( isClose(m.meanAtomicNumber, 7.372955340000004) );
-      REQUIRE( isClose(m.normalDensity, 1.293000000000002e-3) );
-      REQUIRE( isClose(m.rhoMin, 1e-7) );
-      REQUIRE( isClose(m.rhoMax, 15) );
-      REQUIRE( isClose(m.TMin, 175.235) );
-      REQUIRE( isClose(m.TMax, 3.4815e8) );
-      REQUIRE( isClose(m.sieMin, 8.402e8)  );
-      REQUIRE( isClose(m.sieMax, 2.484e16) );
-      REQUIRE( m.numRho == 21 );
-      REQUIRE( m.numT == 31 );
-      REQUIRE( m.name == "dry air" );
+    THEN("Known quantities are as expected") {
+      REQUIRE(isClose(m.exchangeCoefficient, 0.0));
+      REQUIRE(isClose(m.meanAtomicMass, 1.480303959999998e1));
+      REQUIRE(isClose(m.meanAtomicNumber, 7.372955340000004));
+      REQUIRE(isClose(m.normalDensity, 1.293000000000002e-3));
+      REQUIRE(isClose(m.rhoMin, 1e-7));
+      REQUIRE(isClose(m.rhoMax, 15));
+      REQUIRE(isClose(m.TMin, 175.235));
+      REQUIRE(isClose(m.TMax, 3.4815e8));
+      REQUIRE(isClose(m.sieMin, 8.402e8));
+      REQUIRE(isClose(m.sieMax, 2.484e16));
+      REQUIRE(m.numRho == 21);
+      REQUIRE(m.numT == 31);
+      REQUIRE(m.name == "dry air");
     }
   }
 }
 
-SCENARIO( "Reading air data for indep. variables rho, sie",
-	  "[eospac],[eosDataOfRhoSie]" ) {
+SCENARIO("Reading air data for indep. variables rho, sie", "[eospac],[eosDataOfRhoSie]") {
 
   DataBox P, T, bMods, dPdRho, dPde, dTdRho, dTde, dEdRho;
   DataBox mask;
@@ -86,179 +82,164 @@ SCENARIO( "Reading air data for indep. variables rho, sie",
   // TODO: these bounds are totally arbitrary
   //       BUT they are experimentally verified to be
   //       on the SESAME tables.
-  Bounds lRhoBounds(-2,1,NRHO); 
-  Bounds leBounds(12,16,NUME);    
+  Bounds lRhoBounds(-2, 1, NRHO);
+  Bounds leBounds(12, 16, NUME);
 
-  GIVEN( "DataBoxes are filled by eospac" ) {
-    eosDataOfRhoSie(matid,
-		    lRhoBounds, leBounds,
-		    P, T, bMods,
-		    dPdRho, dPde,
-		    dTdRho, dTde,
-		    dEdRho,
-		    mask,
-		    Verbosity::Verbose);
-    THEN( "The shapes are correct" ) {
-      REQUIRE( P.dim(1)      == NUME   );
-      REQUIRE( P.dim(2)      == NRHO );
-      REQUIRE( T.dim(1)      == NUME   );
-      REQUIRE( T.dim(2)      == NRHO );
-      REQUIRE( bMods.dim(1)  == NUME   );
-      REQUIRE( bMods.dim(2)  == NRHO );
-      REQUIRE( dPdRho.dim(1) == NUME   );
-      REQUIRE( dPdRho.dim(2) == NRHO );
-      REQUIRE( dPde.dim(1)   == NUME   );
-      REQUIRE( dPde.dim(2)   == NRHO );
-      REQUIRE( dTdRho.dim(1) == NUME   );
-      REQUIRE( dTdRho.dim(2) == NRHO );
-      REQUIRE( dTde.dim(1)   == NUME   );
-      REQUIRE( dTde.dim(2)   == NRHO );
+  GIVEN("DataBoxes are filled by eospac") {
+    eosDataOfRhoSie(matid, lRhoBounds, leBounds, P, T, bMods, dPdRho, dPde, dTdRho, dTde,
+                    dEdRho, mask, Verbosity::Verbose);
+    THEN("The shapes are correct") {
+      REQUIRE(P.dim(1) == NUME);
+      REQUIRE(P.dim(2) == NRHO);
+      REQUIRE(T.dim(1) == NUME);
+      REQUIRE(T.dim(2) == NRHO);
+      REQUIRE(bMods.dim(1) == NUME);
+      REQUIRE(bMods.dim(2) == NRHO);
+      REQUIRE(dPdRho.dim(1) == NUME);
+      REQUIRE(dPdRho.dim(2) == NRHO);
+      REQUIRE(dPde.dim(1) == NUME);
+      REQUIRE(dPde.dim(2) == NRHO);
+      REQUIRE(dTdRho.dim(1) == NUME);
+      REQUIRE(dTdRho.dim(2) == NRHO);
+      REQUIRE(dTde.dim(1) == NUME);
+      REQUIRE(dTde.dim(2) == NRHO);
 
-      AND_THEN( "The tables contain all finite values" ) {
-	bool nansPresent = false;
-	for (int j = 0; j < NRHO; j++) {
-	  for (int i = 0; i < NUME; i++) {
-	    nansPresent |= std::isnan(P(j,i));
-	    nansPresent |= std::isnan(T(j,i));
-	    nansPresent |= std::isnan(bMods(j,i));
-	    nansPresent |= std::isnan(dPdRho(j,i));
-	    nansPresent |= std::isnan(dPdRho(j,i));
-	    nansPresent |= std::isnan(dPde(j,i));
-	    nansPresent |= std::isnan(dTdRho(j,i));
-	    nansPresent |= std::isnan(dTde(j,i));
-	  }
-	}
-	REQUIRE( !nansPresent );
+      AND_THEN("The tables contain all finite values") {
+        bool nansPresent = false;
+        for (int j = 0; j < NRHO; j++) {
+          for (int i = 0; i < NUME; i++) {
+            nansPresent |= std::isnan(P(j, i));
+            nansPresent |= std::isnan(T(j, i));
+            nansPresent |= std::isnan(bMods(j, i));
+            nansPresent |= std::isnan(dPdRho(j, i));
+            nansPresent |= std::isnan(dPdRho(j, i));
+            nansPresent |= std::isnan(dPde(j, i));
+            nansPresent |= std::isnan(dTdRho(j, i));
+            nansPresent |= std::isnan(dTde(j, i));
+          }
+        }
+        REQUIRE(!nansPresent);
       }
     }
   }
 }
 
-SCENARIO( "Reading air data for indep. variables rho, T",
-	  "[eospac],[eosDataOfRhoT]" ) {
+SCENARIO("Reading air data for indep. variables rho, T", "[eospac],[eosDataOfRhoT]") {
 
   DataBox P, sie, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho, dEdT, mask;
-  Bounds lRhoBounds(-4,1,NRHO);
-  Bounds lTBounds(2.4,4,NUMT);
+  Bounds lRhoBounds(-4, 1, NRHO);
+  Bounds lTBounds(2.4, 4, NUMT);
 
-  GIVEN( "DataBoxes are filled by eospac" ) {
-    eosDataOfRhoT(matid, lRhoBounds, lTBounds,
-		  P,sie,bMod,dPdRho,dPdE,dTdRho,dTdE,dEdRho,dEdT,
-		  mask,
-		  Verbosity::Verbose);
-    THEN( "The shapes are correct" ) {
-      REQUIRE( P.dim(1) == NUMT   );
-      REQUIRE( P.dim(2) == NRHO );
-      AND_THEN( "The tables contain all finite values" ) {
-	bool nansPresent = false;
-	for (int j = 0; j < NRHO; j++) {
-	  for (int i = 0; i < NUMT; i++) {
-	    nansPresent |= std::isnan(P(j,i));
-	    nansPresent |= std::isnan(sie(j,i));
-	    nansPresent |= std::isnan(bMod(j,i));
-	    nansPresent |= std::isnan(dPdRho(j,i));
-	    nansPresent |= std::isnan(dPdRho(j,i));
-	    nansPresent |= std::isnan(dPdE(j,i));
-	    nansPresent |= std::isnan(dTdRho(j,i));
-	    nansPresent |= std::isnan(dTdE(j,i));
-	  }
-	}
-	REQUIRE( !nansPresent );
+  GIVEN("DataBoxes are filled by eospac") {
+    eosDataOfRhoT(matid, lRhoBounds, lTBounds, P, sie, bMod, dPdRho, dPdE, dTdRho, dTdE,
+                  dEdRho, dEdT, mask, Verbosity::Verbose);
+    THEN("The shapes are correct") {
+      REQUIRE(P.dim(1) == NUMT);
+      REQUIRE(P.dim(2) == NRHO);
+      AND_THEN("The tables contain all finite values") {
+        bool nansPresent = false;
+        for (int j = 0; j < NRHO; j++) {
+          for (int i = 0; i < NUMT; i++) {
+            nansPresent |= std::isnan(P(j, i));
+            nansPresent |= std::isnan(sie(j, i));
+            nansPresent |= std::isnan(bMod(j, i));
+            nansPresent |= std::isnan(dPdRho(j, i));
+            nansPresent |= std::isnan(dPdRho(j, i));
+            nansPresent |= std::isnan(dPdE(j, i));
+            nansPresent |= std::isnan(dTdRho(j, i));
+            nansPresent |= std::isnan(dTdE(j, i));
+          }
+        }
+        REQUIRE(!nansPresent);
       }
     }
   }
 }
 
-SCENARIO( "Reading air data for all indep. variables one after the other",
-	  "[eospac],[eosDataOfRhoT],[eosDataOfRhoSie]" ) {
+SCENARIO("Reading air data for all indep. variables one after the other",
+         "[eospac],[eosDataOfRhoT],[eosDataOfRhoSie]") {
   DataBox P, T, sie, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho, dEdT, mask;
-  Bounds lRhoBounds(-2,1,NRHO); 
-  Bounds lTBounds(2.4,4,NUMT);
-  Bounds leBounds(12,16,NUME);
-  GIVEN ( "Databoxes filled for log rho and log T" ) {
-    eosDataOfRhoT(matid, lRhoBounds, lTBounds,
-		  P, sie, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho,dEdT,
-		  mask,
-		  Verbosity::Verbose);
-    THEN( "The shapes are correct") {
-      REQUIRE( P.dim(1) == NUMT      );
-      REQUIRE( P.dim(2) == NRHO      );
-      REQUIRE( sie.dim(1) == NUMT    );
-      REQUIRE( sie.dim(2) == NRHO    );
-      REQUIRE( bMod.dim(1) == NUMT   );
-      REQUIRE( bMod.dim(2) == NRHO   );
-      REQUIRE( dPdRho.dim(1) == NUMT );
-      REQUIRE( dPdRho.dim(2) == NRHO );
-      REQUIRE( dPdE.dim(1) == NUMT   );
-      REQUIRE( dPdE.dim(2) == NRHO   );
-      REQUIRE( dTdRho.dim(1) == NUMT );
-      REQUIRE( dTdRho.dim(2) == NRHO );
-      REQUIRE( dTdE.dim(1) == NUMT   );
-      REQUIRE( dTdE.dim(2) == NRHO   );
+  Bounds lRhoBounds(-2, 1, NRHO);
+  Bounds lTBounds(2.4, 4, NUMT);
+  Bounds leBounds(12, 16, NUME);
+  GIVEN("Databoxes filled for log rho and log T") {
+    eosDataOfRhoT(matid, lRhoBounds, lTBounds, P, sie, bMod, dPdRho, dPdE, dTdRho, dTdE,
+                  dEdRho, dEdT, mask, Verbosity::Verbose);
+    THEN("The shapes are correct") {
+      REQUIRE(P.dim(1) == NUMT);
+      REQUIRE(P.dim(2) == NRHO);
+      REQUIRE(sie.dim(1) == NUMT);
+      REQUIRE(sie.dim(2) == NRHO);
+      REQUIRE(bMod.dim(1) == NUMT);
+      REQUIRE(bMod.dim(2) == NRHO);
+      REQUIRE(dPdRho.dim(1) == NUMT);
+      REQUIRE(dPdRho.dim(2) == NRHO);
+      REQUIRE(dPdE.dim(1) == NUMT);
+      REQUIRE(dPdE.dim(2) == NRHO);
+      REQUIRE(dTdRho.dim(1) == NUMT);
+      REQUIRE(dTdRho.dim(2) == NRHO);
+      REQUIRE(dTdE.dim(1) == NUMT);
+      REQUIRE(dTdE.dim(2) == NRHO);
 
-      AND_THEN( "The tables contain all finite values") {
-	bool nansPresent = false;
-	for (int j = 0; j < NRHO; j++) {
-	  for (int i = 0; i < NUMT; i++) {
-	    nansPresent |= std::isnan(P(j,i));
-	    nansPresent |= std::isnan(sie(j,i));
-	    nansPresent |= std::isnan(bMod(j,i));
-	    nansPresent |= std::isnan(dPdRho(j,i));
-	    nansPresent |= std::isnan(dPdRho(j,i));
-	    nansPresent |= std::isnan(dPdE(j,i));
-	    nansPresent |= std::isnan(dTdRho(j,i));
-	    nansPresent |= std::isnan(dTdE(j,i));
-	  }
-	}
-	REQUIRE( !nansPresent );
+      AND_THEN("The tables contain all finite values") {
+        bool nansPresent = false;
+        for (int j = 0; j < NRHO; j++) {
+          for (int i = 0; i < NUMT; i++) {
+            nansPresent |= std::isnan(P(j, i));
+            nansPresent |= std::isnan(sie(j, i));
+            nansPresent |= std::isnan(bMod(j, i));
+            nansPresent |= std::isnan(dPdRho(j, i));
+            nansPresent |= std::isnan(dPdRho(j, i));
+            nansPresent |= std::isnan(dPdE(j, i));
+            nansPresent |= std::isnan(dTdRho(j, i));
+            nansPresent |= std::isnan(dTdE(j, i));
+          }
+        }
+        REQUIRE(!nansPresent);
 
-	GIVEN( "Databoxes filled for log rho and log sie" ) {
-	  eosDataOfRhoSie(matid,
-			  lRhoBounds, leBounds,
-			  P, T, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho,
-			  mask,
-			  Verbosity::Verbose);
-	  THEN( "The shapes are correct" ) {
-	    REQUIRE( P.dim(1)      == NUME   );
-	    REQUIRE( P.dim(2)      == NRHO );
-	    REQUIRE( T.dim(1)      == NUME   );
-	    REQUIRE( T.dim(2)      == NRHO );
-	    REQUIRE( bMod.dim(1)  == NUME   );
-	    REQUIRE( bMod.dim(2)  == NRHO );
-	    REQUIRE( dPdRho.dim(1) == NUME   );
-	    REQUIRE( dPdRho.dim(2) == NRHO );
-	    REQUIRE( dPdE.dim(1)   == NUME   );
-	    REQUIRE( dPdE.dim(2)   == NRHO );
-	    REQUIRE( dTdRho.dim(1) == NUME   );
-	    REQUIRE( dTdRho.dim(2) == NRHO );
-	    REQUIRE( dTdE.dim(1)   == NUME   );
-	    REQUIRE( dTdE.dim(2)   == NRHO );
-	    
-	    AND_THEN( "The tables contain all finite values" ) {
-	      bool nansPresent = false;
-	      for (int j = 0; j < NRHO; j++) {
-		for (int i = 0; i < NUME; i++) {
-		  nansPresent |= std::isnan(P(j,i));
-		  nansPresent |= std::isnan(T(j,i));
-		  nansPresent |= std::isnan(bMod(j,i));
-		  nansPresent |= std::isnan(dPdRho(j,i));
-		  nansPresent |= std::isnan(dPdRho(j,i));
-		  nansPresent |= std::isnan(dPdE(j,i));
-		  nansPresent |= std::isnan(dTdRho(j,i));
-		  nansPresent |= std::isnan(dTdE(j,i));
-		}
-	      }
-	      REQUIRE( !nansPresent );
-	    }
-	  }
-	}
+        GIVEN("Databoxes filled for log rho and log sie") {
+          eosDataOfRhoSie(matid, lRhoBounds, leBounds, P, T, bMod, dPdRho, dPdE, dTdRho,
+                          dTdE, dEdRho, mask, Verbosity::Verbose);
+          THEN("The shapes are correct") {
+            REQUIRE(P.dim(1) == NUME);
+            REQUIRE(P.dim(2) == NRHO);
+            REQUIRE(T.dim(1) == NUME);
+            REQUIRE(T.dim(2) == NRHO);
+            REQUIRE(bMod.dim(1) == NUME);
+            REQUIRE(bMod.dim(2) == NRHO);
+            REQUIRE(dPdRho.dim(1) == NUME);
+            REQUIRE(dPdRho.dim(2) == NRHO);
+            REQUIRE(dPdE.dim(1) == NUME);
+            REQUIRE(dPdE.dim(2) == NRHO);
+            REQUIRE(dTdRho.dim(1) == NUME);
+            REQUIRE(dTdRho.dim(2) == NRHO);
+            REQUIRE(dTdE.dim(1) == NUME);
+            REQUIRE(dTdE.dim(2) == NRHO);
+
+            AND_THEN("The tables contain all finite values") {
+              bool nansPresent = false;
+              for (int j = 0; j < NRHO; j++) {
+                for (int i = 0; i < NUME; i++) {
+                  nansPresent |= std::isnan(P(j, i));
+                  nansPresent |= std::isnan(T(j, i));
+                  nansPresent |= std::isnan(bMod(j, i));
+                  nansPresent |= std::isnan(dPdRho(j, i));
+                  nansPresent |= std::isnan(dPdRho(j, i));
+                  nansPresent |= std::isnan(dPdE(j, i));
+                  nansPresent |= std::isnan(dTdRho(j, i));
+                  nansPresent |= std::isnan(dTdE(j, i));
+                }
+              }
+              REQUIRE(!nansPresent);
+            }
+          }
+        }
       }
     }
   }
 }
 
-SCENARIO( "Converting air to file using saveMaterial",
-	  "[saveMaterial]" ) {
+SCENARIO("Converting air to file using saveMaterial", "[saveMaterial]") {
   SesameMetadata m;
   eosGetMetadata(matid, m, Verbosity::Verbose);
 
@@ -268,17 +249,12 @@ SCENARIO( "Converting air to file using saveMaterial",
   // Extremely conservative because extrapolation likely to go bad
   // Don't actually do this
   Bounds leBounds(m.sieMin, m.sieMax, m.numT, true, 0.5);
-  
-  GIVEN( "HDF5 file can be written to" ) {
-    hid_t file = H5Fcreate(SP5::defaultSesFileName, H5F_ACC_TRUNC,
-			   H5P_DEFAULT, H5P_DEFAULT);
-    herr_t status = saveMaterial(file,m,
-				 lRhoBounds,lTBounds,leBounds,
-				 name);
+
+  GIVEN("HDF5 file can be written to") {
+    hid_t file =
+        H5Fcreate(SP5::defaultSesFileName, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    herr_t status = saveMaterial(file, m, lRhoBounds, lTBounds, leBounds, name);
     status += H5Fclose(file);
-    THEN( "HDF5 returns no errors" ) {
-      REQUIRE( status == H5_SUCCESS );
-    }
+    THEN("HDF5 returns no errors") { REQUIRE(status == H5_SUCCESS); }
   }
 }
-

--- a/singularity-eos/base/eos_error.hpp
+++ b/singularity-eos/base/eos_error.hpp
@@ -19,7 +19,9 @@
 #include <stdexcept>
 #define EOS_ERROR(x) (throw std::runtime_error(x))
 #else
-#define EOS_ERROR(x) printf("%s\n", x); assert(false);
+#define EOS_ERROR(x)                                                                     \
+  printf("%s\n", x);                                                                     \
+  assert(false);
 #endif
 #define UNDEFINED_ERROR EOS_ERROR("DEFINE ME\n")
 

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -15,8 +15,8 @@
 #ifndef _SINGULARITY_EOS_CLOSURE_MIXED_CELL_MODELS_
 #define _SINGULARITY_EOS_CLOSURE_MIXED_CELL_MODELS_
 
-#include <singularity-eos/eos/eos.hpp>
 #include <ports-of-call/portability.hpp>
+#include <singularity-eos/eos/eos.hpp>
 
 #include <cmath>
 
@@ -47,58 +47,54 @@ namespace singularity {
 */
 // Version templated on nmat
 // niter version produces histogram
-template <int nmat, typename EOSIndexer, typename RealIndexer,
-          typename ConstRealIndexer, typename LambdaIndexer>
+template <int nmat, typename EOSIndexer, typename RealIndexer, typename ConstRealIndexer,
+          typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool pte_closure_flag_with_line(
     EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
     ConstRealIndexer &&ComponentMasses, RealIndexer &&ComponentVolumes,
     RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas, int &niter);
-template <int nmat, typename EOSIndexer, typename RealIndexer,
-          typename ConstRealIndexer, typename LambdaIndexer>
-PORTABLE_INLINE_FUNCTION bool pte_closure_flag_with_line(
-    EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
-    ConstRealIndexer &&ComponentMasses, RealIndexer &&ComponentVolumes,
-    RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas) {
+template <int nmat, typename EOSIndexer, typename RealIndexer, typename ConstRealIndexer,
+          typename LambdaIndexer>
+PORTABLE_INLINE_FUNCTION bool
+pte_closure_flag_with_line(EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
+                           ConstRealIndexer &&ComponentMasses,
+                           RealIndexer &&ComponentVolumes,
+                           RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas) {
   int niter;
   return pte_closure_flag_with_line(eoss, Volume, TotalSIE, ComponentMasses,
-                                    ComponentVolumes, ComponentEnergies, lambdas,
-                                    niter);
+                                    ComponentVolumes, ComponentEnergies, lambdas, niter);
 }
 // Version with nmat available at runtime
 template <typename EOSIndexer, typename RealIndexer, typename ConstRealIndexer,
           typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_flag(int nmat, EOSIndexer &&eoss, const Real Volume,
-                 const Real TotalSIE, ConstRealIndexer &&ComponentMasses,
-                 RealIndexer &&ComponentVolumes,
+pte_closure_flag(int nmat, EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
+                 ConstRealIndexer &&ComponentMasses, RealIndexer &&ComponentVolumes,
                  RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas, int &niter);
 template <typename EOSIndexer, typename RealIndexer, typename ConstRealIndexer,
           typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_flag(int nmat, EOSIndexer &&eoss, const Real Volume,
-                 const Real TotalSIE, ConstRealIndexer &&ComponentMasses,
-                 RealIndexer &&ComponentVolumes,
+pte_closure_flag(int nmat, EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
+                 ConstRealIndexer &&ComponentMasses, RealIndexer &&ComponentVolumes,
                  RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas) {
   int niter;
-  return pte_closure_flag(nmat, eoss, Volume, TotalSIE, ComponentMasses,
-                          ComponentVolumes, ComponentEnergies, lambdas, niter);
+  return pte_closure_flag(nmat, eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes,
+                          ComponentEnergies, lambdas, niter);
 }
 // Pointer-only version with offset for EOS indexing
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_flag_offset(int nmat, EOS *eoss, const Real Volume,
-                        const Real TotalSIE, int const *const ComponentMats,
-                        const Real *ComponentMasses, Real *ComponentVolumes,
-                        Real *ComponentEnergies, Real **lambdas, int &niter);
+pte_closure_flag_offset(int nmat, EOS *eoss, const Real Volume, const Real TotalSIE,
+                        int const *const ComponentMats, const Real *ComponentMasses,
+                        Real *ComponentVolumes, Real *ComponentEnergies, Real **lambdas,
+                        int &niter);
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_flag_offset(int nmat, EOS *eoss, const Real Volume,
-                        const Real TotalSIE, int const *const ComponentMats,
-                        const Real *ComponentMasses, Real *ComponentVolumes,
-                        Real *ComponentEnergies, Real **lambdas) {
+pte_closure_flag_offset(int nmat, EOS *eoss, const Real Volume, const Real TotalSIE,
+                        int const *const ComponentMats, const Real *ComponentMasses,
+                        Real *ComponentVolumes, Real *ComponentEnergies, Real **lambdas) {
   int niter;
-  return pte_closure_flag_offset(nmat, eoss, Volume,
-                                 TotalSIE, ComponentMats,
-                                 ComponentMasses, ComponentVolumes,
-                                 ComponentEnergies, lambdas, niter);
+  return pte_closure_flag_offset(nmat, eoss, Volume, TotalSIE, ComponentMats,
+                                 ComponentMasses, ComponentVolumes, ComponentEnergies,
+                                 lambdas, niter);
 }
 /*
   This solver was developed by Josh Dolence, and is guaranteed to
@@ -110,55 +106,49 @@ pte_closure_flag_offset(int nmat, EOS *eoss, const Real Volume,
   LambdaIndexer must have an operator[](int) that returns a Real*. e.g., Real**
 */
 // Version templated on nmat.
-template <int nmat, typename EOSIndexer, typename RealIndexer,
-          typename LambdaIndexer>
+template <int nmat, typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool pte_closure_josh(EOSIndexer &&eos, const Real vfrac_tot,
                                                const Real sie_tot, RealIndexer &&rho,
                                                RealIndexer &&vfrac, RealIndexer &&sie,
                                                RealIndexer &&temp, RealIndexer &&press,
                                                LambdaIndexer &&lambda, int &niter);
-template <int nmat, typename EOSIndexer, typename RealIndexer,
-          typename LambdaIndexer>
-PORTABLE_INLINE_FUNCTION bool pte_closure_josh(EOSIndexer &&eos, const Real vfrac_tot,
-                                               const Real sie_tot, RealIndexer &&rho,
-                                               RealIndexer &&vfrac, RealIndexer &&sie,
-                                               RealIndexer &&temp, RealIndexer &&press,
-                                               LambdaIndexer &&lambda) {
+template <int nmat, typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
+PORTABLE_INLINE_FUNCTION bool
+pte_closure_josh(EOSIndexer &&eos, const Real vfrac_tot, const Real sie_tot,
+                 RealIndexer &&rho, RealIndexer &&vfrac, RealIndexer &&sie,
+                 RealIndexer &&temp, RealIndexer &&press, LambdaIndexer &&lambda) {
   int niter;
-  return pte_closure_josh(eos, vfrac_tot, sie_tot, rho,
-                          vfrac, sie, temp, press, lambda, niter);
+  return pte_closure_josh(eos, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press, lambda,
+                          niter);
 }
 // Version with nmat available at runtime.
 template <typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_josh(int nmat, EOSIndexer &&eoss, const Real vfrac_tot,
-                 const Real sie_tot, RealIndexer &&rho, RealIndexer &&vfrac,
-                 RealIndexer &&sie, RealIndexer &&temp, RealIndexer &&press,
-                 LambdaIndexer &&lambdas, int &niter);
+pte_closure_josh(int nmat, EOSIndexer &&eoss, const Real vfrac_tot, const Real sie_tot,
+                 RealIndexer &&rho, RealIndexer &&vfrac, RealIndexer &&sie,
+                 RealIndexer &&temp, RealIndexer &&press, LambdaIndexer &&lambdas,
+                 int &niter);
 template <typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_josh(int nmat, EOSIndexer &&eoss, const Real vfrac_tot,
-                 const Real sie_tot, RealIndexer &&rho, RealIndexer &&vfrac,
-                 RealIndexer &&sie, RealIndexer &&temp, RealIndexer &&press,
-                 LambdaIndexer &&lambdas) {
+pte_closure_josh(int nmat, EOSIndexer &&eoss, const Real vfrac_tot, const Real sie_tot,
+                 RealIndexer &&rho, RealIndexer &&vfrac, RealIndexer &&sie,
+                 RealIndexer &&temp, RealIndexer &&press, LambdaIndexer &&lambdas) {
   int niter;
-  return pte_closure_josh(nmat, eoss, vfrac_tot, sie_tot, rho, vfrac,
-                          sie, temp, press, lambdas, niter);
+  return pte_closure_josh(nmat, eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press,
+                          lambdas, niter);
 }
 // Pointer-only version with offset for EOS indexing
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_josh_offset(int nmat, EOS *eoss, const Real vfrac_tot,
-                        const Real sie_tot, int const *const Mats, Real *rho,
-                        Real *vfrac, Real *sie, Real *temp, Real *press,
-                        Real **lambdas, int &niter);
+pte_closure_josh_offset(int nmat, EOS *eoss, const Real vfrac_tot, const Real sie_tot,
+                        int const *const Mats, Real *rho, Real *vfrac, Real *sie,
+                        Real *temp, Real *press, Real **lambdas, int &niter);
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_josh_offset(int nmat, EOS *eoss, const Real vfrac_tot,
-                        const Real sie_tot, int const *const Mats, Real *rho,
-                        Real *vfrac, Real *sie, Real *temp, Real *press,
-                        Real **lambdas) {
+pte_closure_josh_offset(int nmat, EOS *eoss, const Real vfrac_tot, const Real sie_tot,
+                        int const *const Mats, Real *rho, Real *vfrac, Real *sie,
+                        Real *temp, Real *press, Real **lambdas) {
   int niter;
-  return pte_closure_josh_offset(nmat, eoss, vfrac_tot, sie_tot, Mats, rho,
-                                 vfrac, sie, temp, press, lambdas, niter);
+  return pte_closure_josh_offset(nmat, eoss, vfrac_tot, sie_tot, Mats, rho, vfrac, sie,
+                                 temp, press, lambdas, niter);
 }
 
 /*
@@ -176,22 +166,21 @@ pte_closure_josh_offset(int nmat, EOS *eoss, const Real vfrac_tot,
     ConstRealIndexer is as RealIndexer, but assumed const type.
     LambdaIndexer must have an operator[](int) that returns a Real*. e.g., Real**
 */
-template <typename EOSIndexer, typename RealIndexer,
-          typename ConstRealIndexer, typename LambdaIndexer>
+template <typename EOSIndexer, typename RealIndexer, typename ConstRealIndexer,
+          typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool
 pte_closure_ideal(int nmat, EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
                   ConstRealIndexer &&ComponentMasses, RealIndexer &&ComponentVolumes,
                   RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas, int &niter);
-template <typename EOSIndexer, typename RealIndexer,
-          typename ConstRealIndexer, typename LambdaIndexer>
+template <typename EOSIndexer, typename RealIndexer, typename ConstRealIndexer,
+          typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool
 pte_closure_ideal(int nmat, EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
                   ConstRealIndexer &&ComponentMasses, RealIndexer &&ComponentVolumes,
                   RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas) {
   int niter;
-  return pte_closure_ideal(nmat, eoss, Volume, TotalSIE,
-                           ComponentMasses, ComponentVolumes,
-                           ComponentEnergies, lambdas, niter);
+  return pte_closure_ideal(nmat, eoss, Volume, TotalSIE, ComponentMasses,
+                           ComponentVolumes, ComponentEnergies, lambdas, niter);
 }
 
 // ======================================================================
@@ -211,8 +200,8 @@ constexpr Real line_search_fac = 0.05;
 } // namespace mix_params
 
 namespace mix_impl {
-template <typename T, typename = typename std::enable_if<
-                          std::is_floating_point<T>::value>::type>
+template <typename T,
+          typename = typename std::enable_if<std::is_floating_point<T>::value>::type>
 constexpr bool isfinite(const T &a) {
   return (a == a) && ((a == 0) || (a != 2 * a));
 }
@@ -234,7 +223,8 @@ bool check_nans(Real const *const a, const int n, const bool verbose = false) {
   return retval;
 }
 
-template <int n> PORTABLE_INLINE_FUNCTION bool solve_Ax_b(Real *a, Real *b) {
+template <int n>
+PORTABLE_INLINE_FUNCTION bool solve_Ax_b(Real *a, Real *b) {
 #ifdef SINGULARITY_USE_KOKKOSKERNELS
 #ifndef PORTABILITY_STRATEGY_KOKKOS
 #error "Kokkos Kernels requires Kokkos."
@@ -292,13 +282,14 @@ template <int n> PORTABLE_INLINE_FUNCTION bool solve_Ax_b(Real *a, Real *b) {
   return retval;
 }
 
-template <int nmat, typename EOSIndexer, typename RealIndexer,
-          typename ConstRealIndexer, typename LambdaIndexer, typename OFFSETTER>
-PORTABLE_INLINE_FUNCTION bool pte_closure_flag_with_line_impl(
-    EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
-    ConstRealIndexer &&ComponentMasses, RealIndexer &&ComponentVolumes,
-    RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas,
-    const OFFSETTER ofst, int &iter) {
+template <int nmat, typename EOSIndexer, typename RealIndexer, typename ConstRealIndexer,
+          typename LambdaIndexer, typename OFFSETTER>
+PORTABLE_INLINE_FUNCTION bool
+pte_closure_flag_with_line_impl(EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
+                                ConstRealIndexer &&ComponentMasses,
+                                RealIndexer &&ComponentVolumes,
+                                RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas,
+                                const OFFSETTER ofst, int &iter) {
   using namespace mix_params;
 
   Real TotalMass = 0.0, Vsum = 0.0, Esum = 0.0;
@@ -337,9 +328,9 @@ PORTABLE_INLINE_FUNCTION bool pte_closure_flag_with_line_impl(
     // Call the EOSs
     for (int mat = 0; mat < nmat; ++mat) {
       Densities[mat] = ComponentMasses[mat] / ComponentVolumes[mat];
-      eoss[ofst(mat)].PTofRE(Densities[mat], ComponentEnergies[mat],
-                             lambdas[mat], Pressures[mat], Temperatures[mat],
-                             dpdr[mat], dpde[mat], dtdr[mat], dtde[mat]);
+      eoss[ofst(mat)].PTofRE(Densities[mat], ComponentEnergies[mat], lambdas[mat],
+                             Pressures[mat], Temperatures[mat], dpdr[mat], dpde[mat],
+                             dtdr[mat], dtde[mat]);
     }
     // Now, zero the matrix and vector
     for (int i = 0; i < 2 * nmat * 2 * nmat; ++i)
@@ -367,16 +358,14 @@ PORTABLE_INLINE_FUNCTION bool pte_closure_flag_with_line_impl(
       A[i * 2 * nmat + n + 1] = -dpde[n + 1];
       A[i * 2 * nmat + i] = dpdr[n];
       A[i * 2 * nmat + i + 1] = -dpdr[n + 1];
-      A[(2 * nmat - 1) * 2 * nmat + i] =
-          ComponentMasses[n] / square(Densities[n]);
+      A[(2 * nmat - 1) * 2 * nmat + i] = ComponentMasses[n] / square(Densities[n]);
       b[i] = Pressures[n + 1] - Pressures[n];
       vsum += ComponentMasses[n] / Densities[n];
     }
     A[(nmat - 1) * 2 * nmat + nmat - 1] = ComponentMasses[nmat - 1];
     esum += ComponentMasses[nmat - 1] * ComponentEnergies[nmat - 1];
     b[nmat - 1] = TotalSIE * TotalMass - esum; // esum - TotalSIE*TotalMass;
-    A[4 * nmat * nmat - 1] =
-        ComponentMasses[nmat - 1] / square(Densities[nmat - 1]);
+    A[4 * nmat * nmat - 1] = ComponentMasses[nmat - 1] / square(Densities[nmat - 1]);
     vsum += ComponentMasses[nmat - 1] / Densities[nmat - 1];
     b[2 * nmat - 1] = vsum - Volume;
     for (int i = 0; i < 2 * nmat; ++i)
@@ -400,8 +389,7 @@ PORTABLE_INLINE_FUNCTION bool pte_closure_flag_with_line_impl(
       }
       const Real dt = (dtdr[m] * b[m + nmat] + dtde[m] * b[m]);
       const Real tt = Temperatures[m] + scale * dt;
-      if (tt < 0.0)
-        scale = -0.9 * Temperatures[m] / dt;
+      if (tt < 0.0) scale = -0.9 * Temperatures[m] / dt;
     }
     // Now apply the overall pre-scaling
     for (int i = 0; i < 2 * nmat; ++i)
@@ -460,10 +448,10 @@ PORTABLE_INLINE_FUNCTION bool pte_closure_flag_with_line_impl(
     mean_t /= TotalMass;
     err_p = std::sqrt(err_p);
     err_t = std::sqrt(err_t);
-    bool converged_p = (err_p < pte_rel_tolerance_p * std::abs(mean_p) ||
-                        err_p < pte_abs_tolerance_p);
-    bool converged_t = (err_t < pte_rel_tolerance_t * std::abs(mean_t) ||
-                        err_t < pte_abs_tolerance_t);
+    bool converged_p =
+        (err_p < pte_rel_tolerance_p * std::abs(mean_p) || err_p < pte_abs_tolerance_p);
+    bool converged_t =
+        (err_t < pte_rel_tolerance_t * std::abs(mean_t) || err_t < pte_abs_tolerance_t);
     if (converged_p && converged_t) {
       return true; // FIXME
     }
@@ -474,9 +462,8 @@ PORTABLE_INLINE_FUNCTION bool pte_closure_flag_with_line_impl(
 // RealIndexer types may be different because some might be arrays and
 // some might be pointers.
 template <int nmat, typename T1, typename T2, typename T3>
-PORTABLE_INLINE_FUNCTION static void pte_residual(const Real utot, T1 &&vfrac,
-                                                  Real *u, T2 &&temp,
-                                                  T3 &&press, Real *residual) {
+PORTABLE_INLINE_FUNCTION static void pte_residual(const Real utot, T1 &&vfrac, Real *u,
+                                                  T2 &&temp, T3 &&press, Real *residual) {
   Real vsum = 0.0;
   Real esum = 0.0;
   for (int m = 0; m < nmat; ++m) {
@@ -491,15 +478,13 @@ PORTABLE_INLINE_FUNCTION static void pte_residual(const Real utot, T1 &&vfrac,
   }
 }
 
-template <int nmat, typename EOSIndexer, typename RealIndexer,
-          typename LambdaIndexer, typename OFFSETTER>
+template <int nmat, typename EOSIndexer, typename RealIndexer, typename LambdaIndexer,
+          typename OFFSETTER>
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot,
-                      const Real sie_tot, RealIndexer &&rho,
-                      RealIndexer &&vfrac, RealIndexer &&sie,
-                      RealIndexer &&temp, RealIndexer &&press,
-                      LambdaIndexer &&lambda, const OFFSETTER ofst,
-                      int &niter) {
+pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot, const Real sie_tot,
+                      RealIndexer &&rho, RealIndexer &&vfrac, RealIndexer &&sie,
+                      RealIndexer &&temp, RealIndexer &&press, LambdaIndexer &&lambda,
+                      const OFFSETTER ofst, int &niter) {
   using namespace mix_params;
   const Real ilog2 = 1.0 / std::log(2.0);
   Real vsum = 0.0;
@@ -536,21 +521,18 @@ pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot,
   Real dpde[nmat], dtde[nmat], dpdv[nmat], dtdv[nmat];
 
   // set some options and make the initial EOS calls
-  enum class EosPreference {RhoT, Rhoe};
+  enum class EosPreference { RhoT, Rhoe };
   EosPreference eos_choice[nmat];
   for (int m = 0; m < nmat; m++) {
-    temp[m] = eos[ofst(m)].TemperatureFromDensityInternalEnergy(
-      rho[m], sie[m], Cache[m]);
+    temp[m] = eos[ofst(m)].TemperatureFromDensityInternalEnergy(rho[m], sie[m], Cache[m]);
     if (eos[ofst(m)].PreferredInput() ==
         (thermalqs::density | thermalqs::specific_internal_energy)) {
       eos_choice[m] = EosPreference::Rhoe;
-      press[m] = eos[ofst(m)].PressureFromDensityInternalEnergy(
-                  rho[m], sie[m], Cache[m]);
+      press[m] = eos[ofst(m)].PressureFromDensityInternalEnergy(rho[m], sie[m], Cache[m]);
     } else if (eos[ofst(m)].PreferredInput() ==
                (thermalqs::density | thermalqs::temperature)) {
       eos_choice[m] = EosPreference::RhoT;
-      press[m] = eos[ofst(m)].PressureFromDensityTemperature(
-                  rho[m], temp[m], Cache[m]);
+      press[m] = eos[ofst(m)].PressureFromDensityTemperature(rho[m], temp[m], Cache[m]);
     }
   }
 
@@ -572,17 +554,16 @@ pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot,
       const Real rho_pert = rhobar[m] / vf_pert;
 
       Real p_pert;
-      Real t_pert = eos[ofst(m)].TemperatureFromDensityInternalEnergy(
-          rho_pert, sie[m], Cache[m]);
+      Real t_pert =
+          eos[ofst(m)].TemperatureFromDensityInternalEnergy(rho_pert, sie[m], Cache[m]);
       switch (eos_choice[m]) {
-        case EosPreference::Rhoe:
-          p_pert = eos[ofst(m)].PressureFromDensityInternalEnergy(
-              rho_pert, sie[m], Cache[m]);
-          break;
-        case EosPreference::RhoT:
-          p_pert = eos[ofst(m)].PressureFromDensityTemperature(
-              rho_pert, t_pert, Cache[m]);
-          break;
+      case EosPreference::Rhoe:
+        p_pert =
+            eos[ofst(m)].PressureFromDensityInternalEnergy(rho_pert, sie[m], Cache[m]);
+        break;
+      case EosPreference::RhoT:
+        p_pert = eos[ofst(m)].PressureFromDensityTemperature(rho_pert, t_pert, Cache[m]);
+        break;
       }
       dpdv[m] = (p_pert - press[m]) / dv;
       dtdv[m] = (t_pert - temp[m]) / dv;
@@ -593,22 +574,21 @@ pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot,
       const Real de = std::pow(2.0, std::round(lde));
       Real e_pert = (u[m] + de) / rhobar[m];
 
-      t_pert = eos[ofst(m)].TemperatureFromDensityInternalEnergy(
-          rho[m], e_pert, Cache[m]);
+      t_pert =
+          eos[ofst(m)].TemperatureFromDensityInternalEnergy(rho[m], e_pert, Cache[m]);
       switch (eos_choice[m]) {
-        case EosPreference::Rhoe:
-          p_pert = eos[ofst(m)].PressureFromDensityInternalEnergy(
-              rho[m], e_pert, Cache[m]);
-          break;
-        case EosPreference::RhoT:
-          p_pert = eos[ofst(m)].PressureFromDensityTemperature(
-              rho[m], t_pert, Cache[m]);
-          break;
+      case EosPreference::Rhoe:
+        p_pert = eos[ofst(m)].PressureFromDensityInternalEnergy(rho[m], e_pert, Cache[m]);
+        break;
+      case EosPreference::RhoT:
+        p_pert = eos[ofst(m)].PressureFromDensityTemperature(rho[m], t_pert, Cache[m]);
+        break;
       }
       dpde[m] = (p_pert - press[m]) / de;
       dtde[m] = (t_pert - temp[m]) / de;
       if (std::abs(dtde[m]) < 1.e-16) { // must be on the cold curve
-        dtde[m] = derivative_eps;;
+        dtde[m] = derivative_eps;
+        ;
       }
     }
     // Fill in the residual
@@ -663,9 +643,9 @@ pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot,
         scale = 0.1 * (1.0 - vfrac[m]) / dx[m];
       }
       // maybe the below is dangerous??
-      //const Real dt = (dtdv[m] * dx[m] + dtde[m] * dx[m + nmat]);
-      //const Real tt = temp[m] + scale * dt;
-      //if (tt < 0.0)
+      // const Real dt = (dtdv[m] * dx[m] + dtde[m] * dx[m + nmat]);
+      // const Real tt = temp[m] + scale * dt;
+      // if (tt < 0.0)
       //  scale = -0.1 * temp[m] / dt;
     }
     // Now apply the overall scaling
@@ -682,17 +662,17 @@ pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot,
         rtemp[m] = rhobar[m] / vtemp[m];
         utemp[m] = u[m] + scale * dx[nmat + m];
         sie[m] = utemp[m] / rhobar[m];
-        temp[m] = eos[ofst(m)].TemperatureFromDensityInternalEnergy(
-            rtemp[m], sie[m], Cache[m]);
+        temp[m] =
+            eos[ofst(m)].TemperatureFromDensityInternalEnergy(rtemp[m], sie[m], Cache[m]);
         switch (eos_choice[m]) {
-          case EosPreference::Rhoe:
-            press[m] = eos[ofst(m)].PressureFromDensityInternalEnergy(
-                rtemp[m], sie[m], Cache[m]);
-            break;
-          case EosPreference::RhoT:
-            press[m] = eos[ofst(m)].PressureFromDensityTemperature(
-                rtemp[m], temp[m], Cache[m]);
-            break;
+        case EosPreference::Rhoe:
+          press[m] =
+              eos[ofst(m)].PressureFromDensityInternalEnergy(rtemp[m], sie[m], Cache[m]);
+          break;
+        case EosPreference::RhoT:
+          press[m] =
+              eos[ofst(m)].PressureFromDensityTemperature(rtemp[m], temp[m], Cache[m]);
+          break;
         }
       }
       pte_residual<nmat>(utot, vtemp, utemp, temp, press, residual);
@@ -731,11 +711,10 @@ pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot,
     // Check for convergence
     converged_p = (error_p < pte_rel_tolerance_p * std::abs(mean_p) ||
                    error_p < pte_abs_tolerance_p);
-    converged_t = (error_t < pte_rel_tolerance_t * mean_t ||
-                   error_t < pte_abs_tolerance_t);
+    converged_t =
+        (error_t < pte_rel_tolerance_t * mean_t || error_t < pte_abs_tolerance_t);
     converged = (converged_p && converged_t);
-    if (converged)
-      break;
+    if (converged) break;
     // niter++;
   } // while (niter < pte_max_iter && !converged);
   for (int m = 0; m < nmat; ++m)
@@ -749,83 +728,78 @@ struct NullPtrIndexer {
 
 } // namespace mix_impl
 
-template <int nmat, typename EOSIndexer, typename RealIndexer,
-          typename ConstRealIndexer, typename LambdaIndexer>
+template <int nmat, typename EOSIndexer, typename RealIndexer, typename ConstRealIndexer,
+          typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool pte_closure_flag_with_line(
     EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
     ConstRealIndexer &&ComponentMasses, RealIndexer &&ComponentVolumes,
-    RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas,
-    int &niter) {
+    RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas, int &niter) {
   using namespace mix_impl;
   return pte_closure_flag_with_line_impl<nmat>(
-      eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes,
-      ComponentEnergies, lambdas, [](const int m) { return m; }, niter);
+      eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes, ComponentEnergies,
+      lambdas, [](const int m) { return m; }, niter);
 }
 
 template <int nmat>
-PORTABLE_INLINE_FUNCTION bool pte_closure_flag_with_line_offset(
-    EOS *eoss, const Real Volume, const Real TotalSIE,
-    int const *const ComponentMats, const Real *ComponentMasses,
-    Real *ComponentVolumes, Real *ComponentEnergies, Real **lambdas,
-    int &niter) {
+PORTABLE_INLINE_FUNCTION bool
+pte_closure_flag_with_line_offset(EOS *eoss, const Real Volume, const Real TotalSIE,
+                                  int const *const ComponentMats,
+                                  const Real *ComponentMasses, Real *ComponentVolumes,
+                                  Real *ComponentEnergies, Real **lambdas, int &niter) {
   using namespace mix_impl;
   if (lambdas == nullptr) {
     NullPtrIndexer lambda_indexer;
     return pte_closure_flag_with_line_impl<nmat>(
-        eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes,
-        ComponentEnergies, lambda_indexer,
-        [&ComponentMats](const int m) { return ComponentMats[m]; }, niter);
+        eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes, ComponentEnergies,
+        lambda_indexer, [&ComponentMats](const int m) { return ComponentMats[m]; },
+        niter);
   }
   return pte_closure_flag_with_line_impl<nmat>(
-      eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes,
-      ComponentEnergies, lambdas,
-      [&ComponentMats](const int m) { return ComponentMats[m]; }, niter);
+      eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes, ComponentEnergies,
+      lambdas, [&ComponentMats](const int m) { return ComponentMats[m]; }, niter);
 }
 
-template <int nmat, typename EOSIndexer, typename RealIndexer,
-          typename LambdaIndexer>
+template <int nmat, typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool pte_closure_josh(EOSIndexer &&eos, const Real vfrac_tot,
                                                const Real sie_tot, RealIndexer &&rho,
                                                RealIndexer &&vfrac, RealIndexer &&sie,
                                                RealIndexer &&temp, RealIndexer &&press,
                                                LambdaIndexer &&lambda, int &niter) {
   using namespace mix_impl;
-  return pte_closure_josh_impl<nmat>(eos, vfrac_tot, sie_tot, rho, vfrac, sie,
-                                     temp, press, lambda,
-                                     [&](const int m) { return m; }, niter);
+  return pte_closure_josh_impl<nmat>(
+      eos, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press, lambda,
+      [&](const int m) { return m; }, niter);
 }
 
 template <int nmat>
 PORTABLE_INLINE_FUNCTION bool
 pte_closure_josh_offset(EOS *eos, const Real vfrac_tot, const Real sie_tot,
-                        int const *const Mats, Real *rho, Real *vfrac,
-                        Real *sie, Real *temp, Real *press, Real **lambda,
-                        int &niter) {
+                        int const *const Mats, Real *rho, Real *vfrac, Real *sie,
+                        Real *temp, Real *press, Real **lambda, int &niter) {
   using namespace mix_impl;
   if (lambda == nullptr) {
     NullPtrIndexer lambda_indexer;
-    return pte_closure_josh_impl<nmat>(eos, vfrac_tot, sie_tot, rho, vfrac, sie,
-                                       temp, press, lambda_indexer,
-                                       [&](const int m) { return m; }, niter);
+    return pte_closure_josh_impl<nmat>(
+        eos, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press, lambda_indexer,
+        [&](const int m) { return m; }, niter);
   }
-  return pte_closure_josh_impl<nmat>(eos, vfrac_tot, sie_tot, rho, vfrac, sie,
-                                     temp, press, lambda,
-                                     [&Mats](const int m) { return Mats[m]; }, niter);
+  return pte_closure_josh_impl<nmat>(
+      eos, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press, lambda,
+      [&Mats](const int m) { return Mats[m]; }, niter);
 }
 
-template <int nmat, typename EOSIndexer, typename RealIndexer,
-          typename ConstRealIndexer, typename LambdaIndexer>
+template <int nmat, typename EOSIndexer, typename RealIndexer, typename ConstRealIndexer,
+          typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool
 pte_closure_ideal(EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
                   ConstRealIndexer &&ComponentMasses, RealIndexer &&ComponentVolumes,
-                  RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas,
-                  int &iter) {
+                  RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas, int &iter) {
   using namespace mix_params;
   using namespace mix_impl;
   Real TotalMass = 0.0, Vsum = 0.0, Esum = 0.0;
-  Real Densities[nmat], Pressures[nmat], Temperatures[nmat], dpdr[nmat],
-      dpde[nmat], dtdr[nmat], dtde[nmat], dtpdv[nmat], dtpde[nmat], dtdv[nmat],
-      b[2 * nmat], A[4 * nmat * nmat], rtemp[nmat], sietemp[nmat];
+  Real Densities[nmat], Pressures[nmat], Temperatures[nmat], dpdr[nmat], dpde[nmat],
+      dtdr[nmat], dtde[nmat], dtpdv[nmat], dtpde[nmat], dtdv[nmat], b[2 * nmat],
+      A[4 * nmat * nmat], rtemp[nmat], sietemp[nmat];
   // First, normalize the energies and volumes.
   // This may or may not be close to reality since SIE isn't strictly positive.
   for (int i = 0; i < nmat; ++i)
@@ -859,17 +833,15 @@ pte_closure_ideal(EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
     for (int mat = 0; mat < nmat; ++mat) {
       Densities[mat] = ComponentMasses[mat] / ComponentVolumes[mat];
       eoss[mat].PTofRE(Densities[mat], ComponentEnergies[mat], lambdas[mat],
-                       Pressures[mat], Temperatures[mat], dpdr[mat], dpde[mat],
-                       dtdr[mat], dtde[mat]);
+                       Pressures[mat], Temperatures[mat], dpdr[mat], dpde[mat], dtdr[mat],
+                       dtde[mat]);
       // NOTE: here we are re-using this space for d(P/T)/dr and /de using the
       // chain rule If it is deemed useful, we can output this quantity from the
       // EOS call instead
-      dtpdv[mat] =
-          -(dtdr[mat] - Temperatures[mat] / Pressures[mat] * dpdr[mat]) /
-          Pressures[mat] * square(Densities[mat]);
+      dtpdv[mat] = -(dtdr[mat] - Temperatures[mat] / Pressures[mat] * dpdr[mat]) /
+                   Pressures[mat] * square(Densities[mat]);
       dtpde[mat] =
-          (dtde[mat] - Temperatures[mat] / Pressures[mat] * dpde[mat]) /
-          Pressures[mat];
+          (dtde[mat] - Temperatures[mat] / Pressures[mat] * dpde[mat]) / Pressures[mat];
       dtdv[mat] = -dtdr[mat] * square(Densities[mat]);
     }
     // Now, zero the matrix and vector
@@ -896,8 +868,7 @@ pte_closure_ideal(EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
       A[i * 2 * nmat + i] = dtpdv[n];
       A[i * 2 * nmat + i + 1] = -dtpdv[n + 1];
       A[(2 * nmat - 1) * 2 * nmat + i] = 1;
-      b[i] = Pressures[n + 1] / Temperatures[n + 1] -
-             Pressures[n] / Temperatures[n];
+      b[i] = Pressures[n + 1] / Temperatures[n + 1] - Pressures[n] / Temperatures[n];
       vsum += ComponentMasses[n] / Densities[n];
       esum += ComponentMasses[n] * ComponentEnergies[n];
     }
@@ -920,15 +891,13 @@ pte_closure_ideal(EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
     // Now, get overall scaling limit
     Real scale = 1.0;
     for (int m = 0; m < nmat; ++m) {
-      Real rt =
-          ComponentMasses[m] / (ComponentVolumes[m] + scale * b[m + nmat]);
+      Real rt = ComponentMasses[m] / (ComponentVolumes[m] + scale * b[m + nmat]);
       if (rt < 0.0) {
         scale = -0.9 * ComponentVolumes[m] / b[m + nmat];
       }
       const Real dt = (dtdv[m] * b[m + nmat] + dtde[m] * b[m]);
       const Real tt = Temperatures[m] + scale * dt;
-      if (tt < 0.0)
-        scale = -0.9 * Temperatures[m] / dt;
+      if (tt < 0.0) scale = -0.9 * Temperatures[m] / dt;
     }
     // Now apply the overall pre-scaling
     for (int i = 0; i < 2 * nmat; ++i)
@@ -941,19 +910,18 @@ pte_closure_ideal(EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
     Real err_p, err_t;
     do {
       for (int m = 0; m < nmat; ++m) {
-        rtemp[m] =
-            ComponentMasses[m] / (ComponentVolumes[m] + scale * b[m + nmat]);
+        rtemp[m] = ComponentMasses[m] / (ComponentVolumes[m] + scale * b[m + nmat]);
         sietemp[m] = ComponentEnergies[m] + scale * b[m];
         Temperatures[m] = eoss[m].TemperatureFromDensityInternalEnergy(
             rtemp[m], sietemp[m], lambdas[m]);
         if (eoss[m].PreferredInput() ==
             (thermalqs::density | thermalqs::specific_internal_energy)) {
-          Pressures[m] = eoss[m].PressureFromDensityInternalEnergy(
-              rtemp[m], sietemp[m], lambdas[m]);
+          Pressures[m] =
+              eoss[m].PressureFromDensityInternalEnergy(rtemp[m], sietemp[m], lambdas[m]);
         } else if (eoss[m].PreferredInput() ==
                    (thermalqs::density | thermalqs::temperature)) {
-          Pressures[m] = eoss[m].PressureFromDensityTemperature(
-              rtemp[m], Temperatures[m], lambdas[m]);
+          Pressures[m] = eoss[m].PressureFromDensityTemperature(rtemp[m], Temperatures[m],
+                                                                lambdas[m]);
         }
       }
       err_p = 0.0;
@@ -988,10 +956,10 @@ pte_closure_ideal(EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
     mean_t /= TotalMass;
     err_p = std::sqrt(err_p);
     err_t = std::sqrt(err_t);
-    bool converged_p = (err_p < pte_rel_tolerance_p * std::abs(mean_p) ||
-                        err_p < pte_abs_tolerance_p);
-    bool converged_t = (err_t < pte_rel_tolerance_t * std::abs(mean_t) ||
-                        err_t < pte_abs_tolerance_t);
+    bool converged_p =
+        (err_p < pte_rel_tolerance_p * std::abs(mean_p) || err_p < pte_abs_tolerance_p);
+    bool converged_t =
+        (err_t < pte_rel_tolerance_t * std::abs(mean_t) || err_t < pte_abs_tolerance_t);
     if (converged_p && converged_t) {
       return true; // FIXME
     }
@@ -1006,188 +974,176 @@ pte_closure_ideal(EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
 template <typename EOSIndexer, typename RealIndexer, typename ConstRealIndexer,
           typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_flag(int nmat, EOSIndexer &&eoss, const Real Volume,
-                 const Real TotalSIE, ConstRealIndexer &&ComponentMasses,
-                 RealIndexer &&ComponentVolumes,
-                 RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas,
-                 int &niter) {
+pte_closure_flag(int nmat, EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
+                 ConstRealIndexer &&ComponentMasses, RealIndexer &&ComponentVolumes,
+                 RealIndexer &&ComponentEnergies, LambdaIndexer &&lambdas, int &niter) {
   switch (nmat) {
   case 1:
     return true; // (or should we call the EOS actually?)
   case 2:
-    return pte_closure_flag_with_line<2>(eoss, Volume, TotalSIE,
-                                         ComponentMasses, ComponentVolumes,
-                                         ComponentEnergies, lambdas,
+    return pte_closure_flag_with_line<2>(eoss, Volume, TotalSIE, ComponentMasses,
+                                         ComponentVolumes, ComponentEnergies, lambdas,
                                          niter);
     break;
   case 3:
-    return pte_closure_flag_with_line<3>(eoss, Volume, TotalSIE,
-                                         ComponentMasses, ComponentVolumes,
-                                         ComponentEnergies, lambdas,
+    return pte_closure_flag_with_line<3>(eoss, Volume, TotalSIE, ComponentMasses,
+                                         ComponentVolumes, ComponentEnergies, lambdas,
                                          niter);
     break;
   case 4:
-    return pte_closure_flag_with_line<4>(eoss, Volume, TotalSIE,
-                                         ComponentMasses, ComponentVolumes,
-                                         ComponentEnergies, lambdas,
+    return pte_closure_flag_with_line<4>(eoss, Volume, TotalSIE, ComponentMasses,
+                                         ComponentVolumes, ComponentEnergies, lambdas,
                                          niter);
     break;
   case 5:
-    return pte_closure_flag_with_line<5>(eoss, Volume, TotalSIE,
-                                         ComponentMasses, ComponentVolumes,
-                                         ComponentEnergies, lambdas,
+    return pte_closure_flag_with_line<5>(eoss, Volume, TotalSIE, ComponentMasses,
+                                         ComponentVolumes, ComponentEnergies, lambdas,
                                          niter);
     break;
   case 6:
-    return pte_closure_flag_with_line<6>(eoss, Volume, TotalSIE,
-                                         ComponentMasses, ComponentVolumes,
-                                         ComponentEnergies, lambdas,
+    return pte_closure_flag_with_line<6>(eoss, Volume, TotalSIE, ComponentMasses,
+                                         ComponentVolumes, ComponentEnergies, lambdas,
                                          niter);
     break;
   case 7:
-    return pte_closure_flag_with_line<7>(eoss, Volume, TotalSIE,
-                                         ComponentMasses, ComponentVolumes,
-                                         ComponentEnergies, lambdas,
+    return pte_closure_flag_with_line<7>(eoss, Volume, TotalSIE, ComponentMasses,
+                                         ComponentVolumes, ComponentEnergies, lambdas,
                                          niter);
     break;
   case 8:
-    return pte_closure_flag_with_line<8>(eoss, Volume, TotalSIE,
-                                         ComponentMasses, ComponentVolumes,
-                                         ComponentEnergies, lambdas,
+    return pte_closure_flag_with_line<8>(eoss, Volume, TotalSIE, ComponentMasses,
+                                         ComponentVolumes, ComponentEnergies, lambdas,
                                          niter);
     break;
   }
   return false;
 }
 PORTABLE_INLINE_FUNCTION
-bool pte_closure_flag_offset(int nmat, EOS *eoss, const Real Volume,
-                             const Real TotalSIE,
-                             int const *const ComponentMats,
-                             const Real *ComponentMasses,
+bool pte_closure_flag_offset(int nmat, EOS *eoss, const Real Volume, const Real TotalSIE,
+                             int const *const ComponentMats, const Real *ComponentMasses,
                              Real *ComponentVolumes, Real *ComponentEnergies,
                              Real **lambdas, int &niter) {
   switch (nmat) {
   case 1:
     return true; // (or should we call the EOS actually?)
   case 2:
-    return pte_closure_flag_with_line_offset<2>(
-        eoss, Volume, TotalSIE, ComponentMats, ComponentMasses,
-        ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_flag_with_line_offset<2>(eoss, Volume, TotalSIE, ComponentMats,
+                                                ComponentMasses, ComponentVolumes,
+                                                ComponentEnergies, lambdas, niter);
     break;
   case 3:
-    return pte_closure_flag_with_line_offset<3>(
-        eoss, Volume, TotalSIE, ComponentMats, ComponentMasses,
-        ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_flag_with_line_offset<3>(eoss, Volume, TotalSIE, ComponentMats,
+                                                ComponentMasses, ComponentVolumes,
+                                                ComponentEnergies, lambdas, niter);
     break;
   case 4:
-    return pte_closure_flag_with_line_offset<4>(
-        eoss, Volume, TotalSIE, ComponentMats, ComponentMasses,
-        ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_flag_with_line_offset<4>(eoss, Volume, TotalSIE, ComponentMats,
+                                                ComponentMasses, ComponentVolumes,
+                                                ComponentEnergies, lambdas, niter);
     break;
   case 5:
-    return pte_closure_flag_with_line_offset<5>(
-        eoss, Volume, TotalSIE, ComponentMats, ComponentMasses,
-        ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_flag_with_line_offset<5>(eoss, Volume, TotalSIE, ComponentMats,
+                                                ComponentMasses, ComponentVolumes,
+                                                ComponentEnergies, lambdas, niter);
     break;
   case 6:
-    return pte_closure_flag_with_line_offset<6>(
-        eoss, Volume, TotalSIE, ComponentMats, ComponentMasses,
-        ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_flag_with_line_offset<6>(eoss, Volume, TotalSIE, ComponentMats,
+                                                ComponentMasses, ComponentVolumes,
+                                                ComponentEnergies, lambdas, niter);
     break;
   case 7:
-    return pte_closure_flag_with_line_offset<7>(
-        eoss, Volume, TotalSIE, ComponentMats, ComponentMasses,
-        ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_flag_with_line_offset<7>(eoss, Volume, TotalSIE, ComponentMats,
+                                                ComponentMasses, ComponentVolumes,
+                                                ComponentEnergies, lambdas, niter);
     break;
   case 8:
-    return pte_closure_flag_with_line_offset<8>(
-        eoss, Volume, TotalSIE, ComponentMats, ComponentMasses,
-        ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_flag_with_line_offset<8>(eoss, Volume, TotalSIE, ComponentMats,
+                                                ComponentMasses, ComponentVolumes,
+                                                ComponentEnergies, lambdas, niter);
     break;
   }
   return false;
 }
 template <typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_josh(int nmat, EOSIndexer &&eoss, const Real vfrac_tot,
-                 const Real sie_tot, RealIndexer &&rho, RealIndexer &&vfrac,
-                 RealIndexer &&sie, RealIndexer &&temp, RealIndexer &&press,
-                 LambdaIndexer &&lambdas, int &niter) {
+pte_closure_josh(int nmat, EOSIndexer &&eoss, const Real vfrac_tot, const Real sie_tot,
+                 RealIndexer &&rho, RealIndexer &&vfrac, RealIndexer &&sie,
+                 RealIndexer &&temp, RealIndexer &&press, LambdaIndexer &&lambdas,
+                 int &niter) {
   switch (nmat) {
   case 1:
     return true; // (or should we call the EOS actually?)
   case 2:
-    return pte_closure_josh<2>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp,
-                               press, lambdas, niter);
+    return pte_closure_josh<2>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press,
+                               lambdas, niter);
     break;
   case 3:
-    return pte_closure_josh<3>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp,
-                               press, lambdas, niter);
+    return pte_closure_josh<3>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press,
+                               lambdas, niter);
     break;
   case 4:
-    return pte_closure_josh<4>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp,
-                               press, lambdas, niter);
+    return pte_closure_josh<4>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press,
+                               lambdas, niter);
     break;
   case 5:
-    return pte_closure_josh<5>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp,
-                               press, lambdas, niter);
+    return pte_closure_josh<5>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press,
+                               lambdas, niter);
     break;
   case 6:
-    return pte_closure_josh<6>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp,
-                               press, lambdas, niter);
+    return pte_closure_josh<6>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press,
+                               lambdas, niter);
     break;
   case 7:
-    return pte_closure_josh<7>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp,
-                               press, lambdas, niter);
+    return pte_closure_josh<7>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press,
+                               lambdas, niter);
     break;
   case 8:
-    return pte_closure_josh<8>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp,
-                               press, lambdas, niter);
+    return pte_closure_josh<8>(eoss, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press,
+                               lambdas, niter);
     break;
   }
   return false;
 }
 PORTABLE_INLINE_FUNCTION bool
-pte_closure_josh_offset(int nmat, EOS *eoss, const Real vfrac_tot,
-                        const Real sie_tot, int const *const Mats, Real *rho,
-                        Real *vfrac, Real *sie, Real *temp, Real *press,
-                        Real **lambdas, int &niter) {
+pte_closure_josh_offset(int nmat, EOS *eoss, const Real vfrac_tot, const Real sie_tot,
+                        int const *const Mats, Real *rho, Real *vfrac, Real *sie,
+                        Real *temp, Real *press, Real **lambdas, int &niter) {
   switch (nmat) {
   case 1:
     return true; // (or should we call the EOS actually?)
   case 2:
-    return pte_closure_josh_offset<2>(eoss, vfrac_tot, sie_tot, Mats, rho,
-                                      vfrac, sie, temp, press, lambdas, niter);
+    return pte_closure_josh_offset<2>(eoss, vfrac_tot, sie_tot, Mats, rho, vfrac, sie,
+                                      temp, press, lambdas, niter);
     break;
   case 3:
-    return pte_closure_josh_offset<3>(eoss, vfrac_tot, sie_tot, Mats, rho,
-                                      vfrac, sie, temp, press, lambdas, niter);
+    return pte_closure_josh_offset<3>(eoss, vfrac_tot, sie_tot, Mats, rho, vfrac, sie,
+                                      temp, press, lambdas, niter);
     break;
   case 4:
-    return pte_closure_josh_offset<4>(eoss, vfrac_tot, sie_tot, Mats, rho,
-                                      vfrac, sie, temp, press, lambdas, niter);
+    return pte_closure_josh_offset<4>(eoss, vfrac_tot, sie_tot, Mats, rho, vfrac, sie,
+                                      temp, press, lambdas, niter);
     break;
   case 5:
-    return pte_closure_josh_offset<5>(eoss, vfrac_tot, sie_tot, Mats, rho,
-                                      vfrac, sie, temp, press, lambdas, niter);
+    return pte_closure_josh_offset<5>(eoss, vfrac_tot, sie_tot, Mats, rho, vfrac, sie,
+                                      temp, press, lambdas, niter);
     break;
   case 6:
-    return pte_closure_josh_offset<6>(eoss, vfrac_tot, sie_tot, Mats, rho,
-                                      vfrac, sie, temp, press, lambdas, niter);
+    return pte_closure_josh_offset<6>(eoss, vfrac_tot, sie_tot, Mats, rho, vfrac, sie,
+                                      temp, press, lambdas, niter);
     break;
   case 7:
-    return pte_closure_josh_offset<7>(eoss, vfrac_tot, sie_tot, Mats, rho,
-                                      vfrac, sie, temp, press, lambdas, niter);
+    return pte_closure_josh_offset<7>(eoss, vfrac_tot, sie_tot, Mats, rho, vfrac, sie,
+                                      temp, press, lambdas, niter);
     break;
   case 8:
-    return pte_closure_josh_offset<8>(eoss, vfrac_tot, sie_tot, Mats, rho,
-                                      vfrac, sie, temp, press, lambdas, niter);
+    return pte_closure_josh_offset<8>(eoss, vfrac_tot, sie_tot, Mats, rho, vfrac, sie,
+                                      temp, press, lambdas, niter);
     break;
   }
   return false;
 }
-template <typename EOSIndexer, typename RealIndexer,
-          typename ConstRealIndexer, typename LambdaIndexer>
+template <typename EOSIndexer, typename RealIndexer, typename ConstRealIndexer,
+          typename LambdaIndexer>
 PORTABLE_INLINE_FUNCTION bool
 pte_closure_ideal(int nmat, EOSIndexer &&eoss, const Real Volume, const Real TotalSIE,
                   ConstRealIndexer &&ComponentMasses, RealIndexer &&ComponentVolumes,
@@ -1196,32 +1152,32 @@ pte_closure_ideal(int nmat, EOSIndexer &&eoss, const Real Volume, const Real Tot
   case 1:
     return true; // (or should we call the EOS actually?)
   case 2:
-    return pte_closure_ideal<2>(eoss, Volume, TotalSIE, ComponentMasses,
-                                ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_ideal<2>(eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes,
+                                ComponentEnergies, lambdas, niter);
     break;
   case 3:
-    return pte_closure_ideal<3>(eoss, Volume, TotalSIE, ComponentMasses,
-                                ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_ideal<3>(eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes,
+                                ComponentEnergies, lambdas, niter);
     break;
   case 4:
-    return pte_closure_ideal<4>(eoss, Volume, TotalSIE, ComponentMasses,
-                                ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_ideal<4>(eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes,
+                                ComponentEnergies, lambdas, niter);
     break;
   case 5:
-    return pte_closure_ideal<5>(eoss, Volume, TotalSIE, ComponentMasses,
-                                ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_ideal<5>(eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes,
+                                ComponentEnergies, lambdas, niter);
     break;
   case 6:
-    return pte_closure_ideal<6>(eoss, Volume, TotalSIE, ComponentMasses,
-                                ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_ideal<6>(eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes,
+                                ComponentEnergies, lambdas, niter);
     break;
   case 7:
-    return pte_closure_ideal<7>(eoss, Volume, TotalSIE, ComponentMasses,
-                                ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_ideal<7>(eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes,
+                                ComponentEnergies, lambdas, niter);
     break;
   case 8:
-    return pte_closure_ideal<8>(eoss, Volume, TotalSIE, ComponentMasses,
-                                ComponentVolumes, ComponentEnergies, lambdas, niter);
+    return pte_closure_ideal<8>(eoss, Volume, TotalSIE, ComponentMasses, ComponentVolumes,
+                                ComponentEnergies, lambdas, niter);
     break;
   }
   return false;

--- a/singularity-eos/eos/eos.hpp
+++ b/singularity-eos/eos/eos.hpp
@@ -26,16 +26,16 @@
 #include <limits>
 #include <utility>
 
-#include <singularity-eos/eos/eos_variant.hpp>
 #include <ports-of-call/portability.hpp>
+#include <singularity-eos/eos/eos_variant.hpp>
 
 #ifdef SPINER_USE_HDF
 #include <fast-math/logs.hpp>
+#include <hdf5.h>
+#include <hdf5_hl.h>
 #include <root-finding-1d/root_finding.hpp>
 #include <spiner/databox.hpp>
 #include <spiner/spiner_types.hpp>
-#include <hdf5.h>
-#include <hdf5_hl.h>
 #endif // SPINER_USE_HDF
 
 #include <singularity-eos/base/constants.hpp>
@@ -47,8 +47,9 @@
 
 namespace singularity {
 
-template <typename T> class ScaledEOS {
-public:
+template <typename T>
+class ScaledEOS {
+ public:
   // move semantics ensures dynamic memory comes along for the ride
   ScaledEOS(T &&t, const Real scale)
       : t_(std::forward<T>(t)), scale_(scale), inv_scale_(1. / scale) {}
@@ -60,71 +61,61 @@ public:
   PORTABLE_FUNCTION
   Real TemperatureFromDensityInternalEnergy(const Real rho, const Real sie,
                                             Real *lambda = nullptr) const {
-    return t_.TemperatureFromDensityInternalEnergy(scale_ * rho,
-                                                   inv_scale_ * sie, lambda);
+    return t_.TemperatureFromDensityInternalEnergy(scale_ * rho, inv_scale_ * sie,
+                                                   lambda);
   }
   PORTABLE_FUNCTION
-  Real InternalEnergyFromDensityTemperature(const Real rho,
-                                            const Real temperature,
+  Real InternalEnergyFromDensityTemperature(const Real rho, const Real temperature,
                                             Real *lambda = nullptr) const {
-    Real energy =
-        t_.InternalEnergyFromDensityTemperature(rho, temperature, lambda);
+    Real energy = t_.InternalEnergyFromDensityTemperature(rho, temperature, lambda);
     return scale_ * energy;
   }
   PORTABLE_FUNCTION
   Real PressureFromDensityInternalEnergy(const Real rho, const Real sie,
                                          Real *lambda = nullptr) const {
-    return t_.PressureFromDensityInternalEnergy(scale_ * rho, inv_scale_ * sie,
-                                                lambda);
+    return t_.PressureFromDensityInternalEnergy(scale_ * rho, inv_scale_ * sie, lambda);
   }
   PORTABLE_FUNCTION
   Real SpecificHeatFromDensityInternalEnergy(const Real rho, const Real sie,
                                              Real *lambda = nullptr) const {
-    return t_.SpecificHeatFromDensityInternalEnergy(scale_ * rho,
-                                                    inv_scale_ * sie, lambda);
+    return t_.SpecificHeatFromDensityInternalEnergy(scale_ * rho, inv_scale_ * sie,
+                                                    lambda);
   }
   PORTABLE_FUNCTION
   Real BulkModulusFromDensityInternalEnergy(const Real rho, const Real sie,
                                             Real *lambda = nullptr) const {
-    return t_.BulkModulusFromDensityInternalEnergy(scale_ * rho,
-                                                   inv_scale_ * sie, lambda);
+    return t_.BulkModulusFromDensityInternalEnergy(scale_ * rho, inv_scale_ * sie,
+                                                   lambda);
   }
   PORTABLE_FUNCTION
   Real GruneisenParamFromDensityInternalEnergy(const Real rho, const Real sie,
                                                Real *lambda = nullptr) const {
-    return t_.GruneisenParamFromDensityInternalEnergy(scale_ * rho,
-                                                      inv_scale_ * sie, lambda);
+    return t_.GruneisenParamFromDensityInternalEnergy(scale_ * rho, inv_scale_ * sie,
+                                                      lambda);
   }
   PORTABLE_FUNCTION
   Real PressureFromDensityTemperature(const Real rho, const Real temperature,
                                       Real *lambda = nullptr) const {
-    return t_.PressureFromDensityInternalEnergy(scale_ * rho, temperature,
-                                                lambda);
+    return t_.PressureFromDensityInternalEnergy(scale_ * rho, temperature, lambda);
   }
   PORTABLE_FUNCTION
-  Real SpecificHeatFromDensityTemperature(const Real rho,
-                                          const Real temperature,
+  Real SpecificHeatFromDensityTemperature(const Real rho, const Real temperature,
                                           Real *lambda = nullptr) const {
-    return t_.SpecificHeatFromDensityTemperature(scale_ * rho, temperature,
-                                                 lambda);
+    return t_.SpecificHeatFromDensityTemperature(scale_ * rho, temperature, lambda);
   }
   PORTABLE_FUNCTION
   Real BulkModulusFromDensityTemperature(const Real rho, const Real temperature,
                                          Real *lambda = nullptr) const {
-    return t_.BulkModulusFromDensityTemperature(scale_ * rho, temperature,
-                                                lambda);
+    return t_.BulkModulusFromDensityTemperature(scale_ * rho, temperature, lambda);
   }
   PORTABLE_FUNCTION
-  Real GruneisenParamFromDensityTemperature(const Real rho,
-                                            const Real temperature,
+  Real GruneisenParamFromDensityTemperature(const Real rho, const Real temperature,
                                             Real *lambda = nullptr) const {
-    return t_.GruneisenParamFromDensityTemperature(scale_ * rho, temperature,
-                                                   lambda);
+    return t_.GruneisenParamFromDensityTemperature(scale_ * rho, temperature, lambda);
   }
   PORTABLE_FUNCTION
-  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv,
-               Real &bmod, const unsigned long output,
-               Real *lambda = nullptr) const {
+  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, Real &bmod,
+               const unsigned long output, Real *lambda = nullptr) const {
     Real srho, senergy;
     switch (t_.PreferredInput()) {
     case thermalqs::density | thermalqs::temperature:
@@ -143,11 +134,10 @@ public:
   }
 
   PORTABLE_FUNCTION
-  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
-                              Real &cv, Real &bmod, Real &dpde, Real &dvdt,
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const {
-    t_.ValuesAtReferenceState(rho, temp, sie, press, cv, bmod, dpde, dvdt,
-                              lambda);
+    t_.ValuesAtReferenceState(rho, temp, sie, press, cv, bmod, dpde, dvdt, lambda);
     rho *= inv_scale_;
     sie *= scale_;
   }
@@ -164,33 +154,32 @@ public:
   }
   PORTABLE_FUNCTION
   void DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                            Real *lambda, Real &rho,
-                                            Real &sie) const {
+                                            Real *lambda, Real &rho, Real &sie) const {
     t_.DensityEnergyFromPressureTemperature(press, temp, lambda, rho, sie);
     rho = rho * inv_scale_;
     sie = sie * scale_;
   }
 
   PORTABLE_FUNCTION
-  void PTofRE(const Real rho, const Real sie, Real *lambda, Real &press,
-              Real &temp, Real &dpdr, Real &dpde, Real &dtdr,
-              Real &dtde) const {
-    t_.PTofRE(scale_ * rho, inv_scale_ * sie, lambda, press, temp, dpdr, dpde,
-              dtdr, dtde);
+  void PTofRE(const Real rho, const Real sie, Real *lambda, Real &press, Real &temp,
+              Real &dpdr, Real &dpde, Real &dtdr, Real &dtde) const {
+    t_.PTofRE(scale_ * rho, inv_scale_ * sie, lambda, press, temp, dpdr, dpde, dtdr,
+              dtde);
     dpdr = dpdr * scale_;
     dtdr = dtdr * scale_;
     dpde = dpde * inv_scale_;
     dtde = dtde * inv_scale_;
   }
 
-private:
+ private:
   T t_;
   double scale_;
   double inv_scale_;
 };
 
-template <typename T> class ShiftedEOS {
-public:
+template <typename T>
+class ShiftedEOS {
+ public:
   // move semantics ensures dynamic memory comes along for the ride
   ShiftedEOS(T &&t, const Real shift) : t_(std::forward<T>(t)), shift_(shift) {}
   ShiftedEOS() = default;
@@ -204,11 +193,9 @@ public:
     return t_.TemperatureFromDensityInternalEnergy(rho, sie - shift_, lambda);
   }
   PORTABLE_FUNCTION
-  Real InternalEnergyFromDensityTemperature(const Real rho,
-                                            const Real temperature,
+  Real InternalEnergyFromDensityTemperature(const Real rho, const Real temperature,
                                             Real *lambda = nullptr) const {
-    Real energy =
-        t_.InternalEnergyFromDensityTemperature(rho, temperature, lambda);
+    Real energy = t_.InternalEnergyFromDensityTemperature(rho, temperature, lambda);
     return energy + shift_;
   }
   PORTABLE_FUNCTION
@@ -229,8 +216,7 @@ public:
   PORTABLE_FUNCTION
   Real GruneisenParamFromDensityInternalEnergy(const Real rho, const Real sie,
                                                Real *lambda = nullptr) const {
-    return t_.GruneisenParamFromDensityInternalEnergy(rho, sie - shift_,
-                                                      lambda);
+    return t_.GruneisenParamFromDensityInternalEnergy(rho, sie - shift_, lambda);
   }
   PORTABLE_FUNCTION
   Real PressureFromDensityTemperature(const Real rho, const Real temperature,
@@ -238,8 +224,7 @@ public:
     return t_.PressureFromDensityInternalEnergy(rho, temperature, lambda);
   }
   PORTABLE_FUNCTION
-  Real SpecificHeatFromDensityTemperature(const Real rho,
-                                          const Real temperature,
+  Real SpecificHeatFromDensityTemperature(const Real rho, const Real temperature,
                                           Real *lambda = nullptr) const {
     return t_.SpecificHeatFromDensityTemperature(rho, temperature, lambda);
   }
@@ -249,15 +234,13 @@ public:
     return t_.BulkModulusFromDensityTemperature(rho, temperature, lambda);
   }
   PORTABLE_FUNCTION
-  Real GruneisenParamFromDensityTemperature(const Real rho,
-                                            const Real temperature,
+  Real GruneisenParamFromDensityTemperature(const Real rho, const Real temperature,
                                             Real *lambda = nullptr) const {
     return t_.GruneisenParamFromDensityTemperature(rho, temperature, lambda);
   }
   PORTABLE_FUNCTION
-  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv,
-               Real &bmod, const unsigned long output,
-               Real *lambda = nullptr) const {
+  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, Real &bmod,
+               const unsigned long output, Real *lambda = nullptr) const {
     Real senergy;
     switch (t_.PreferredInput()) {
     case thermalqs::density | thermalqs::temperature:
@@ -285,34 +268,32 @@ public:
   }
   PORTABLE_FUNCTION
   void DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                            Real *lambda, Real &rho,
-                                            Real &sie) const {
+                                            Real *lambda, Real &rho, Real &sie) const {
     t_.DensityEnergyFromPressureTemperature(press, temp, lambda, rho, sie);
     sie = sie + shift_;
   }
 
   PORTABLE_FUNCTION
-  void PTofRE(const Real rho, const Real sie, Real *lambda, Real &press,
-              Real &temp, Real &dpdr, Real &dpde, Real &dtdr,
-              Real &dtde) const {
+  void PTofRE(const Real rho, const Real sie, Real *lambda, Real &press, Real &temp,
+              Real &dpdr, Real &dpde, Real &dtdr, Real &dtde) const {
     t_.PTofRE(rho, sie - shift_, lambda, press, temp, dpdr, dpde, dtdr, dtde);
   }
   PORTABLE_FUNCTION
-  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
-                              Real &cv, Real &bmod, Real &dpde, Real &dvdt,
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const {
-    t_.ValuesAtReferenceState(rho, temp, sie, press, cv, bmod, dpde, dvdt,
-                              lambda);
+    t_.ValuesAtReferenceState(rho, temp, sie, press, cv, bmod, dpde, dvdt, lambda);
     sie += shift_;
   }
 
-private:
+ private:
   T t_;
   double shift_;
 };
 
-template <typename T> class RelativisticEOS {
-public:
+template <typename T>
+class RelativisticEOS {
+ public:
   // move semantics ensures dynamic memory comes along for the ride
   RelativisticEOS(T &&t, const Real cl)
       : t_(std::forward<T>(t)), cl_(cl) // speed of light, units arbitrary
@@ -330,8 +311,7 @@ public:
     return t_.TemperatureFromDensityInternalEnergy(rho, sie, lambda);
   }
   PORTABLE_FUNCTION
-  Real InternalEnergyFromDensityTemperature(const Real rho,
-                                            const Real temperature,
+  Real InternalEnergyFromDensityTemperature(const Real rho, const Real temperature,
                                             Real *lambda = nullptr) const {
     return t_.InternalEnergyFromDensityTemperature(rho, temperature, lambda);
   }
@@ -364,8 +344,7 @@ public:
     return t_.PressureFromDensityTemperature(rho, temperature, lambda);
   }
   PORTABLE_FUNCTION
-  Real SpecificHeatFromDensityTemperature(const Real rho,
-                                          const Real temperature,
+  Real SpecificHeatFromDensityTemperature(const Real rho, const Real temperature,
                                           Real *lambda = nullptr) const {
     return t_.SpecificHeatFromDensityTemperature(rho, temperature, lambda);
   }
@@ -379,15 +358,13 @@ public:
     return std::max(0.0, bmod / (std::abs(h) + EPS));
   }
   PORTABLE_FUNCTION
-  Real GruneisenParamFromDensityTemperature(const Real rho,
-                                            const Real temperature,
+  Real GruneisenParamFromDensityTemperature(const Real rho, const Real temperature,
                                             Real *lambda = nullptr) const {
     return t_.GruneisenParamFromDensityTemperature(rho, temperature, lambda);
   }
   PORTABLE_FUNCTION
-  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv,
-               Real &bmod, const unsigned long output,
-               Real *lambda = nullptr) const {
+  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, Real &bmod,
+               const unsigned long output, Real *lambda = nullptr) const {
     t_.FillEos(rho, temp, energy, press, cv, bmod, output, lambda);
   }
 
@@ -400,32 +377,29 @@ public:
   PORTABLE_FUNCTION void PrintParams() const { t_.PrintParams(); }
   PORTABLE_FUNCTION
   void DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                            Real *lambda, Real &rho,
-                                            Real &sie) const {
+                                            Real *lambda, Real &rho, Real &sie) const {
     t_.DensityEnergyFromPressureTemperature(press, temp, lambda, rho, sie);
   }
 
   PORTABLE_FUNCTION
-  void PTofRE(const Real rho, const Real sie, Real *lambda, Real &press,
-              Real &temp, Real &dpdr, Real &dpde, Real &dtdr,
-              Real &dtde) const {
+  void PTofRE(const Real rho, const Real sie, Real *lambda, Real &press, Real &temp,
+              Real &dpdr, Real &dpde, Real &dtdr, Real &dtde) const {
     t_.PTofRE(rho, sie, lambda, press, temp, dpdr, dpde, dtdr, dtde);
   }
   PORTABLE_FUNCTION
-  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
-                              Real &cv, Real &bmod, Real &dpde, Real &dvdt,
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const {
-    t_.ValuesAtReferenceState(rho, temp, sie, press, cv, bmod, dpde, dvdt,
-                              lambda);
+    t_.ValuesAtReferenceState(rho, temp, sie, press, cv, bmod, dpde, dvdt, lambda);
   }
 
-private:
+ private:
   T t_;
   Real cl_, cl2_;
 };
 
 class IdealGas {
-public:
+ public:
   IdealGas() = default;
   PORTABLE_INLINE_FUNCTION IdealGas(Real gm1, Real Cv)
       : _Cv(Cv), _gm1(gm1), _rho0(_P0 / (_gm1 * _Cv * _T0)), _sie0(_Cv * _T0),
@@ -437,29 +411,31 @@ public:
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real InternalEnergyFromDensityTemperature(
       const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(
-      const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityTemperature(const Real rho,
+                                                        const Real temperature,
+                                                        Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(const Real rho, const Real sie,
+                                                           Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(const Real rho,
+                                                            const Real temperature,
+                                                            Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real SpecificHeatFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(const Real rho,
+                                                           const Real temperature,
+                                                           Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real BulkModulusFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real GruneisenParamFromDensityTemperature(
       const Real rho, const Real temperature, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real GruneisenParamFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy,
-                                 Real &press, Real &cv, Real &bmod,
-                                 const unsigned long output,
+  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy, Real &press,
+                                 Real &cv, Real &bmod, const unsigned long output,
                                  Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
-                              Real &cv, Real &bmod, Real &dpde, Real &dvdt,
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const;
 
   PORTABLE_INLINE_FUNCTION
@@ -470,13 +446,12 @@ public:
   }
   PORTABLE_FUNCTION void DensityEnergyFromPressureTemperature(const Real press,
                                                               const Real temp,
-                                                              Real *lambda,
-                                                              Real &rho,
+                                                              Real *lambda, Real &rho,
                                                               Real &sie) const;
   inline void Finalize() {}
   static std::string EosType() { return std::string("IdealGas"); }
 
-private:
+ private:
   Real _Cv, _gm1;
   // reference values
   Real _rho0, _sie0, _bmod0, _dpde0, _dvdt0;
@@ -491,62 +466,60 @@ private:
 // the Gruneisen EOS which should correspond to eostype(3) in xRAGE and
 // /[...]/eos/gruneisen in FLAG
 class Gruneisen {
-public:
+ public:
   Gruneisen() = default;
   PORTABLE_INLINE_FUNCTION
-  Gruneisen(const Real C0, const Real s1, const Real s2, const Real s3,
-            const Real G0, const Real b, const Real rho0, const Real T0,
-            const Real P0, const Real Cv)
-      : _C0(C0), _s1(s1), _s2(s2), _s3(s3), _G0(G0), _b(b), _rho0(rho0),
-        _T0(T0), _P0(P0), _Cv(Cv) {}
+  Gruneisen(const Real C0, const Real s1, const Real s2, const Real s3, const Real G0,
+            const Real b, const Real rho0, const Real T0, const Real P0, const Real Cv)
+      : _C0(C0), _s1(s1), _s2(s2), _s3(s3), _G0(G0), _b(b), _rho0(rho0), _T0(T0), _P0(P0),
+        _Cv(Cv) {}
   Gruneisen GetOnDevice() { return *this; }
   PORTABLE_FUNCTION Real TemperatureFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real InternalEnergyFromDensityTemperature(
       const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(
-      const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(
-      const Real rho, const Real temperatummmmmmre,
-      Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityTemperature(const Real rho,
+                                                        const Real temperature,
+                                                        Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(const Real rho, const Real sie,
+                                                           Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(const Real rho,
+                                                            const Real temperatummmmmmre,
+                                                            Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real SpecificHeatFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(const Real rho,
+                                                           const Real temperature,
+                                                           Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real BulkModulusFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real GruneisenParamFromDensityTemperature(
       const Real rho, const Real temperature, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real GruneisenParamFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy,
-                                 Real &press, Real &cv, Real &bmod,
-                                 const unsigned long output,
+  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy, Real &press,
+                                 Real &cv, Real &bmod, const unsigned long output,
                                  Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
-                              Real &cv, Real &bmod, Real &dpde, Real &dvdt,
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const;
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
   PORTABLE_FUNCTION void PrintParams() const {
     static constexpr char s1[]{"Gruneisen Params: "};
-    printf(
-        "%sC0:%e s1:%e s2:%e\ns3:%e G0:%e b:%e\nrho0:%e T0:%e P0:%e\nCv:%E\n",
-        s1, _C0, _s1, _s2, _s3, _G0, _b, _rho0, _T0, _P0, _Cv);
+    printf("%sC0:%e s1:%e s2:%e\ns3:%e G0:%e b:%e\nrho0:%e T0:%e P0:%e\nCv:%E\n", s1, _C0,
+           _s1, _s2, _s3, _G0, _b, _rho0, _T0, _P0, _Cv);
   }
   PORTABLE_FUNCTION void DensityEnergyFromPressureTemperature(const Real press,
                                                               const Real temp,
-                                                              Real *lambda,
-                                                              Real &rho,
+                                                              Real *lambda, Real &rho,
                                                               Real &sie) const;
   inline void Finalize() {}
   static std::string EosType() { return std::string("Gruneisen"); }
 
-private:
+ private:
   Real _C0, _s1, _s2, _s3, _G0, _b, _rho0, _T0, _P0, _Cv;
   // static constexpr const char _eos_type[] = {"Gruneisen"};
   PORTABLE_INLINE_FUNCTION
@@ -560,59 +533,59 @@ private:
 // COMMENT: This is meant to be an implementation of the "standard" JWL as
 // implemented in xRAGE for eostype(1).  It does not include any energy shifting
 class JWL {
-public:
+ public:
   JWL() = default;
-  PORTABLE_INLINE_FUNCTION JWL(const Real A, const Real B, const Real R1,
-                               const Real R2, const Real w, const Real rho0,
-                               const Real Cv)
+  PORTABLE_INLINE_FUNCTION JWL(const Real A, const Real B, const Real R1, const Real R2,
+                               const Real w, const Real rho0, const Real Cv)
       : _A(A), _B(B), _R1(R1), _R2(R2), _w(w), _rho0(rho0), _Cv(Cv) {}
   JWL GetOnDevice() { return *this; }
   PORTABLE_FUNCTION Real TemperatureFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real InternalEnergyFromDensityTemperature(
       const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(
-      const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityTemperature(const Real rho,
+                                                        const Real temperature,
+                                                        Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(const Real rho, const Real sie,
+                                                           Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(const Real rho,
+                                                            const Real temperature,
+                                                            Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real SpecificHeatFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(const Real rho,
+                                                           const Real temperature,
+                                                           Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real BulkModulusFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real GruneisenParamFromDensityTemperature(
       const Real rho, const Real temperature, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real GruneisenParamFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy,
-                                 Real &press, Real &cv, Real &bmod,
-                                 const unsigned long output,
+  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy, Real &press,
+                                 Real &cv, Real &bmod, const unsigned long output,
                                  Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   PORTABLE_FUNCTION
-  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
-                              Real &cv, Real &bmod, Real &dpde, Real &dvdt,
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const;
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
   PORTABLE_FUNCTION void PrintParams() const {
     static constexpr char s1[]{"JWL Params: "};
-    printf("%sA:%e B:%e R1: %e\nR2:%e w:%e rho0:%e\nCv:%e\n", s1, _A, _B, _R1,
-           _R2, _w, _rho0, _Cv);
+    printf("%sA:%e B:%e R1: %e\nR2:%e w:%e rho0:%e\nCv:%e\n", s1, _A, _B, _R1, _R2, _w,
+           _rho0, _Cv);
   }
   PORTABLE_FUNCTION void DensityEnergyFromPressureTemperature(const Real press,
                                                               const Real temp,
-                                                              Real *lambda,
-                                                              Real &rho,
+                                                              Real *lambda, Real &rho,
                                                               Real &sie) const;
   inline void Finalize() {}
   static std::string EosType() { return std::string("JWL"); }
 
-private:
+ private:
   Real _A, _B, _R1, _R2, _w, _rho0, _Cv;
   PORTABLE_INLINE_FUNCTION Real ReferenceEnergy(const Real rho) const;
   PORTABLE_INLINE_FUNCTION Real ReferencePressure(const Real rho) const;
@@ -622,47 +595,48 @@ private:
 };
 
 class DavisReactants {
-public:
+ public:
   DavisReactants() = default;
   PORTABLE_INLINE_FUNCTION
   DavisReactants(const Real rho0, const Real e0, const Real P0, const Real T0,
-                 const Real A, const Real B, const Real C, const Real G0,
-                 const Real Z, const Real alpha, const Real Cv0)
-      : _rho0(rho0), _e0(e0), _P0(P0), _T0(T0), _A(A), _B(B), _C(C), _G0(G0),
-        _Z(Z), _alpha(alpha), _Cv0(Cv0) {}
+                 const Real A, const Real B, const Real C, const Real G0, const Real Z,
+                 const Real alpha, const Real Cv0)
+      : _rho0(rho0), _e0(e0), _P0(P0), _T0(T0), _A(A), _B(B), _C(C), _G0(G0), _Z(Z),
+        _alpha(alpha), _Cv0(Cv0) {}
   DavisReactants GetOnDevice() { return *this; }
   PORTABLE_FUNCTION Real TemperatureFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real InternalEnergyFromDensityTemperature(
       const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(
-      const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityTemperature(const Real rho,
+                                                        const Real temperature,
+                                                        Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(const Real rho, const Real sie,
+                                                           Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(const Real rho,
+                                                            const Real temperature,
+                                                            Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real SpecificHeatFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(const Real rho,
+                                                           const Real temperature,
+                                                           Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real BulkModulusFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real GruneisenParamFromDensityTemperature(
       const Real rho, const Real temperature, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real GruneisenParamFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy,
-                                 Real &press, Real &cv, Real &bmod,
-                                 const unsigned long output,
+  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy, Real &press,
+                                 Real &cv, Real &bmod, const unsigned long output,
                                  Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
-                              Real &cv, Real &bmod, Real &dpde, Real &dvdt,
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const;
   PORTABLE_FUNCTION void DensityEnergyFromPressureTemperature(const Real press,
                                                               const Real temp,
-                                                              Real *lambda,
-                                                              Real &rho,
+                                                              Real *lambda, Real &rho,
                                                               Real &sie) const;
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
@@ -676,7 +650,7 @@ public:
   void inline Finalize() {}
   static std::string EosType() { return std::string("DavisReactants"); }
 
-private:
+ private:
   Real _rho0, _e0, _P0, _T0, _A, _B, _C, _G0, _Z, _alpha, _Cv0;
   // static constexpr const char _eos_type[] = "DavisReactants";
   static constexpr unsigned long _preferred_input =
@@ -688,27 +662,30 @@ private:
 };
 
 class DavisProducts {
-public:
+ public:
   DavisProducts() = default;
   PORTABLE_INLINE_FUNCTION
-  DavisProducts(const Real a, const Real b, const Real k, const Real n,
-                const Real vc, const Real pc, const Real Cv, const Real E0)
+  DavisProducts(const Real a, const Real b, const Real k, const Real n, const Real vc,
+                const Real pc, const Real Cv, const Real E0)
       : _a(a), _b(b), _k(k), _n(n), _vc(vc), _pc(pc), _Cv(Cv), _E0(E0) {}
   DavisProducts GetOnDevice() { return *this; }
   PORTABLE_FUNCTION Real TemperatureFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real InternalEnergyFromDensityTemperature(
       const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(
-      const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityTemperature(const Real rho,
+                                                        const Real temperature,
+                                                        Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(const Real rho, const Real sie,
+                                                           Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(const Real rho,
+                                                            const Real temperature,
+                                                            Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real SpecificHeatFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(const Real rho,
+                                                           const Real temperature,
+                                                           Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real BulkModulusFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real GruneisenParamFromDensityTemperature(
@@ -717,16 +694,14 @@ public:
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION void DensityEnergyFromPressureTemperature(const Real press,
                                                               const Real temp,
-                                                              Real *lambda,
-                                                              Real &rho,
+                                                              Real *lambda, Real &rho,
                                                               Real &sie) const;
-  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy,
-                                 Real &press, Real &cv, Real &bmod,
-                                 const unsigned long output,
+  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy, Real &press,
+                                 Real &cv, Real &bmod, const unsigned long output,
                                  Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
-                              Real &cv, Real &bmod, Real &dpde, Real &dvdt,
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const;
   // PORTABLE_FUNCTION void PTofRE(const Real rho, const Real sie, Real *
   // lambda, Real& press, Real& temp, Real & dpdr, Real & dpde, Real & dtdr,
@@ -736,13 +711,13 @@ public:
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
   PORTABLE_FUNCTION void PrintParams() const {
     static constexpr char s1[]{"DavisProducts Params: "};
-    printf("%sa:%e b:%e k:%e\nn:%e vc:%e pc:%e\nCv:%e E0:%e\n", s1, _a, _b, _k,
-           _n, _vc, _pc, _Cv, _E0);
+    printf("%sa:%e b:%e k:%e\nn:%e vc:%e pc:%e\nCv:%e E0:%e\n", s1, _a, _b, _k, _n, _vc,
+           _pc, _Cv, _E0);
   }
   inline void Finalize() {}
   static std::string EosType() { return std::string("DavisProducts"); }
 
-private:
+ private:
   Real _a, _b, _k, _n, _vc, _pc, _Cv, _E0;
   // static constexpr const char _eos_type[] = "DavisProducts";
   static constexpr const unsigned long _preferred_input =
@@ -767,7 +742,7 @@ private:
   we use log-linear extrapolation.
 */
 class SpinerEOSDependsRhoT {
-public:
+ public:
   // A weakly typed index map for lambdas
   struct Lambda {
     enum Index { lRho = 0, lT = 1 };
@@ -775,8 +750,7 @@ public:
 
   SpinerEOSDependsRhoT(const std::string &filename, int matid,
                        bool reproduciblity_mode = false);
-  SpinerEOSDependsRhoT(const std::string &filename,
-                       const std::string &materialName,
+  SpinerEOSDependsRhoT(const std::string &filename, const std::string &materialName,
                        bool reproducibility_mode = false);
   PORTABLE_INLINE_FUNCTION
   SpinerEOSDependsRhoT() : memoryStatus_(DataStatus::Deallocated) {}
@@ -787,8 +761,7 @@ public:
   Real TemperatureFromDensityInternalEnergy(const Real rho, const Real sie,
                                             Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  Real InternalEnergyFromDensityTemperature(const Real rho,
-                                            const Real temperature,
+  Real InternalEnergyFromDensityTemperature(const Real rho, const Real temperature,
                                             Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   Real PressureFromDensityTemperature(const Real rho, const Real temperature,
@@ -797,8 +770,7 @@ public:
   Real PressureFromDensityInternalEnergy(const Real rho, const Real sie,
                                          Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  Real SpecificHeatFromDensityTemperature(const Real rho,
-                                          const Real temperature,
+  Real SpecificHeatFromDensityTemperature(const Real rho, const Real temperature,
                                           Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   Real SpecificHeatFromDensityInternalEnergy(const Real rho, const Real sie,
@@ -810,27 +782,24 @@ public:
   Real BulkModulusFromDensityInternalEnergy(const Real rho, const Real sie,
                                             Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  Real GruneisenParamFromDensityTemperature(const Real rho,
-                                            const Real temperature,
+  Real GruneisenParamFromDensityTemperature(const Real rho, const Real temperature,
                                             Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   Real GruneisenParamFromDensityInternalEnergy(const Real rho, const Real sie,
                                                Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   void DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                            Real *lambda, Real &rho,
-                                            Real &sie) const;
+                                            Real *lambda, Real &rho, Real &sie) const;
   PORTABLE_FUNCTION
-  void PTofRE(const Real rho, const Real sie, Real *lambda, Real &press,
-              Real &temp, Real &dpdr, Real &dpde, Real &dtdr, Real &dtde) const;
+  void PTofRE(const Real rho, const Real sie, Real *lambda, Real &press, Real &temp,
+              Real &dpdr, Real &dpde, Real &dtdr, Real &dtde) const;
   PORTABLE_FUNCTION
-  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv,
-               Real &bmod, const unsigned long output,
-               Real *lambda = nullptr) const;
+  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, Real &bmod,
+               const unsigned long output, Real *lambda = nullptr) const;
 
   PORTABLE_FUNCTION
-  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
-                              Real &cv, Real &bmod, Real &dpde, Real &dvdt,
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const;
 
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
@@ -847,32 +816,29 @@ public:
     static constexpr char s3[]{"EOS file   = "};
     static constexpr char s4[]{"EOS mat ID = "};
     static constexpr char s5[]{"EOS name   = "};
-    printf("%s\n\t%s\n\t%s%s\n\t%s%i\n\t%s%s\n", s1, s2, s3, filename_, s4,
-           matid_, s5, materialName_);
+    printf("%s\n\t%s\n\t%s%s\n\t%s%i\n\t%s%s\n", s1, s2, s3, filename_, s4, matid_, s5,
+           materialName_);
     return;
   }
-  static PORTABLE_FORCEINLINE_FUNCTION
-  int nlambda() { return _n_lambda; }
+  static PORTABLE_FORCEINLINE_FUNCTION int nlambda() { return _n_lambda; }
   inline RootFinding1D::Status rootStatus() const { return status_; }
   inline TableStatus tableStatus() const { return whereAmI_; }
   RootFinding1D::RootCounts counts;
   void Finalize();
   static std::string EosType() { return std::string("SpinerEOSDependsRhoT"); }
 
-private:
+ private:
   herr_t loadDataboxes_(const std::string &matid_str, hid_t file, hid_t lTGroup,
                         hid_t coldGroup);
   void fixBulkModulus_();
   void setlTColdCrit_();
 
-  static PORTABLE_FORCEINLINE_FUNCTION Real
-  toLog_(const Real x, const Real offset) {
+  static PORTABLE_FORCEINLINE_FUNCTION Real toLog_(const Real x, const Real offset) {
     // return std::log10(x + offset + EPS);
     // return std::log10(std::abs(std::max(x,-offset) + offset)+EPS);
     return Math::log10(std::abs(std::max(x, -offset) + offset) + EPS);
   }
-  static PORTABLE_FORCEINLINE_FUNCTION Real
-  fromLog_(const Real lx, const Real offset) {
+  static PORTABLE_FORCEINLINE_FUNCTION Real fromLog_(const Real lx, const Real offset) {
     return std::pow(10., lx) - offset;
   }
   PORTABLE_INLINE_FUNCTION Real __attribute__((always_inline))
@@ -905,20 +871,19 @@ private:
   Real lRhoFromPlT_(const Real P, const Real lT, TableStatus &whereAmI,
                     Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  void getLogsRhoT_(const Real rho, const Real temperature, Real &lRho,
-                    Real &lT, Real *lambda = nullptr) const;
+  void getLogsRhoT_(const Real rho, const Real temperature, Real &lRho, Real &lT,
+                    Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   Real sieFromlRhoTlT_(const Real lRho, const Real T, const Real lT,
                        const TableStatus &whereAmI) const;
   PORTABLE_FUNCTION
-  Real PFromRholRhoTlT_(const Real rho, const Real lRho, const Real T,
-                        const Real lT, const TableStatus &whereAmI) const;
+  Real PFromRholRhoTlT_(const Real rho, const Real lRho, const Real T, const Real lT,
+                        const TableStatus &whereAmI) const;
   PORTABLE_FUNCTION
-  Real CvFromlRholT_(const Real lRho, const Real lT,
-                     const TableStatus &whereAmI) const;
+  Real CvFromlRholT_(const Real lRho, const Real lT, const TableStatus &whereAmI) const;
   PORTABLE_FUNCTION
-  Real bModFromRholRhoTlT_(const Real rho, const Real lRho, const Real T,
-                           const Real lT, const TableStatus &whereAmI) const;
+  Real bModFromRholRhoTlT_(const Real rho, const Real lRho, const Real T, const Real lT,
+                           const TableStatus &whereAmI) const;
   PORTABLE_FUNCTION
   TableStatus getLocDependsRhoSie_(const Real lRho, const Real sie) const;
   PORTABLE_FUNCTION
@@ -930,8 +895,7 @@ private:
       thermalqs::density | thermalqs::temperature;
   // static constexpr const char _eos_type[] {"SpinerEOSDependsRhoT"};
   static constexpr const int numDataBoxes_ = 12;
-  Spiner::DataBox P_, sie_, bMod_, dPdRho_, dPdE_, dTdRho_, dTdE_, dEdRho_,
-      dEdT_;
+  Spiner::DataBox P_, sie_, bMod_, dPdRho_, dPdE_, dTdRho_, dTdE_, dEdRho_, dEdT_;
   Spiner::DataBox PMax_, sielTMax_, dEdTMax_, gm1Max_;
   Spiner::DataBox lTColdCrit_;
   Spiner::DataBox PCold_, sieCold_, bModCold_;
@@ -976,7 +940,7 @@ private:
   mitigated by Ye and (1-Ye) to control how important each term is.
  */
 class SpinerEOSDependsRhoSie {
-public:
+ public:
   struct SP5Tables {
     Spiner::DataBox P, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho;
   };
@@ -984,8 +948,7 @@ public:
       : memoryStatus_(DataStatus::Deallocated) {}
   SpinerEOSDependsRhoSie(const std::string &filename, int matid,
                          bool reproducibility_mode = false);
-  SpinerEOSDependsRhoSie(const std::string &filename,
-                         const std::string &materialName,
+  SpinerEOSDependsRhoSie(const std::string &filename, const std::string &materialName,
                          bool reproducibility_mode = false);
   SpinerEOSDependsRhoSie GetOnDevice();
 
@@ -1023,18 +986,16 @@ public:
                                                Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   void DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                            Real *lambda, Real &rho,
-                                            Real &sie) const;
+                                            Real *lambda, Real &rho, Real &sie) const;
   PORTABLE_FUNCTION
-  void PTofRE(const Real rho, const Real sie, Real *lambda, Real &press,
-              Real &temp, Real &dpdr, Real &dpde, Real &dtdr, Real &dtde) const;
+  void PTofRE(const Real rho, const Real sie, Real *lambda, Real &press, Real &temp,
+              Real &dpdr, Real &dpde, Real &dtdr, Real &dtde) const;
   PORTABLE_FUNCTION
-  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv,
-               Real &bmod, const unsigned long output,
-               Real *lambda = nullptr) const;
+  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, Real &bmod,
+               const unsigned long output, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
-                              Real &cv, Real &bmod, Real &dpde, Real &dvdt,
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const;
 
   PORTABLE_FUNCTION
@@ -1052,16 +1013,15 @@ public:
   Real sieMin() const { return fromLog_(T_.range(0).min(), lEOffset_); }
   Real sieMax() const { return fromLog_(T_.range(0).max(), lEOffset_); }
 
-  static PORTABLE_FORCEINLINE_FUNCTION
-  int nlambda() { return _n_lambda; }
+  static PORTABLE_FORCEINLINE_FUNCTION int nlambda() { return _n_lambda; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     static constexpr char s1[]{"SpinerEOS Parameters:"};
     static constexpr char s2[]{"depends on log_10(rho) and log_10(sie)"};
     static constexpr char s3[]{"EOS file   = "};
     static constexpr char s4[]{"EOS mat ID = "};
     static constexpr char s5[]{"EOS name   = "};
-    printf("%s\n\t%s\n\t%s%s\n\t%s%i\n\t%s%s\n", s1, s2, s3, filename_, s4,
-           matid_, s5, materialName_);
+    printf("%s\n\t%s\n\t%s%s\n\t%s%i\n\t%s%s\n", s1, s2, s3, filename_, s4, matid_, s5,
+           materialName_);
     return;
   }
   RootFinding1D::Status rootStatus() const { return status_; }
@@ -1069,18 +1029,16 @@ public:
   static std::string EosType() { return std::string("SpinerEOSDependsRhoSie"); }
   void Finalize();
 
-private:
+ private:
   herr_t loadDataboxes_(const std::string &matid_str, hid_t file, hid_t lTGroup,
                         hid_t lEGroup);
   void calcBMod_(SP5Tables &tables);
 
-  static PORTABLE_FORCEINLINE_FUNCTION
-  Real toLog_(const Real x, const Real offset) {
+  static PORTABLE_FORCEINLINE_FUNCTION Real toLog_(const Real x, const Real offset) {
     // return std::log10(std::abs(std::max(x,-offset) + offset)+EPS);
     return Math::log10(std::abs(std::max(x, -offset) + offset) + EPS);
   }
-  static PORTABLE_FORCEINLINE_FUNCTION
-  Real fromLog_(const Real lx, const Real offset) {
+  static PORTABLE_FORCEINLINE_FUNCTION Real fromLog_(const Real lx, const Real offset) {
     return std::pow(10., lx) - offset;
   }
   PORTABLE_FUNCTION
@@ -1126,7 +1084,7 @@ private:
 // is linear extrapolation in log-log space. We should reconsider this
 // and introduce extrapolation as needed.
 class StellarCollapse {
-public:
+ public:
   // A weakly typed index map for lambdas
   struct Lambda {
     enum Index { Ye = 0, lT = 1 };
@@ -1147,8 +1105,7 @@ public:
   Real TemperatureFromDensityInternalEnergy(const Real rho, const Real sie,
                                             Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  Real InternalEnergyFromDensityTemperature(const Real rho,
-                                            const Real temperature,
+  Real InternalEnergyFromDensityTemperature(const Real rho, const Real temperature,
                                             Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   Real PressureFromDensityTemperature(const Real rho, const Real temperature,
@@ -1157,8 +1114,7 @@ public:
   Real PressureFromDensityInternalEnergy(const Real rho, const Real sie,
                                          Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  Real SpecificHeatFromDensityTemperature(const Real rho,
-                                          const Real temperature,
+  Real SpecificHeatFromDensityTemperature(const Real rho, const Real temperature,
                                           Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   Real SpecificHeatFromDensityInternalEnergy(const Real rho, const Real sie,
@@ -1170,16 +1126,14 @@ public:
   Real BulkModulusFromDensityInternalEnergy(const Real rho, const Real sie,
                                             Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
-  Real GruneisenParamFromDensityTemperature(const Real rho,
-                                            const Real temperature,
+  Real GruneisenParamFromDensityTemperature(const Real rho, const Real temperature,
                                             Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   Real GruneisenParamFromDensityInternalEnergy(const Real rho, const Real sie,
                                                Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   void DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                            Real *lambda, Real &rho,
-                                            Real &sie) const;
+                                            Real *lambda, Real &rho, Real &sie) const;
   /*
   // Provided by eos_variant
   PORTABLE_FUNCTION
@@ -1190,13 +1144,12 @@ public:
   */
   // TODO(JMM): Should this function fill in the mass fractions too?
   PORTABLE_FUNCTION
-  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv,
-               Real &bmod, const unsigned long output,
-               Real *lambda = nullptr) const;
+  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, Real &bmod,
+               const unsigned long output, Real *lambda = nullptr) const;
 
   PORTABLE_FUNCTION
-  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
-                              Real &cv, Real &bmod, Real &dpde, Real &dvdt,
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const;
 
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
@@ -1233,14 +1186,13 @@ public:
   void Finalize();
   static std::string EosType() { return std::string("StellarCollapse"); }
 
-private:
+ private:
   void LoadFromSP5File_(const std::string &filename);
   void LoadFromStellarCollapseFile_(const std::string &filename);
   int readSCInt_(const hid_t &file_id, const std::string &name);
-  void readBounds_(const hid_t &file_id, const std::string &name, int size,
-                   Real &lo, Real &hi);
-  void readSCDset_(const hid_t &file_id, const std::string &name,
-                   Spiner::DataBox &db);
+  void readBounds_(const hid_t &file_id, const std::string &name, int size, Real &lo,
+                   Real &hi);
+  void readSCDset_(const hid_t &file_id, const std::string &name, Spiner::DataBox &db);
 
   void medianFilter_(Spiner::DataBox &db);
   void medianFilter_(const Spiner::DataBox &in, Spiner::DataBox &out);
@@ -1254,8 +1206,7 @@ private:
   PORTABLE_INLINE_FUNCTION __attribute__((always_inline)) void
   checkLambda_(Real *lambda) const noexcept {
     if (lambda == nullptr) {
-      EOS_ERROR(
-          "StellarCollapse: lambda must contain Ye and 1 space for caching.\n");
+      EOS_ERROR("StellarCollapse: lambda must contain Ye and 1 space for caching.\n");
     }
   }
 
@@ -1318,8 +1269,8 @@ private:
   PORTABLE_FUNCTION Real lTFromlRhoSie_(const Real lRho, const Real sie,
                                         Real *lambda) const noexcept;
   PORTABLE_INLINE_FUNCTION __attribute__((always_inline)) void
-  getLogsFromRhoT_(const Real rho, const Real temp, Real *lambda, Real &lRho,
-                   Real &lT, Real &Ye) const noexcept {
+  getLogsFromRhoT_(const Real rho, const Real temp, Real *lambda, Real &lRho, Real &lT,
+                   Real &Ye) const noexcept {
     checkLambda_(lambda);
     lRho = lRho_(rho);
     lT = lT_(temp);
@@ -1327,8 +1278,8 @@ private:
     lambda[Lambda::lT] = lT;
   }
   PORTABLE_INLINE_FUNCTION __attribute__((always_inline)) void
-  getLogsFromRhoSie_(const Real rho, const Real sie, Real *lambda, Real &lRho,
-                     Real &lT, Real &Ye) const noexcept {
+  getLogsFromRhoSie_(const Real rho, const Real sie, Real *lambda, Real &lRho, Real &lT,
+                     Real &Ye) const noexcept {
     lRho = lRho_(rho);
     lT = lTFromlRhoSie_(lRho, sie, lambda);
     Ye = lambda[Lambda::Ye];
@@ -1372,8 +1323,7 @@ private:
 
   // offsets must be non-negative
   Real lEOffset_;
-  static constexpr Real lRhoOffset_ =
-      0.0; // TODO(JMM): Address if this ever changes
+  static constexpr Real lRhoOffset_ = 0.0; // TODO(JMM): Address if this ever changes
   static constexpr Real lTOffset_ = 0.0;
   static constexpr Real lPOffset_ = 0.0;
   static constexpr Real lBOffset_ = 0.0;
@@ -1397,7 +1347,7 @@ private:
 // Only really works in serial
 // Not really supported on device
 class EOSPAC {
-public:
+ public:
   EOSPAC() = default;
   EOSPAC(int matid);
   EOSPAC GetOnDevice() { return *this; }
@@ -1405,36 +1355,36 @@ public:
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real InternalEnergyFromDensityTemperature(
       const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(
-      const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityTemperature(const Real rho,
+                                                        const Real temperature,
+                                                        Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real PressureFromDensityInternalEnergy(const Real rho, const Real sie,
+                                                           Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real SpecificHeatFromDensityTemperature(const Real rho,
+                                                            const Real temperature,
+                                                            Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real SpecificHeatFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(
-      const Real rho, const Real temperature, Real *lambda = nullptr) const;
+  PORTABLE_FUNCTION Real BulkModulusFromDensityTemperature(const Real rho,
+                                                           const Real temperature,
+                                                           Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real BulkModulusFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real GruneisenParamFromDensityTemperature(
       const Real rho, const Real temperature, Real *lambda = nullptr) const;
   PORTABLE_FUNCTION Real GruneisenParamFromDensityInternalEnergy(
       const Real rho, const Real sie, Real *lambda = nullptr) const;
-  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy,
-                                 Real &press, Real &cv, Real &bmod,
-                                 const unsigned long output,
+  PORTABLE_FUNCTION void FillEos(Real &rho, Real &temp, Real &energy, Real &press,
+                                 Real &cv, Real &bmod, const unsigned long output,
                                  Real *lambda = nullptr) const;
   PORTABLE_FUNCTION
   void DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                            Real *lambda, Real &rho,
-                                            Real &sie) const;
-  PORTABLE_FUNCTION void PTofRE(const Real rho, const Real sie, Real *lambda,
-                                Real &press, Real &temp, Real &dpdr, Real &dpde,
-                                Real &dtdr, Real &dtde) const;
-  PORTABLE_FUNCTION void ValuesAtReferenceState(Real &rho, Real &temp,
-                                                Real &sie, Real &press,
-                                                Real &cv, Real &bmod,
+                                            Real *lambda, Real &rho, Real &sie) const;
+  PORTABLE_FUNCTION void PTofRE(const Real rho, const Real sie, Real *lambda, Real &press,
+                                Real &temp, Real &dpdr, Real &dpde, Real &dtdr,
+                                Real &dtde) const;
+  PORTABLE_FUNCTION void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie,
+                                                Real &press, Real &cv, Real &bmod,
                                                 Real &dpde, Real &dvdt,
                                                 Real *lambda = nullptr) const;
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
@@ -1445,7 +1395,7 @@ public:
     printf("EOSPAC parameters:\nmatid = %s\n", matid_);
   }
 
-private:
+ private:
   static constexpr const unsigned long _preferred_input =
       thermalqs::density | thermalqs::temperature;
   int matid_;
@@ -1468,26 +1418,22 @@ private:
 #endif // SINGULARITY_USE_EOSPAC
 
 using EOS = Variant<
-    IdealGas, Gruneisen, JWL, DavisReactants, DavisProducts,
-    ScaledEOS<IdealGas>, ShiftedEOS<IdealGas>, ShiftedEOS<ScaledEOS<IdealGas>>,
-    ScaledEOS<ShiftedEOS<IdealGas>>, RelativisticEOS<IdealGas>,
-    ScaledEOS<Gruneisen>, ShiftedEOS<Gruneisen>,
-    ScaledEOS<ShiftedEOS<Gruneisen>>,
-    ScaledEOS<JWL>, ShiftedEOS<JWL>, ScaledEOS<ShiftedEOS<JWL>>,
-    ScaledEOS<DavisReactants>, ShiftedEOS<DavisReactants>,
-    ScaledEOS<ShiftedEOS<DavisReactants>>,
+    IdealGas, Gruneisen, JWL, DavisReactants, DavisProducts, ScaledEOS<IdealGas>,
+    ShiftedEOS<IdealGas>, ShiftedEOS<ScaledEOS<IdealGas>>,
+    ScaledEOS<ShiftedEOS<IdealGas>>, RelativisticEOS<IdealGas>, ScaledEOS<Gruneisen>,
+    ShiftedEOS<Gruneisen>, ScaledEOS<ShiftedEOS<Gruneisen>>, ScaledEOS<JWL>,
+    ShiftedEOS<JWL>, ScaledEOS<ShiftedEOS<JWL>>, ScaledEOS<DavisReactants>,
+    ShiftedEOS<DavisReactants>, ScaledEOS<ShiftedEOS<DavisReactants>>,
     ScaledEOS<DavisProducts>, ShiftedEOS<DavisProducts>,
     ScaledEOS<ShiftedEOS<DavisProducts>>
 #ifdef SPINER_USE_HDF
     ,
-    SpinerEOSDependsRhoT, SpinerEOSDependsRhoSie,
-    ScaledEOS<SpinerEOSDependsRhoT>, ScaledEOS<SpinerEOSDependsRhoSie>,
-    ShiftedEOS<SpinerEOSDependsRhoT>, ShiftedEOS<SpinerEOSDependsRhoSie>,
-    ShiftedEOS<ScaledEOS<SpinerEOSDependsRhoT>>,
+    SpinerEOSDependsRhoT, SpinerEOSDependsRhoSie, ScaledEOS<SpinerEOSDependsRhoT>,
+    ScaledEOS<SpinerEOSDependsRhoSie>, ShiftedEOS<SpinerEOSDependsRhoT>,
+    ShiftedEOS<SpinerEOSDependsRhoSie>, ShiftedEOS<ScaledEOS<SpinerEOSDependsRhoT>>,
     ShiftedEOS<ScaledEOS<SpinerEOSDependsRhoSie>>,
     ScaledEOS<ShiftedEOS<SpinerEOSDependsRhoT>>,
-    ScaledEOS<ShiftedEOS<SpinerEOSDependsRhoSie>>,
-    RelativisticEOS<SpinerEOSDependsRhoT>,
+    ScaledEOS<ShiftedEOS<SpinerEOSDependsRhoSie>>, RelativisticEOS<SpinerEOSDependsRhoT>,
     RelativisticEOS<SpinerEOSDependsRhoSie>,
     // TODO(JMM): Might need shifted + relativistic
     // for StellarCollapse. Might not. Negative
@@ -1498,8 +1444,8 @@ using EOS = Variant<
 #endif // SPINER_USE_HDF
 #ifdef SINGULARITY_USE_EOSPAC
     ,
-    EOSPAC, ScaledEOS<EOSPAC>, ShiftedEOS<EOSPAC>,
-    ShiftedEOS<ScaledEOS<EOSPAC>>, ScaledEOS<ShiftedEOS<EOSPAC>>
+    EOSPAC, ScaledEOS<EOSPAC>, ShiftedEOS<EOSPAC>, ShiftedEOS<ScaledEOS<EOSPAC>>,
+    ScaledEOS<ShiftedEOS<EOSPAC>>
 #endif // SINGULARITY_USE_EOSPAC
     >;
 

--- a/singularity-eos/eos/eos_builder.cpp
+++ b/singularity-eos/eos/eos_builder.cpp
@@ -12,20 +12,18 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------#
 
-
 #include <iostream> // debug
 #include <singularity-eos/eos/eos_builder.hpp>
 
-#define GETBASE(T,N) T N = mpark::get<T>(base_params[#N])
+#define GETBASE(T, N) T N = mpark::get<T>(base_params[#N])
 
 namespace singularity {
 
-EOS EOSBuilder::buildEOS(EOSBuilder::EOSType type,
-					   EOSBuilder::params_t base_params,
-					   EOSBuilder::modifiers_t modifiers) {
+EOS EOSBuilder::buildEOS(EOSBuilder::EOSType type, EOSBuilder::params_t base_params,
+                         EOSBuilder::modifiers_t modifiers) {
   using namespace EOSBuilder;
   using std::string;
-  bool scaled  = (modifiers.count(EOSModifier::Scaled) > 0);
+  bool scaled = (modifiers.count(EOSModifier::Scaled) > 0);
   bool shifted = (modifiers.count(EOSModifier::Shifted) > 0);
   bool relativistic = (modifiers.count(EOSModifier::Relativistic) > 0);
   if ((shifted || scaled || relativistic) && !(isModifiable(type))) {
@@ -36,7 +34,7 @@ EOS EOSBuilder::buildEOS(EOSBuilder::EOSType type,
   }
   Real scale = 1;
   if (scaled) {
-    scale  = mpark::get<Real>(modifiers[EOSModifier::Scaled]["scale"]);
+    scale = mpark::get<Real>(modifiers[EOSModifier::Scaled]["scale"]);
   }
   Real shift = 0;
   if (shifted) {
@@ -49,53 +47,45 @@ EOS EOSBuilder::buildEOS(EOSBuilder::EOSType type,
   if (type == EOSType::IdealGas) {
     Real gm1 = mpark::get<Real>(base_params["gm1"]);
     Real Cv = mpark::get<Real>(base_params["Cv"]);
-    IdealGas g(gm1,Cv);
+    IdealGas g(gm1, Cv);
     if (relativistic) {
-      return makeRelativistic(std::move(g),cl);
+      return makeRelativistic(std::move(g), cl);
     }
-    return applyScaleAndShift(std::move(g),
-			      scaled,shifted,scale,shift);
+    return applyScaleAndShift(std::move(g), scaled, shifted, scale, shift);
   }
 #ifdef SPINER_USE_HDF
-  if (type == EOSType::SpinerEOSDependsRhoT
-      || type == EOSType::SpinerEOSDependsRhoSie) {
+  if (type == EOSType::SpinerEOSDependsRhoT || type == EOSType::SpinerEOSDependsRhoSie) {
     string filename = mpark::get<string>(base_params["filename"]);
     bool reproducibility_mode = mpark::get<bool>(base_params["reproducibility_mode"]);
     if (base_params.count("matid") > 0) {
       int matid = mpark::get<int>(base_params["matid"]);
       if (type == EOSType::SpinerEOSDependsRhoT) {
-        SpinerEOSDependsRhoT s(filename,matid,reproducibility_mode);
+        SpinerEOSDependsRhoT s(filename, matid, reproducibility_mode);
         if (relativistic) {
-          return makeRelativistic(std::move(s),cl);
+          return makeRelativistic(std::move(s), cl);
         }
-        return applyScaleAndShift(std::move(s),
-                                  scaled,shifted,scale,shift);
-      } 
-      else {
-        SpinerEOSDependsRhoSie s(filename,matid,reproducibility_mode);
+        return applyScaleAndShift(std::move(s), scaled, shifted, scale, shift);
+      } else {
+        SpinerEOSDependsRhoSie s(filename, matid, reproducibility_mode);
         if (relativistic) {
-          return makeRelativistic(std::move(s),cl);
+          return makeRelativistic(std::move(s), cl);
         }
-        return applyScaleAndShift(std::move(s),
-                                  scaled,shifted,scale,shift);
+        return applyScaleAndShift(std::move(s), scaled, shifted, scale, shift);
       }
     } else {
       string materialName = mpark::get<string>(base_params["materialName"]);
       if (type == EOSType::SpinerEOSDependsRhoT) {
-        SpinerEOSDependsRhoT s(filename,materialName,reproducibility_mode);
+        SpinerEOSDependsRhoT s(filename, materialName, reproducibility_mode);
         if (relativistic) {
-          return makeRelativistic(std::move(s),cl);
+          return makeRelativistic(std::move(s), cl);
         }
-        return applyScaleAndShift(std::move(s),
-                                  scaled,shifted,scale,shift);
-      }
-        else {
-        SpinerEOSDependsRhoSie s(filename,materialName,reproducibility_mode);
+        return applyScaleAndShift(std::move(s), scaled, shifted, scale, shift);
+      } else {
+        SpinerEOSDependsRhoSie s(filename, materialName, reproducibility_mode);
         if (relativistic) {
-          return makeRelativistic(std::move(s),cl);
+          return makeRelativistic(std::move(s), cl);
         }
-        return applyScaleAndShift(std::move(s),
-                                  scaled,shifted,scale,shift);
+        return applyScaleAndShift(std::move(s), scaled, shifted, scale, shift);
       }
     }
   }
@@ -113,57 +103,56 @@ EOS EOSBuilder::buildEOS(EOSBuilder::EOSType type,
     if (relativistic) {
       return makeRelativistic(std::move(s), cl);
     }
-    return applyScaleAndShift(std::move(s),
-                              scaled, shifted, scale, shift);
+    return applyScaleAndShift(std::move(s), scaled, shifted, scale, shift);
   }
 #endif
   if (type == EOSType::Gruneisen) {
-    Real C0   = mpark::get<Real>(base_params["C0"]);
-    Real s1   = mpark::get<Real>(base_params["s1"]);
-    Real s2   = mpark::get<Real>(base_params["s2"]);
-    Real s3   = mpark::get<Real>(base_params["s3"]);
-    Real G0   = mpark::get<Real>(base_params["G0"]);
-    Real b    = mpark::get<Real>(base_params["b"]);
+    Real C0 = mpark::get<Real>(base_params["C0"]);
+    Real s1 = mpark::get<Real>(base_params["s1"]);
+    Real s2 = mpark::get<Real>(base_params["s2"]);
+    Real s3 = mpark::get<Real>(base_params["s3"]);
+    Real G0 = mpark::get<Real>(base_params["G0"]);
+    Real b = mpark::get<Real>(base_params["b"]);
     Real rho0 = mpark::get<Real>(base_params["rho0"]);
-    Real T0   = mpark::get<Real>(base_params["T0"]);
-    Real P0   = mpark::get<Real>(base_params["P0"]);
-    Real Cv   = mpark::get<Real>(base_params["Cv"]);
-    return Gruneisen(C0,s1,s2,s3,G0,b,rho0,T0,P0,Cv);
+    Real T0 = mpark::get<Real>(base_params["T0"]);
+    Real P0 = mpark::get<Real>(base_params["P0"]);
+    Real Cv = mpark::get<Real>(base_params["Cv"]);
+    return Gruneisen(C0, s1, s2, s3, G0, b, rho0, T0, P0, Cv);
   }
   if (type == EOSType::JWL) {
-    GETBASE(Real,A); // I got tired of writing this over and over
-    GETBASE(Real,B);
-    GETBASE(Real,R1);
-    GETBASE(Real,R2);
-    GETBASE(Real,w);
-    GETBASE(Real,rho0);
-    GETBASE(Real,Cv);
-    return JWL(A,B,R1,R2,w,rho0,Cv);
+    GETBASE(Real, A); // I got tired of writing this over and over
+    GETBASE(Real, B);
+    GETBASE(Real, R1);
+    GETBASE(Real, R2);
+    GETBASE(Real, w);
+    GETBASE(Real, rho0);
+    GETBASE(Real, Cv);
+    return JWL(A, B, R1, R2, w, rho0, Cv);
   }
   if (type == EOSType::DavisReactants) {
-    GETBASE(Real,rho0);
-    GETBASE(Real,e0);
-    GETBASE(Real,P0);
-    GETBASE(Real,T0);
-    GETBASE(Real,A);
-    GETBASE(Real,B);
-    GETBASE(Real,C);
-    GETBASE(Real,G0);
-    GETBASE(Real,Z);
-    GETBASE(Real,alpha);
-    GETBASE(Real,Cv0);
-    return DavisReactants(rho0,e0,P0,T0,A,B,C,G0,Z,alpha,Cv0);
+    GETBASE(Real, rho0);
+    GETBASE(Real, e0);
+    GETBASE(Real, P0);
+    GETBASE(Real, T0);
+    GETBASE(Real, A);
+    GETBASE(Real, B);
+    GETBASE(Real, C);
+    GETBASE(Real, G0);
+    GETBASE(Real, Z);
+    GETBASE(Real, alpha);
+    GETBASE(Real, Cv0);
+    return DavisReactants(rho0, e0, P0, T0, A, B, C, G0, Z, alpha, Cv0);
   }
   if (type == EOSType::DavisProducts) {
-    GETBASE(Real,a);
-    GETBASE(Real,b);
-    GETBASE(Real,k);
-    GETBASE(Real,n);
-    GETBASE(Real,vc);
-    GETBASE(Real,pc);
-    GETBASE(Real,Cv);
-    GETBASE(Real,E0);
-    return DavisProducts(a,b,k,n,vc,pc,Cv,E0);
+    GETBASE(Real, a);
+    GETBASE(Real, b);
+    GETBASE(Real, k);
+    GETBASE(Real, n);
+    GETBASE(Real, vc);
+    GETBASE(Real, pc);
+    GETBASE(Real, Cv);
+    GETBASE(Real, E0);
+    return DavisProducts(a, b, k, n, vc, pc, Cv, E0);
   }
   exit(1);
 }

--- a/singularity-eos/eos/eos_builder.hpp
+++ b/singularity-eos/eos/eos_builder.hpp
@@ -16,97 +16,92 @@
 #define _SINGULARITY_EOS_EOS_EOS_BUILDER_HPP_
 
 #include <map>
+#include <ports-of-call/portability.hpp>
+#include <singularity-eos/eos/eos.hpp>
 #include <string>
 #include <unordered_set>
 #include <variant/include/mpark/variant.hpp>
-#include <ports-of-call/portability.hpp>
-#include <singularity-eos/eos/eos.hpp>
 
 namespace singularity {
 
 namespace EOSBuilder {
 
-  // TODO(JMM): This could be strings? Or at least use a macro so we
-  // only have to write these down once?
-  // strings might allow us to create these structrs more easily
-  // in the host code.
-  enum class EOSType {
-    IdealGas
-    , Gruneisen
-    , JWL
-    , DavisReactants
-    , DavisProducts
+// TODO(JMM): This could be strings? Or at least use a macro so we
+// only have to write these down once?
+// strings might allow us to create these structrs more easily
+// in the host code.
+enum class EOSType {
+  IdealGas,
+  Gruneisen,
+  JWL,
+  DavisReactants,
+  DavisProducts
 #ifdef SPINER_USE_HDF
-    , SpinerEOSDependsRhoT
-    , SpinerEOSDependsRhoSie
-    , StellarCollapse
+  ,
+  SpinerEOSDependsRhoT,
+  SpinerEOSDependsRhoSie,
+  StellarCollapse
 #endif
-  };
-  enum class EOSModifier { Scaled, Shifted, Relativistic };
+};
+enum class EOSModifier { Scaled, Shifted, Relativistic };
 
-  // evil type erasure
-  using param_t = mpark::variant<bool,int,Real,std::string>;
-  using params_t = std::map<std::string,param_t>;
-  using modifiers_t = std::map<EOSModifier,params_t>;
-  const params_t NO_PARAMS;
+// evil type erasure
+using param_t = mpark::variant<bool, int, Real, std::string>;
+using params_t = std::map<std::string, param_t>;
+using modifiers_t = std::map<EOSModifier, params_t>;
+const params_t NO_PARAMS;
 
-  const std::unordered_set<EOSType>
-  modifiable({EOSType::IdealGas
+const std::unordered_set<EOSType> modifiable({EOSType::IdealGas
 #ifdef SPINER_USE_HDF
-	, EOSType::SpinerEOSDependsRhoT
-	, EOSType::SpinerEOSDependsRhoSie
-  , EOSType::StellarCollapse
+                                              ,
+                                              EOSType::SpinerEOSDependsRhoT,
+                                              EOSType::SpinerEOSDependsRhoSie,
+                                              EOSType::StellarCollapse
 #endif
-	});
-  bool isModifiable(EOSType t);
-  EOS buildEOS(EOSType type,
-				 params_t base_params,
-				 modifiers_t modifiers);
-  inline auto buildEOS(EOSType type, params_t base_params) {
-    modifiers_t modifiers;
-    return buildEOS(type,base_params,modifiers);
-  }
+});
+bool isModifiable(EOSType t);
+EOS buildEOS(EOSType type, params_t base_params, modifiers_t modifiers);
+inline auto buildEOS(EOSType type, params_t base_params) {
+  modifiers_t modifiers;
+  return buildEOS(type, base_params, modifiers);
+}
 
-  template<typename T>
-  EOS makeRelativistic(T&& eos, Real cl) {
-    return RelativisticEOS<T>(std::move(eos), cl);
-  }
+template <typename T>
+EOS makeRelativistic(T &&eos, Real cl) {
+  return RelativisticEOS<T>(std::move(eos), cl);
+}
 
-  template<typename T>
-  EOS applyScaleAndShift(T&& eos,
-			 bool scaled, bool shifted,
-			 Real scale, Real shift) {
-    if (shifted && scaled) {
-      ScaledEOS<T> a(std::move(eos),scale);
-      ShiftedEOS<ScaledEOS<T>> b(std::move(a),shift);
-      return b;
-    }
-    if (shifted) {
-      return ShiftedEOS<T>(std::move(eos),shift);
-    }
-    if (scaled) {
-      return ScaledEOS<T>(std::move(eos),scale);
-    }
-    return eos;
+template <typename T>
+EOS applyScaleAndShift(T &&eos, bool scaled, bool shifted, Real scale, Real shift) {
+  if (shifted && scaled) {
+    ScaledEOS<T> a(std::move(eos), scale);
+    ShiftedEOS<ScaledEOS<T>> b(std::move(a), shift);
+    return b;
   }
+  if (shifted) {
+    return ShiftedEOS<T>(std::move(eos), shift);
+  }
+  if (scaled) {
+    return ScaledEOS<T>(std::move(eos), scale);
+  }
+  return eos;
+}
 
-  template<typename T>
-  EOS applyShiftAndScale(T&& eos,
-                         bool scaled, bool shifted,
-                         Real scale, Real shift) {
-    if (shifted && scaled) {
-      ShiftedEOS<T> a(std::forward<T>(eos),shift);
-      ScaledEOS<ShiftedEOS<T>> b(std::move(a),scale);
-      return b;
-    }
-    if (shifted) {
-      return ShiftedEOS<T>(std::forward<T>(eos),shift);
-    }
-    if (scaled) {
-      return ScaledEOS<T>(std::forward<T>(eos),scale);
-    }
-    return eos;
+template <typename T>
+EOS applyShiftAndScale(T &&eos, bool scaled, bool shifted, Real scale, Real shift) {
+  if (shifted && scaled) {
+    ShiftedEOS<T> a(std::forward<T>(eos), shift);
+    ScaledEOS<ShiftedEOS<T>> b(std::move(a), scale);
+    return b;
   }
+  if (shifted) {
+    return ShiftedEOS<T>(std::forward<T>(eos), shift);
+  }
+  if (scaled) {
+    return ScaledEOS<T>(std::forward<T>(eos), scale);
+  }
+  return eos;
+}
 } // namespace EOSBuilder
 
 } // namespace singularity

--- a/singularity-eos/eos/eos_davis.cpp
+++ b/singularity-eos/eos/eos_davis.cpp
@@ -12,176 +12,184 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
-#include <singularity-eos/eos/eos.hpp>
 #include <cmath>
+#include <singularity-eos/eos/eos.hpp>
 
 namespace singularity {
 
-PORTABLE_INLINE_FUNCTION Real square(const Real x) {return x*x;}
-PORTABLE_INLINE_FUNCTION Real cube(const Real x) {return x*x*x;}
-PORTABLE_INLINE_FUNCTION Real fourth(const Real x) {return x*x*x*x;}
-PORTABLE_INLINE_FUNCTION Real fifth(const Real x) {return x*x*x*x*x;}
+PORTABLE_INLINE_FUNCTION Real square(const Real x) { return x * x; }
+PORTABLE_INLINE_FUNCTION Real cube(const Real x) { return x * x * x; }
+PORTABLE_INLINE_FUNCTION Real fourth(const Real x) { return x * x * x * x; }
+PORTABLE_INLINE_FUNCTION Real fifth(const Real x) { return x * x * x * x * x; }
 
-constexpr Real onethird = 1.0/3.0;
+constexpr Real onethird = 1.0 / 3.0;
 
-PORTABLE_INLINE_FUNCTION Real DavisReactants::Ps(const Real rho) const
-{
-    const Real y = 1.0-_rho0/rho;
-    const Real phat = 0.25*_A*_A/_B*_rho0;
-    const Real b4y = 4.0*_B*y;
+PORTABLE_INLINE_FUNCTION Real DavisReactants::Ps(const Real rho) const {
+  const Real y = 1.0 - _rho0 / rho;
+  const Real phat = 0.25 * _A * _A / _B * _rho0;
+  const Real b4y = 4.0 * _B * y;
 
-    if(rho>=_rho0) 
-    {
-        return phat*(b4y+0.5*(square(b4y)+onethird*(cube(b4y)+_C*fourth(b4y)*0.25))+square(y)/fourth(1-y));
-    }
-    else
-    {
-        return phat*(std::exp(b4y)-1.0);
-    }
+  if (rho >= _rho0) {
+    return phat *
+           (b4y + 0.5 * (square(b4y) + onethird * (cube(b4y) + _C * fourth(b4y) * 0.25)) +
+            square(y) / fourth(1 - y));
+  } else {
+    return phat * (std::exp(b4y) - 1.0);
+  }
 }
-PORTABLE_INLINE_FUNCTION Real DavisReactants::Es(const Real rho) const
-{
-    const Real y = 1-_rho0/rho;
-    const Real phat = 0.25*_A*_A/_B*_rho0;
-    const Real b4y = 4*_B*y;
-    Real e_s;
-    if(y>0.0) {
-        const Real z=rho/_rho0 - 1;
-	    e_s = 0.5*y*b4y*(1.0+onethird*b4y*(1.0+0.25*b4y*(1.0+_C*0.2*b4y)))+onethird*cube(z);
-    } else {
-        e_s = -y-(1.0-std::exp(b4y))/(4.0*_B);
-    }
-    return _e0+_P0*(1.0/_rho0-1.0/rho)+phat/_rho0*e_s;
+PORTABLE_INLINE_FUNCTION Real DavisReactants::Es(const Real rho) const {
+  const Real y = 1 - _rho0 / rho;
+  const Real phat = 0.25 * _A * _A / _B * _rho0;
+  const Real b4y = 4 * _B * y;
+  Real e_s;
+  if (y > 0.0) {
+    const Real z = rho / _rho0 - 1;
+    e_s = 0.5 * y * b4y *
+              (1.0 + onethird * b4y * (1.0 + 0.25 * b4y * (1.0 + _C * 0.2 * b4y))) +
+          onethird * cube(z);
+  } else {
+    e_s = -y - (1.0 - std::exp(b4y)) / (4.0 * _B);
+  }
+  return _e0 + _P0 * (1.0 / _rho0 - 1.0 / rho) + phat / _rho0 * e_s;
 }
-PORTABLE_INLINE_FUNCTION Real DavisReactants::Ts(const Real rho) const
-{
-    if(rho>=_rho0) 
-    {
-        const Real y = 1-_rho0/rho;
-        return _T0*std::exp(-_Z*y)*std::pow(_rho0/rho,-_G0-_Z);
-    }
-    else
-    {
-        return _T0*std::pow(_rho0/rho,-_G0);
-    }
+PORTABLE_INLINE_FUNCTION Real DavisReactants::Ts(const Real rho) const {
+  if (rho >= _rho0) {
+    const Real y = 1 - _rho0 / rho;
+    return _T0 * std::exp(-_Z * y) * std::pow(_rho0 / rho, -_G0 - _Z);
+  } else {
+    return _T0 * std::pow(_rho0 / rho, -_G0);
+  }
 }
-PORTABLE_INLINE_FUNCTION Real DavisReactants::Gamma(const Real rho) const
-{
-    if(rho>=_rho0) 
-    {
-        const Real y = 1-_rho0/rho;
-        return _G0+_Z*y;
-    } else
-    {
-        return _G0;
-    }
+PORTABLE_INLINE_FUNCTION Real DavisReactants::Gamma(const Real rho) const {
+  if (rho >= _rho0) {
+    const Real y = 1 - _rho0 / rho;
+    return _G0 + _Z * y;
+  } else {
+    return _G0;
+  }
 }
-PORTABLE_FUNCTION Real DavisReactants::InternalEnergyFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    const Real t_s = Ts(rho);
-    return Es(rho) +_Cv0*t_s/(1.0+_alpha)*(std::pow(temp/t_s,1.0+_alpha)-1.0);
+PORTABLE_FUNCTION Real DavisReactants::InternalEnergyFromDensityTemperature(
+    const Real rho, const Real temp, Real *lambda) const {
+  const Real t_s = Ts(rho);
+  return Es(rho) +
+         _Cv0 * t_s / (1.0 + _alpha) * (std::pow(temp / t_s, 1.0 + _alpha) - 1.0);
 }
-PORTABLE_FUNCTION Real DavisReactants::PressureFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    return Ps(rho)+Gamma(rho)*rho*(sie-Es(rho));
+PORTABLE_FUNCTION Real DavisReactants::PressureFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  return Ps(rho) + Gamma(rho) * rho * (sie - Es(rho));
 }
-PORTABLE_FUNCTION Real DavisReactants::TemperatureFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    const Real es = Es(rho);
-    const Real tmp = std::pow((1.0+_alpha)/(Ts(rho)*_Cv0)*(sie-es)+1.0,1.0/(1.0+_alpha));
-    if(tmp>0) return Ts(rho)*tmp;
-    return Ts(rho) + (sie - es)/_Cv0; // This branch is a negative temperature
+PORTABLE_FUNCTION Real DavisReactants::TemperatureFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  const Real es = Es(rho);
+  const Real tmp = std::pow((1.0 + _alpha) / (Ts(rho) * _Cv0) * (sie - es) + 1.0,
+                            1.0 / (1.0 + _alpha));
+  if (tmp > 0) return Ts(rho) * tmp;
+  return Ts(rho) + (sie - es) / _Cv0; // This branch is a negative temperature
 }
-PORTABLE_FUNCTION Real DavisReactants::SpecificHeatFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    return _Cv0/std::pow((1+_alpha)/(Ts(rho)*_Cv0)*(sie-Es(rho))+1,-_alpha/(1+_alpha));
+PORTABLE_FUNCTION Real DavisReactants::SpecificHeatFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  return _Cv0 / std::pow((1 + _alpha) / (Ts(rho) * _Cv0) * (sie - Es(rho)) + 1,
+                         -_alpha / (1 + _alpha));
 }
-PORTABLE_FUNCTION Real DavisReactants::BulkModulusFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    const Real y = 1-_rho0/rho;
-    const Real phat = 0.25*_A*_A/_B*_rho0;
-    const Real b4y = 4*_B*y;
-    const Real gamma = Gamma(rho);
-    const Real esv = -Ps(rho);
-    const Real psv = (rho>=_rho0)? -phat*_rho0*(4*_B*(1+b4y+0.5*(square(b4y)+_C/3*cube(b4y)))+3*y/fourth(1-y)+4*square(y)/fifth(1-y)) : -phat*4*_B*_rho0*std::exp(b4y);
-    const Real gammav = (rho>=_rho0)? _Z*_rho0 : 0.0;
-    return -(psv+(sie-Es(rho))*rho*(gammav-gamma*rho)-gamma*rho*esv)/rho;
+PORTABLE_FUNCTION Real DavisReactants::BulkModulusFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  const Real y = 1 - _rho0 / rho;
+  const Real phat = 0.25 * _A * _A / _B * _rho0;
+  const Real b4y = 4 * _B * y;
+  const Real gamma = Gamma(rho);
+  const Real esv = -Ps(rho);
+  const Real psv =
+      (rho >= _rho0)
+          ? -phat * _rho0 *
+                (4 * _B * (1 + b4y + 0.5 * (square(b4y) + _C / 3 * cube(b4y))) +
+                 3 * y / fourth(1 - y) + 4 * square(y) / fifth(1 - y))
+          : -phat * 4 * _B * _rho0 * std::exp(b4y);
+  const Real gammav = (rho >= _rho0) ? _Z * _rho0 : 0.0;
+  return -(psv + (sie - Es(rho)) * rho * (gammav - gamma * rho) - gamma * rho * esv) /
+         rho;
 }
 PORTABLE_FUNCTION
 Real DavisReactants::GruneisenParamFromDensityInternalEnergy(const Real rho,
                                                              const Real sie,
-                                                             Real *lambda) const
-{
+                                                             Real *lambda) const {
   return Gamma(rho);
 }
 // Below are "unimplemented" routines
-PORTABLE_FUNCTION Real DavisReactants::PressureFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    return PressureFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real DavisReactants::PressureFromDensityTemperature(
+    const Real rho, const Real temp, Real *lambda) const {
+  return PressureFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
-PORTABLE_FUNCTION Real DavisReactants::SpecificHeatFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    return SpecificHeatFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real DavisReactants::SpecificHeatFromDensityTemperature(
+    const Real rho, const Real temp, Real *lambda) const {
+  return SpecificHeatFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
-PORTABLE_FUNCTION Real DavisReactants::BulkModulusFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    return BulkModulusFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real DavisReactants::BulkModulusFromDensityTemperature(
+    const Real rho, const Real temp, Real *lambda) const {
+  return BulkModulusFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
 PORTABLE_FUNCTION
-Real DavisReactants::GruneisenParamFromDensityTemperature(const Real rho,
-                                                          const Real temp,
-                                                          Real *lambda) const
-{
+Real DavisReactants::GruneisenParamFromDensityTemperature(const Real rho, const Real temp,
+                                                          Real *lambda) const {
   return Gamma(rho);
 }
-PORTABLE_FUNCTION void DavisReactants::DensityEnergyFromPressureTemperature(const Real press, const Real temp, Real * lambda, Real & rho, Real & sie) const
-{
-    // First, solve P=P(rho,T) for rho.  Note P(rho,e) has an sie-es term, which is only a function of T
-    auto residual = [&](const Real r){return press-(Ps(r)+Gamma(r)*r*_Cv0*Ts(r)/(1+_alpha)*(std::pow(temp/Ts(r),1+_alpha)-1.0));};
-    Real rho1 = _rho0, res1=residual(rho1);
-    Real slope=_Cv0*_G0*((_alpha*_G0-1.0)*temp*std::pow(temp/_T0,_alpha)+_T0+_G0*_T0)/(1+_alpha);
-    Real rho2=rho1+res1/slope,res2=residual(rho2);
-    Real rhom,resm;
-    for(int i=1;i<20;++i){
-        slope = (rho2-rho1)/(res2-res1);
-	rhom = rho2-res2*slope;
-	resm = residual(rhom);
-	if(resm/press<1e-8) break;
-	rho1=rho2;
-	res1=res2;
-	rho2=rhom;
-	res2=resm;
-    }
-    rho = rhom;
-    sie = InternalEnergyFromDensityTemperature(rho,temp);
+PORTABLE_FUNCTION void DavisReactants::DensityEnergyFromPressureTemperature(
+    const Real press, const Real temp, Real *lambda, Real &rho, Real &sie) const {
+  // First, solve P=P(rho,T) for rho.  Note P(rho,e) has an sie-es term, which is only a
+  // function of T
+  auto residual = [&](const Real r) {
+    return press - (Ps(r) + Gamma(r) * r * _Cv0 * Ts(r) / (1 + _alpha) *
+                                (std::pow(temp / Ts(r), 1 + _alpha) - 1.0));
+  };
+  Real rho1 = _rho0, res1 = residual(rho1);
+  Real slope =
+      _Cv0 * _G0 *
+      ((_alpha * _G0 - 1.0) * temp * std::pow(temp / _T0, _alpha) + _T0 + _G0 * _T0) /
+      (1 + _alpha);
+  Real rho2 = rho1 + res1 / slope, res2 = residual(rho2);
+  Real rhom, resm;
+  for (int i = 1; i < 20; ++i) {
+    slope = (rho2 - rho1) / (res2 - res1);
+    rhom = rho2 - res2 * slope;
+    resm = residual(rhom);
+    if (resm / press < 1e-8) break;
+    rho1 = rho2;
+    res1 = res2;
+    rho2 = rhom;
+    res2 = resm;
+  }
+  rho = rhom;
+  sie = InternalEnergyFromDensityTemperature(rho, temp);
 }
 PORTABLE_FUNCTION
-void DavisReactants::FillEos(Real& rho, Real& temp, Real& sie,
-                             Real& press, Real& cv, Real& bmod,
-                             const unsigned long output,
-                             Real *lambda) const
-{
-    if(output&thermalqs::pressure) press=PressureFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::temperature) temp = TemperatureFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::bulk_modulus) bmod = BulkModulusFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::specific_heat) cv=SpecificHeatFromDensityInternalEnergy(rho,sie);
+void DavisReactants::FillEos(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                             Real &bmod, const unsigned long output, Real *lambda) const {
+  if (output & thermalqs::pressure) press = PressureFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::temperature)
+    temp = TemperatureFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::bulk_modulus)
+    bmod = BulkModulusFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::specific_heat)
+    cv = SpecificHeatFromDensityInternalEnergy(rho, sie);
 }
 // TODO: Chad please decide if this is sane
 // TODO(JMM): Pre-cache values instead of computing inline
 PORTABLE_FUNCTION
-void DavisReactants::ValuesAtReferenceState(Real& rho, Real& temp, Real& sie, Real& press,
-                                            Real& cv, Real& bmod, Real& dpde, Real& dvdt,
+void DavisReactants::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
+                                            Real &cv, Real &bmod, Real &dpde, Real &dvdt,
                                             Real *lambda) const {
   rho = _rho0;
   temp = _T0;
-  sie = InternalEnergyFromDensityTemperature(_rho0,_T0);
-  press = PressureFromDensityInternalEnergy(_rho0,sie);
-  cv = SpecificHeatFromDensityInternalEnergy(_rho0,sie);
-  bmod = BulkModulusFromDensityInternalEnergy(_rho0,sie);
-  dpde = Gamma(_rho0)*_rho0;
+  sie = InternalEnergyFromDensityTemperature(_rho0, _T0);
+  press = PressureFromDensityInternalEnergy(_rho0, sie);
+  cv = SpecificHeatFromDensityInternalEnergy(_rho0, sie);
+  bmod = BulkModulusFromDensityInternalEnergy(_rho0, sie);
+  dpde = Gamma(_rho0) * _rho0;
   // chad please fix this. it's wrong
-  Real gm1 = GruneisenParamFromDensityTemperature(_rho0,_T0)*_rho0;
-  dvdt = gm1*cv/bmod;
+  Real gm1 = GruneisenParamFromDensityTemperature(_rho0, _T0) * _rho0;
+  dvdt = gm1 * cv / bmod;
 }
 
 #if 0
@@ -207,135 +215,143 @@ PORTABLE_FUNCTION void DavisReactants::PTofRE(const Real rho, const Real sie, Re
 }
 #endif
 
-
-PORTABLE_INLINE_FUNCTION Real DavisProducts::F(const Real rho) const
-{
-    const Real vvc = 1.0/(rho*_vc);
-    return 2.0*_a/(std::pow(vvc,2*_n)+1.0);
+PORTABLE_INLINE_FUNCTION Real DavisProducts::F(const Real rho) const {
+  const Real vvc = 1.0 / (rho * _vc);
+  return 2.0 * _a / (std::pow(vvc, 2 * _n) + 1.0);
 }
-PORTABLE_INLINE_FUNCTION Real DavisProducts::Es(const Real rho) const
-{
-    const Real vvc = 1/(rho*_vc);
-    const Real ec = _pc*_vc/(_k-1.0+_a);
-    //const Real de = ecj-(Es(rho0)-_E0);
-    return ec*std::pow(0.5*(std::pow(vvc,_n)+std::pow(vvc,-_n)),_a/_n)/std::pow(vvc,_k-1.0+_a);
+PORTABLE_INLINE_FUNCTION Real DavisProducts::Es(const Real rho) const {
+  const Real vvc = 1 / (rho * _vc);
+  const Real ec = _pc * _vc / (_k - 1.0 + _a);
+  // const Real de = ecj-(Es(rho0)-_E0);
+  return ec * std::pow(0.5 * (std::pow(vvc, _n) + std::pow(vvc, -_n)), _a / _n) /
+         std::pow(vvc, _k - 1.0 + _a);
 }
-PORTABLE_INLINE_FUNCTION Real DavisProducts::Ps(const Real rho) const
-{
-    const Real vvc = 1/(rho*_vc);
-    return _pc*std::pow(0.5*(std::pow(vvc,_n)+std::pow(vvc,-_n)),_a/_n)/std::pow(vvc,_k+_a)*(_k-1.0+F(rho))/(_k-1.0+_a);
+PORTABLE_INLINE_FUNCTION Real DavisProducts::Ps(const Real rho) const {
+  const Real vvc = 1 / (rho * _vc);
+  return _pc * std::pow(0.5 * (std::pow(vvc, _n) + std::pow(vvc, -_n)), _a / _n) /
+         std::pow(vvc, _k + _a) * (_k - 1.0 + F(rho)) / (_k - 1.0 + _a);
 }
-PORTABLE_INLINE_FUNCTION Real DavisProducts::Ts(const Real rho) const
-{
-    const Real vvc = 1/(rho*_vc);
-    return std::pow(2.0,-_a*_b/_n)*_pc*_vc/(_Cv*(_k-1+_a))*std::pow(0.5*(std::pow(vvc,_n)+std::pow(vvc,-_n)),_a/_n*(1-_b))/std::pow(vvc,_k-1.0+_a*(1-_b));
+PORTABLE_INLINE_FUNCTION Real DavisProducts::Ts(const Real rho) const {
+  const Real vvc = 1 / (rho * _vc);
+  return std::pow(2.0, -_a * _b / _n) * _pc * _vc / (_Cv * (_k - 1 + _a)) *
+         std::pow(0.5 * (std::pow(vvc, _n) + std::pow(vvc, -_n)), _a / _n * (1 - _b)) /
+         std::pow(vvc, _k - 1.0 + _a * (1 - _b));
 }
-PORTABLE_INLINE_FUNCTION Real DavisProducts::Gamma(const Real rho) const
-{
-    return _k-1.0+(1.0-_b)*F(rho);
+PORTABLE_INLINE_FUNCTION Real DavisProducts::Gamma(const Real rho) const {
+  return _k - 1.0 + (1.0 - _b) * F(rho);
 }
-PORTABLE_FUNCTION Real DavisProducts::InternalEnergyFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    return _Cv*(temp-Ts(rho))+Es(rho);
+PORTABLE_FUNCTION Real DavisProducts::InternalEnergyFromDensityTemperature(
+    const Real rho, const Real temp, Real *lambda) const {
+  return _Cv * (temp - Ts(rho)) + Es(rho);
 }
-PORTABLE_FUNCTION Real DavisProducts::PressureFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    return Ps(rho)+rho*Gamma(rho)*(sie-Es(rho));
+PORTABLE_FUNCTION Real DavisProducts::PressureFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  return Ps(rho) + rho * Gamma(rho) * (sie - Es(rho));
 }
-PORTABLE_FUNCTION Real DavisProducts::TemperatureFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    return Ts(rho) + (sie-Es(rho))/_Cv;
+PORTABLE_FUNCTION Real DavisProducts::TemperatureFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  return Ts(rho) + (sie - Es(rho)) / _Cv;
 }
-PORTABLE_FUNCTION Real DavisProducts::SpecificHeatFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    return _Cv;
+PORTABLE_FUNCTION Real DavisProducts::SpecificHeatFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  return _Cv;
 }
-PORTABLE_FUNCTION Real DavisProducts::BulkModulusFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    const Real vvc = 1/(rho*_vc);
-    const Real Fx = -4*_a*std::pow(vvc,2*_n-1)/square(1+std::pow(vvc,2*_n));
-    const Real tmp = std::pow(0.5*(std::pow(vvc,_n)+std::pow(vvc,-_n)),_a/_n)/std::pow(vvc,_k+_a);
-    const Real tmp_x = 0.5*_a*(std::pow(vvc,_n-1)-std::pow(vvc,-_n-1))*std::pow(0.5*(std::pow(vvc,_n)+std::pow(vvc,-_n)),_a/_n-1)/std::pow(vvc,_k+_a)-(_k+_a)*tmp/vvc;
-    const Real psv = _pc/(_k-1+_a)*(tmp*Fx+(_k-1+F(rho))*tmp_x)/_vc;
-    //const Real esv = _pc*_vc/(_k-1+_a)*(tmp+vvc*tmp_x)/_vc;
-    const Real esv = _pc/(_k-1+_a)*(tmp+vvc*tmp_x);
-    const Real gamma = Gamma(rho);
-    const Real gammav = (1-_b)*Fx*_vc;
-    return -(psv+(sie-Es(rho))*rho*(gammav-gamma*rho)-gamma*rho*esv)/rho;
+PORTABLE_FUNCTION Real DavisProducts::BulkModulusFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  const Real vvc = 1 / (rho * _vc);
+  const Real Fx = -4 * _a * std::pow(vvc, 2 * _n - 1) / square(1 + std::pow(vvc, 2 * _n));
+  const Real tmp = std::pow(0.5 * (std::pow(vvc, _n) + std::pow(vvc, -_n)), _a / _n) /
+                   std::pow(vvc, _k + _a);
+  const Real tmp_x =
+      0.5 * _a * (std::pow(vvc, _n - 1) - std::pow(vvc, -_n - 1)) *
+          std::pow(0.5 * (std::pow(vvc, _n) + std::pow(vvc, -_n)), _a / _n - 1) /
+          std::pow(vvc, _k + _a) -
+      (_k + _a) * tmp / vvc;
+  const Real psv = _pc / (_k - 1 + _a) * (tmp * Fx + (_k - 1 + F(rho)) * tmp_x) / _vc;
+  // const Real esv = _pc*_vc/(_k-1+_a)*(tmp+vvc*tmp_x)/_vc;
+  const Real esv = _pc / (_k - 1 + _a) * (tmp + vvc * tmp_x);
+  const Real gamma = Gamma(rho);
+  const Real gammav = (1 - _b) * Fx * _vc;
+  return -(psv + (sie - Es(rho)) * rho * (gammav - gamma * rho) - gamma * rho * esv) /
+         rho;
 }
 PORTABLE_FUNCTION
 Real DavisProducts::GruneisenParamFromDensityInternalEnergy(const Real rho,
                                                             const Real sie,
-                                                            Real *lambda) const
-{
+                                                            Real *lambda) const {
   return Gamma(rho);
 }
 // Below are "unimplemented" routines
-PORTABLE_FUNCTION Real DavisProducts::PressureFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    return PressureFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real DavisProducts::PressureFromDensityTemperature(const Real rho,
+                                                                     const Real temp,
+                                                                     Real *lambda) const {
+  return PressureFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
-PORTABLE_FUNCTION Real DavisProducts::SpecificHeatFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    return SpecificHeatFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real DavisProducts::SpecificHeatFromDensityTemperature(
+    const Real rho, const Real temp, Real *lambda) const {
+  return SpecificHeatFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
-PORTABLE_FUNCTION Real DavisProducts::BulkModulusFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    return BulkModulusFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real DavisProducts::BulkModulusFromDensityTemperature(
+    const Real rho, const Real temp, Real *lambda) const {
+  return BulkModulusFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
 PORTABLE_FUNCTION
-Real DavisProducts::GruneisenParamFromDensityTemperature(const Real rho,
-                                                         const Real temp,
-                                                         Real *lambda) const
-{
+Real DavisProducts::GruneisenParamFromDensityTemperature(const Real rho, const Real temp,
+                                                         Real *lambda) const {
   return Gamma(rho);
 }
-PORTABLE_FUNCTION void DavisProducts::DensityEnergyFromPressureTemperature(const Real press, const Real temp, Real * lambda, Real & rho, Real & sie) const
-{
-    auto residual = [&](const Real r){return press-(Ps(r)+Gamma(r)*r*_Cv*(temp-Ts(r)));};
-    Real rho1 = 1.0/_vc, res1=residual(rho1);
-    Real slope;
-    Real rho2=rho1*2.0, res2=residual(rho2);
-    Real rhom,resm;
-    for(int i=1;i<20;++i){
-        slope = (rho2-rho1)/(res2-res1);
-	rhom = rho2-res2*slope;
-	resm = residual(rhom);
-	if(resm/press<1e-8) break;
-	rho1=rho2;
-	res1=res2;
-	rho2=rhom;
-	res2=resm;
-    }
-    rho = rhom;
-    sie = InternalEnergyFromDensityTemperature(rho,temp);
+PORTABLE_FUNCTION void DavisProducts::DensityEnergyFromPressureTemperature(
+    const Real press, const Real temp, Real *lambda, Real &rho, Real &sie) const {
+  auto residual = [&](const Real r) {
+    return press - (Ps(r) + Gamma(r) * r * _Cv * (temp - Ts(r)));
+  };
+  Real rho1 = 1.0 / _vc, res1 = residual(rho1);
+  Real slope;
+  Real rho2 = rho1 * 2.0, res2 = residual(rho2);
+  Real rhom, resm;
+  for (int i = 1; i < 20; ++i) {
+    slope = (rho2 - rho1) / (res2 - res1);
+    rhom = rho2 - res2 * slope;
+    resm = residual(rhom);
+    if (resm / press < 1e-8) break;
+    rho1 = rho2;
+    res1 = res2;
+    rho2 = rhom;
+    res2 = resm;
+  }
+  rho = rhom;
+  sie = InternalEnergyFromDensityTemperature(rho, temp);
 }
 PORTABLE_FUNCTION
-void DavisProducts::FillEos(Real& rho, Real& temp, Real& sie,
-                            Real& press, Real& cv, Real& bmod,
-                            const unsigned long output, Real *lambda) const
-{
-    if(output&thermalqs::pressure) press=PressureFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::temperature) temp = TemperatureFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::bulk_modulus) bmod = BulkModulusFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::specific_heat) cv=SpecificHeatFromDensityInternalEnergy(rho,sie);    
+void DavisProducts::FillEos(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                            Real &bmod, const unsigned long output, Real *lambda) const {
+  if (output & thermalqs::pressure) press = PressureFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::temperature)
+    temp = TemperatureFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::bulk_modulus)
+    bmod = BulkModulusFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::specific_heat)
+    cv = SpecificHeatFromDensityInternalEnergy(rho, sie);
 }
-// TODO: pre-cache values instead of computing them 
+// TODO: pre-cache values instead of computing them
 // TODO: chad please decide if these choices are sane
 PORTABLE_FUNCTION
-void DavisProducts::ValuesAtReferenceState(Real& rho, Real& temp, Real& sie, Real& press,
-                                           Real& cv, Real& bmod, Real& dpde, Real& dvdt,
+void DavisProducts::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
+                                           Real &cv, Real &bmod, Real &dpde, Real &dvdt,
                                            Real *lambda) const {
-  rho = 1.0/_vc;
-  sie = 2.*Es(rho);
-  temp = TemperatureFromDensityInternalEnergy(rho,sie);
-  press = PressureFromDensityInternalEnergy(rho,sie);
+  rho = 1.0 / _vc;
+  sie = 2. * Es(rho);
+  temp = TemperatureFromDensityInternalEnergy(rho, sie);
+  press = PressureFromDensityInternalEnergy(rho, sie);
   cv = SpecificHeatFromDensityInternalEnergy(rho, sie);
   bmod = BulkModulusFromDensityInternalEnergy(rho, sie);
-  dpde = Gamma(rho)*rho;
+  dpde = Gamma(rho) * rho;
   // chad please fix this. it's wrong
-  Real gm1 = GruneisenParamFromDensityTemperature(rho,temp)*rho;
-  dvdt = gm1*cv/bmod;
+  Real gm1 = GruneisenParamFromDensityTemperature(rho, temp) * rho;
+  dvdt = gm1 * cv / bmod;
 }
 #if 0
 PORTABLE_FUNCTION void DavisProducts::PTofRE(const Real rho, const Real sie, Real * lambda, Real& press, Real& temp, Real & dpdr, Real & dpde, Real & dtdr, Real & dtde) const

--- a/singularity-eos/eos/eos_eospac.cpp
+++ b/singularity-eos/eos/eos_eospac.cpp
@@ -14,8 +14,8 @@
 
 #ifdef SINGULARITY_USE_EOSPAC
 
-#include <singularity-eos/eos/eos.hpp>
 #include <eos_Interface.h>
+#include <singularity-eos/eos/eos.hpp>
 
 PORTABLE_INLINE_FUNCTION Real TemperatureToSesame(const Real CodeTemp) {
   return CodeTemp;
@@ -29,15 +29,9 @@ PORTABLE_INLINE_FUNCTION Real PressureFromSesame(const Real SesPress) {
 PORTABLE_INLINE_FUNCTION Real PressureToSesame(const Real CodePress) {
   return 1e-10 * CodePress;
 }
-PORTABLE_INLINE_FUNCTION Real SieToSesame(const Real CodeSie) {
-  return 1e-10 * CodeSie;
-}
-PORTABLE_INLINE_FUNCTION Real SieFromSesame(const Real SesSie) {
-  return 1e10 * SesSie;
-}
-PORTABLE_INLINE_FUNCTION Real CvFromSesame(const Real SesCv) {
-  return 1e10 * SesCv;
-}
+PORTABLE_INLINE_FUNCTION Real SieToSesame(const Real CodeSie) { return 1e-10 * CodeSie; }
+PORTABLE_INLINE_FUNCTION Real SieFromSesame(const Real SesSie) { return 1e10 * SesSie; }
+PORTABLE_INLINE_FUNCTION Real CvFromSesame(const Real SesCv) { return 1e10 * SesCv; }
 PORTABLE_INLINE_FUNCTION Real BulkModulusFromSesame(const Real SesBmod) {
   return 1e10 * SesBmod;
 }
@@ -50,8 +44,7 @@ namespace singularity {
 
 EOSPAC::EOSPAC(const int matid) : matid_(matid) {
   EOS_INTEGER ntables = NT, errorCode = EOS_OK;
-  EOS_INTEGER tableType[NT] = {EOS_Pt_DT, EOS_T_DUt, EOS_Ut_DT, EOS_D_PtT,
-                               EOS_Info};
+  EOS_INTEGER tableType[NT] = {EOS_Pt_DT, EOS_T_DUt, EOS_Ut_DT, EOS_D_PtT, EOS_Info};
   EOS_INTEGER MATID[NT];
   for (int i = 0; i < NT; i++) {
     MATID[i] = matid;
@@ -91,33 +84,32 @@ EOSPAC::EOSPAC(const int matid) : matid_(matid) {
   BMOD = rho_ref_ * DPDR + DPDE * (PRESS / (rho_ref_ + EPS) - rho_ref_ * DEDR);
   bmod_ref_ = BulkModulusFromSesame(std::max(BMOD, 0.0));
   dpde_ref_ = PressureFromSesame(SieToSesame(DPDE));
-  dvdt_ref_ = dpde_ref_ * cv_ref_ /
-              (rho_ref_ * rho_ref_ * PressureFromSesame(DPDR) + EPS);
+  dvdt_ref_ =
+      dpde_ref_ * cv_ref_ / (rho_ref_ * rho_ref_ * PressureFromSesame(DPDR) + EPS);
 }
 
-PORTABLE_FUNCTION Real EOSPAC::TemperatureFromDensityInternalEnergy(
-    const Real rho, const Real sie, Real *lambda) const {
+PORTABLE_FUNCTION Real EOSPAC::TemperatureFromDensityInternalEnergy(const Real rho,
+                                                                    const Real sie,
+                                                                    Real *lambda) const {
   EOS_REAL R[1] = {rho}, E[1] = {SieToSesame(sie)}, T[1], dTdr[1], dTde[1];
   EOS_INTEGER nxypairs = 1, errorCode;
   EOS_INTEGER table = TofRE_table_;
   eos_Interpolate(&table, &nxypairs, R, E, T, dTdr, dTde, &errorCode);
   return Real(TemperatureFromSesame(T[0]));
 }
-PORTABLE_FUNCTION Real EOSPAC::PressureFromDensityTemperature(
-    const Real rho, const Real temp, Real *lambda) const {
-  EOS_REAL R[1] = {rho}, P[1], T[1] = {TemperatureToSesame(temp)}, dPdr[1],
-           dPdT[1];
+PORTABLE_FUNCTION Real EOSPAC::PressureFromDensityTemperature(const Real rho,
+                                                              const Real temp,
+                                                              Real *lambda) const {
+  EOS_REAL R[1] = {rho}, P[1], T[1] = {TemperatureToSesame(temp)}, dPdr[1], dPdT[1];
   EOS_INTEGER nxypairs = 1, errorCode;
   EOS_INTEGER table = PofRT_table_;
   eos_Interpolate(&table, &nxypairs, R, T, P, dPdr, dPdT, &errorCode);
   return Real(PressureFromSesame(P[0]));
 }
-PORTABLE_FUNCTION void EOSPAC::FillEos(Real &rho, Real &temp, Real &sie,
-                                       Real &press, Real &cv, Real &bmod,
-                                       const unsigned long output,
+PORTABLE_FUNCTION void EOSPAC::FillEos(Real &rho, Real &temp, Real &sie, Real &press,
+                                       Real &cv, Real &bmod, const unsigned long output,
                                        Real *lambda) const {
-  EOS_REAL R[1] = {rho}, T[1] = {TemperatureToSesame(temp)}, E[1], P[1], dx[1],
-           dy[1];
+  EOS_REAL R[1] = {rho}, T[1] = {TemperatureToSesame(temp)}, E[1], P[1], dx[1], dy[1];
   EOS_INTEGER nxypairs = 1, errorCode = EOS_OK;
   Real CV, BMOD_T, BMOD, SIE, PRESS, DPDE, DPDT, DPDR, DEDT, DEDR;
   if ((output & thermalqs::specific_internal_energy) ||
@@ -169,39 +161,45 @@ PORTABLE_FUNCTION void EOSPAC::FillEos(Real &rho, Real &temp, Real &sie,
   }
 }
 
-PORTABLE_FUNCTION Real EOSPAC::InternalEnergyFromDensityTemperature(
-    const Real rho, const Real temp, Real *lambda) const {
+PORTABLE_FUNCTION Real EOSPAC::InternalEnergyFromDensityTemperature(const Real rho,
+                                                                    const Real temp,
+                                                                    Real *lambda) const {
   Real RHO = rho, TEMP = temp, sie, press, cv, bmod;
   const unsigned long output = thermalqs::specific_internal_energy;
   FillEos(RHO, TEMP, sie, press, cv, bmod, output, lambda);
   return sie;
 }
-PORTABLE_FUNCTION Real EOSPAC::BulkModulusFromDensityTemperature(
-    const Real rho, const Real temp, Real *lambda) const {
+PORTABLE_FUNCTION Real EOSPAC::BulkModulusFromDensityTemperature(const Real rho,
+                                                                 const Real temp,
+                                                                 Real *lambda) const {
   Real RHO = rho, TEMP = temp, sie, press, cv, bmod;
   const unsigned long output = thermalqs::bulk_modulus;
   FillEos(RHO, TEMP, sie, press, cv, bmod, output, lambda);
   return bmod;
 }
-PORTABLE_FUNCTION Real EOSPAC::SpecificHeatFromDensityTemperature(
-    const Real rho, const Real temp, Real *lambda) const {
+PORTABLE_FUNCTION Real EOSPAC::SpecificHeatFromDensityTemperature(const Real rho,
+                                                                  const Real temp,
+                                                                  Real *lambda) const {
   Real RHO = rho, TEMP = temp, sie, press, cv, bmod;
   const unsigned long output = thermalqs::specific_heat;
   FillEos(RHO, TEMP, sie, press, cv, bmod, output, lambda);
   return cv;
 }
-PORTABLE_FUNCTION Real EOSPAC::PressureFromDensityInternalEnergy(
-    const Real rho, const Real sie, Real *lambda) const {
+PORTABLE_FUNCTION Real EOSPAC::PressureFromDensityInternalEnergy(const Real rho,
+                                                                 const Real sie,
+                                                                 Real *lambda) const {
   Real temp = TemperatureFromDensityInternalEnergy(rho, sie, lambda);
   return PressureFromDensityTemperature(rho, temp, lambda);
 }
-PORTABLE_FUNCTION Real EOSPAC::SpecificHeatFromDensityInternalEnergy(
-    const Real rho, const Real sie, Real *lambda) const {
+PORTABLE_FUNCTION Real EOSPAC::SpecificHeatFromDensityInternalEnergy(const Real rho,
+                                                                     const Real sie,
+                                                                     Real *lambda) const {
   Real temp = TemperatureFromDensityInternalEnergy(rho, sie, lambda);
   return SpecificHeatFromDensityTemperature(rho, temp, lambda);
 }
-PORTABLE_FUNCTION Real EOSPAC::BulkModulusFromDensityInternalEnergy(
-    const Real rho, const Real sie, Real *lambda) const {
+PORTABLE_FUNCTION Real EOSPAC::BulkModulusFromDensityInternalEnergy(const Real rho,
+                                                                    const Real sie,
+                                                                    Real *lambda) const {
   Real temp = TemperatureFromDensityInternalEnergy(rho, sie, lambda);
   return BulkModulusFromDensityTemperature(rho, temp, lambda);
 }
@@ -229,8 +227,8 @@ PORTABLE_FUNCTION Real EOSPAC::GruneisenParamFromDensityInternalEnergy(
 
 PORTABLE_FUNCTION
 void EOSPAC::DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-						  Real *lambda, Real &rho,
-						  Real &sie) const {
+                                                  Real *lambda, Real &rho,
+                                                  Real &sie) const {
   EOS_REAL P[1] = {PressureToSesame(press)};
   EOS_REAL T[1] = {TemperatureToSesame(temp)};
   EOS_REAL dx[1], dy[1], R[1], E[1];
@@ -241,16 +239,15 @@ void EOSPAC::DensityEnergyFromPressureTemperature(const Real press, const Real t
   table = RofPT_table_;
   eos_Interpolate(&table, &nxypairs, P, T, R, dx, dy, &errorCode);
   rho = R[0];
-  
+
   table = EofRT_table_;
   eos_Interpolate(&table, &nxypairs, R, T, E, dx, dy, &errorCode);
   sie = SieFromSesame(E[0]);
 }
 
-PORTABLE_FUNCTION void EOSPAC::PTofRE(const Real rho, const Real sie,
-                                      Real *lambda, Real &press, Real &temp,
-                                      Real &dpdr, Real &dpde, Real &dtdr,
-                                      Real &dtde) const {
+PORTABLE_FUNCTION void EOSPAC::PTofRE(const Real rho, const Real sie, Real *lambda,
+                                      Real &press, Real &temp, Real &dpdr, Real &dpde,
+                                      Real &dtdr, Real &dtde) const {
   EOS_REAL R[1] = {rho}, T[1], E[1] = {SieToSesame(sie)}, P[1], dx[1], dy[1];
   EOS_INTEGER nxypairs = 1, errorCode = EOS_OK;
   Real DTDR_E, DTDE_R, DPDR_T, DPDT_R;
@@ -272,9 +269,8 @@ PORTABLE_FUNCTION void EOSPAC::PTofRE(const Real rho, const Real sie,
   dpdr = PressureFromSesame(DPDR_T + DTDR_E * DPDT_R);
 }
 
-PORTABLE_FUNCTION void EOSPAC::ValuesAtReferenceState(Real &rho, Real &temp,
-                                                      Real &sie, Real &press,
-                                                      Real &cv, Real &bmod,
+PORTABLE_FUNCTION void EOSPAC::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie,
+                                                      Real &press, Real &cv, Real &bmod,
                                                       Real &dpde, Real &dvdt,
                                                       Real *lambda) const {
   rho = rho_ref_;

--- a/singularity-eos/eos/eos_gruneisen.cpp
+++ b/singularity-eos/eos/eos_gruneisen.cpp
@@ -16,138 +16,146 @@
 
 namespace singularity {
 
-PORTABLE_INLINE_FUNCTION Real square(const Real x) {return x*x;}
-PORTABLE_INLINE_FUNCTION Real cube(const Real x) {return x*x*x;}
-PORTABLE_FUNCTION Real Gruneisen::InternalEnergyFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-  return _Cv*(temp-_T0);
+PORTABLE_INLINE_FUNCTION Real square(const Real x) { return x * x; }
+PORTABLE_INLINE_FUNCTION Real cube(const Real x) { return x * x * x; }
+PORTABLE_FUNCTION Real Gruneisen::InternalEnergyFromDensityTemperature(
+    const Real rho, const Real temp, Real *lambda) const {
+  return _Cv * (temp - _T0);
 }
-PORTABLE_FUNCTION Real Gruneisen::TemperatureFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-  return _T0+sie/_Cv;
+PORTABLE_FUNCTION Real Gruneisen::TemperatureFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  return _T0 + sie / _Cv;
 }
-PORTABLE_FUNCTION Real Gruneisen::PressureFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{ // Will a compiler clean this up for me?
-    const Real top2 = 1.0-0.5*_G0;
-    const Real top3 = -0.5*_b;
-    const Real eta = rho/_rho0;
-    const Real mu = eta-1.0;
-    Real scale = 1.0;
-    const Real G = Gamma(rho);
-    if(mu>0.0){
-        const Real top = 1.0+mu*(top2+mu*top3);
-        const Real z = mu/eta;
-        const Real bot1 = (1.0-_s1)*mu;
-        const Real bot2 = -_s2*mu*z;
-        const Real bot3 = -_s3*mu*z*z;
-        const Real bot = 1.0+bot1+bot2+bot3;
-        scale = top/square(bot);
-        //if(sie>0.0) G = _G0+_b*mu;
-    }
-    const Real rho_min = rho < _rho0 ? rho : _rho0;
-    return scale*_rho0*_C0*_C0*mu+G*rho_min*sie;
+PORTABLE_FUNCTION Real Gruneisen::PressureFromDensityInternalEnergy(
+    const Real rho, const Real sie,
+    Real *lambda) const { // Will a compiler clean this up for me?
+  const Real top2 = 1.0 - 0.5 * _G0;
+  const Real top3 = -0.5 * _b;
+  const Real eta = rho / _rho0;
+  const Real mu = eta - 1.0;
+  Real scale = 1.0;
+  const Real G = Gamma(rho);
+  if (mu > 0.0) {
+    const Real top = 1.0 + mu * (top2 + mu * top3);
+    const Real z = mu / eta;
+    const Real bot1 = (1.0 - _s1) * mu;
+    const Real bot2 = -_s2 * mu * z;
+    const Real bot3 = -_s3 * mu * z * z;
+    const Real bot = 1.0 + bot1 + bot2 + bot3;
+    scale = top / square(bot);
+    // if(sie>0.0) G = _G0+_b*mu;
+  }
+  const Real rho_min = rho < _rho0 ? rho : _rho0;
+  return scale * _rho0 * _C0 * _C0 * mu + G * rho_min * sie;
 }
-PORTABLE_FUNCTION Real Gruneisen::SpecificHeatFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
+PORTABLE_FUNCTION Real Gruneisen::SpecificHeatFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
   return _Cv;
 }
-PORTABLE_FUNCTION Real Gruneisen::BulkModulusFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-  const Real mu = rho/_rho0-1;
-  if(mu <= 0)
-  {
-    return rho*square(_C0)+
-           _G0*(rho*sie + PressureFromDensityInternalEnergy(rho,sie));
-  }
-  else
-  {
-    const Real x = 1-_rho0/rho;
-    const Real s = _s1+_s2*x+_s3*square(x);
-    const Real ds = _s2 + 2*_s3*x;
-    const Real Pr = _rho0*square(_C0)*x/square(1-x*s);
-    const Real dPr = -square(_rho0*_C0)*(1+x*(s+2*x*ds))/cube(1-s*x);
-    const Real G = _G0+_b*mu;
-    return -dPr/rho*(1-0.5*G*x)-0.5*G*Pr+G*PressureFromDensityInternalEnergy(rho,sie)/(mu+1)+rho*_b*sie;
+PORTABLE_FUNCTION Real Gruneisen::BulkModulusFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  const Real mu = rho / _rho0 - 1;
+  if (mu <= 0) {
+    return rho * square(_C0) +
+           _G0 * (rho * sie + PressureFromDensityInternalEnergy(rho, sie));
+  } else {
+    const Real x = 1 - _rho0 / rho;
+    const Real s = _s1 + _s2 * x + _s3 * square(x);
+    const Real ds = _s2 + 2 * _s3 * x;
+    const Real Pr = _rho0 * square(_C0) * x / square(1 - x * s);
+    const Real dPr = -square(_rho0 * _C0) * (1 + x * (s + 2 * x * ds)) / cube(1 - s * x);
+    const Real G = _G0 + _b * mu;
+    return -dPr / rho * (1 - 0.5 * G * x) - 0.5 * G * Pr +
+           G * PressureFromDensityInternalEnergy(rho, sie) / (mu + 1) + rho * _b * sie;
   }
 }
 PORTABLE_FUNCTION
-Real Gruneisen::GruneisenParamFromDensityInternalEnergy(const Real rho,
-                                                        const Real sie,
-                                                        Real *lambda) const
-{
+Real Gruneisen::GruneisenParamFromDensityInternalEnergy(const Real rho, const Real sie,
+                                                        Real *lambda) const {
   return Gamma(rho);
 }
 // Below are "unimplemented" routines
-PORTABLE_FUNCTION Real Gruneisen::PressureFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-  return PressureFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real Gruneisen::PressureFromDensityTemperature(const Real rho,
+                                                                 const Real temp,
+                                                                 Real *lambda) const {
+  return PressureFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
-PORTABLE_FUNCTION Real Gruneisen::SpecificHeatFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-  return SpecificHeatFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real Gruneisen::SpecificHeatFromDensityTemperature(const Real rho,
+                                                                     const Real temp,
+                                                                     Real *lambda) const {
+  return SpecificHeatFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
-PORTABLE_FUNCTION Real Gruneisen::BulkModulusFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-  return BulkModulusFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real Gruneisen::BulkModulusFromDensityTemperature(const Real rho,
+                                                                    const Real temp,
+                                                                    Real *lambda) const {
+  return BulkModulusFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
 PORTABLE_FUNCTION
-Real Gruneisen::GruneisenParamFromDensityTemperature(const Real rho,
-                                                     const Real temp,
-                                                     Real *lambda) const
-{
+Real Gruneisen::GruneisenParamFromDensityTemperature(const Real rho, const Real temp,
+                                                     Real *lambda) const {
   return Gamma(rho);
 }
-PORTABLE_FUNCTION void Gruneisen::DensityEnergyFromPressureTemperature(const Real press, const Real temp, Real * lambda, Real& rho, Real& sie) const
-{
-    sie = _Cv*(temp-_T0);
-    // We have a branch at rho0, so we need to decide, based on our pressure, whether we should be above
-    // or below rho0
-    Real Pref = PressureFromDensityInternalEnergy(_rho0,sie);
-    if(press < Pref) {
-        rho = (press+_C0*_C0*_rho0)/(_C0*_C0+_G0*sie);
+PORTABLE_FUNCTION void Gruneisen::DensityEnergyFromPressureTemperature(
+    const Real press, const Real temp, Real *lambda, Real &rho, Real &sie) const {
+  sie = _Cv * (temp - _T0);
+  // We have a branch at rho0, so we need to decide, based on our pressure, whether we
+  // should be above or below rho0
+  Real Pref = PressureFromDensityInternalEnergy(_rho0, sie);
+  if (press < Pref) {
+    rho = (press + _C0 * _C0 * _rho0) / (_C0 * _C0 + _G0 * sie);
+  } else { // We are in compression; iterate
+    auto residual = [&](const Real r) {
+      return press - PressureFromDensityInternalEnergy(r, sie);
+    };
+    Real rho1 = _rho0, res1 = residual(rho1), slope = _G0 * sie + _C0 * _C0, rho2, res2,
+         rhom, resm;
+    rho2 = (rho > rho1 + 1e-3) ? rho : rho1 + res1 / slope;
+    res2 = residual(rho2);
+    for (int i = 0; i < 20; ++i) {
+      slope = (rho2 - rho1) / (res2 - res1 + 1.0e-10);
+      rhom = rho2 - res2 * slope;
+      resm = residual(rhom);
+      if (resm / press < 1e-8) break;
+      rho1 = rho2;
+      res1 = res2;
+      rho2 = rhom;
+      res2 = resm;
     }
-    else { // We are in compression; iterate
-	auto residual = [&](const Real r){return press-PressureFromDensityInternalEnergy(r,sie);};
-        Real rho1 = _rho0, res1 = residual(rho1),slope = _G0*sie+_C0*_C0, rho2, res2, rhom, resm;
-        rho2 = (rho>rho1+1e-3)? rho : rho1+res1/slope;
-	res2 = residual(rho2);
-	for(int i=0;i<20;++i){
-            slope = (rho2-rho1)/(res2-res1+1.0e-10);
-	    rhom = rho2 - res2*slope;
-	    resm = residual(rhom);
-	    if(resm/press<1e-8) break;
-	    rho1=rho2;
-	    res1=res2;
-	    rho2=rhom;
-	    res2=resm;
-	}
-        rho = rhom;
-    }
+    rho = rhom;
+  }
 }
-PORTABLE_FUNCTION void Gruneisen::FillEos(Real & rho, Real & temp, Real & sie, Real & press, Real & cv, Real & bmod, const unsigned long output, Real * lambda) const
-{
-//The following could be sped up with work!
-    if(output&thermalqs::pressure) press=PressureFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::temperature) temp = TemperatureFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::bulk_modulus) bmod = BulkModulusFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::specific_heat) cv=SpecificHeatFromDensityInternalEnergy(rho,sie);
+PORTABLE_FUNCTION void Gruneisen::FillEos(Real &rho, Real &temp, Real &sie, Real &press,
+                                          Real &cv, Real &bmod,
+                                          const unsigned long output,
+                                          Real *lambda) const {
+  // The following could be sped up with work!
+  if (output & thermalqs::pressure) press = PressureFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::temperature)
+    temp = TemperatureFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::bulk_modulus)
+    bmod = BulkModulusFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::specific_heat)
+    cv = SpecificHeatFromDensityInternalEnergy(rho, sie);
 }
 
 // TODO(JMM): pre-cache these rather than recomputing them each time
 PORTABLE_FUNCTION
-void Gruneisen::ValuesAtReferenceState(Real& rho, Real& temp, Real& sie, Real& press,
-                                       Real& cv, Real& bmod, Real& dpde, Real& dvdt,
+void Gruneisen::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
+                                       Real &cv, Real &bmod, Real &dpde, Real &dvdt,
                                        Real *lambda) const {
   rho = _rho0;
   temp = _T0;
   sie = 0;
-  press = PressureFromDensityInternalEnergy(rho,sie,lambda);
-  cv = SpecificHeatFromDensityInternalEnergy(rho,sie,lambda);
-  bmod = BulkModulusFromDensityInternalEnergy(rho,sie,lambda);
-  dpde = PressureFromDensityInternalEnergy(rho,sie,lambda)/sie;
+  press = PressureFromDensityInternalEnergy(rho, sie, lambda);
+  cv = SpecificHeatFromDensityInternalEnergy(rho, sie, lambda);
+  bmod = BulkModulusFromDensityInternalEnergy(rho, sie, lambda);
+  dpde = PressureFromDensityInternalEnergy(rho, sie, lambda) / sie;
   // TODO: chad please fix this one for me. This is wrong.
-  Real gm1 = GruneisenParamFromDensityInternalEnergy(rho,sie,lambda)*rho;
-  dvdt = gm1*cv / bmod;
+  Real gm1 = GruneisenParamFromDensityInternalEnergy(rho, sie, lambda) * rho;
+  dvdt = gm1 * cv / bmod;
 }
 
 #if 0

--- a/singularity-eos/eos/eos_ideal.cpp
+++ b/singularity-eos/eos/eos_ideal.cpp
@@ -14,78 +14,78 @@
 
 #include <singularity-eos/eos/eos.hpp>
 
-#define MYMAX(a,b) a > b ? a : b
+#define MYMAX(a, b) a > b ? a : b
 
 namespace singularity {
 
 //---------------------
 // Ideal Gas EOS
 //---------------------
-PORTABLE_FUNCTION Real IdealGas::InternalEnergyFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-  return MYMAX(0.0,_Cv*temp);
+PORTABLE_FUNCTION Real IdealGas::InternalEnergyFromDensityTemperature(
+    const Real rho, const Real temp, Real *lambda) const {
+  return MYMAX(0.0, _Cv * temp);
 }
-PORTABLE_FUNCTION Real IdealGas::TemperatureFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-  return MYMAX(0.0,sie/_Cv);
+PORTABLE_FUNCTION Real IdealGas::TemperatureFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  return MYMAX(0.0, sie / _Cv);
 }
-PORTABLE_FUNCTION Real IdealGas::PressureFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-  return MYMAX(0.0,_gm1*rho*sie);
+PORTABLE_FUNCTION Real IdealGas::PressureFromDensityInternalEnergy(const Real rho,
+                                                                   const Real sie,
+                                                                   Real *lambda) const {
+  return MYMAX(0.0, _gm1 * rho * sie);
 }
-PORTABLE_FUNCTION Real IdealGas::SpecificHeatFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    return _Cv;
+PORTABLE_FUNCTION Real IdealGas::SpecificHeatFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  return _Cv;
 }
-PORTABLE_FUNCTION Real IdealGas::BulkModulusFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-  return MYMAX(0.0,(_gm1+1)*_gm1*rho*sie);
+PORTABLE_FUNCTION Real IdealGas::BulkModulusFromDensityInternalEnergy(
+    const Real rho, const Real sie, Real *lambda) const {
+  return MYMAX(0.0, (_gm1 + 1) * _gm1 * rho * sie);
 }
 
 PORTABLE_FUNCTION
-Real IdealGas::GruneisenParamFromDensityInternalEnergy(const Real rho,
-                                                       const Real sie,
-                                                       Real *lambda) const
-{
+Real IdealGas::GruneisenParamFromDensityInternalEnergy(const Real rho, const Real sie,
+                                                       Real *lambda) const {
   return _gm1;
 }
 
-PORTABLE_FUNCTION void IdealGas::DensityEnergyFromPressureTemperature(const Real press, const Real temp, Real * lambda, Real & rho, Real & sie) const
-{
-  sie = MYMAX(0.0,_Cv*temp);
-  rho = MYMAX(0.0,press/(_gm1*sie));
+PORTABLE_FUNCTION void
+IdealGas::DensityEnergyFromPressureTemperature(const Real press, const Real temp,
+                                               Real *lambda, Real &rho, Real &sie) const {
+  sie = MYMAX(0.0, _Cv * temp);
+  rho = MYMAX(0.0, press / (_gm1 * sie));
 }
 
 PORTABLE_FUNCTION
-void IdealGas::FillEos(Real & rho, Real & temp,
-                       Real & sie, Real & press,
-                       Real & cv, Real & bmod,
-                       const unsigned long output, Real * lambda) const
-{
-  if (output&thermalqs::density && output&thermalqs::specific_internal_energy) {
-    if (output&thermalqs::pressure || output&thermalqs::temperature) {
+void IdealGas::FillEos(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                       Real &bmod, const unsigned long output, Real *lambda) const {
+  if (output & thermalqs::density && output & thermalqs::specific_internal_energy) {
+    if (output & thermalqs::pressure || output & thermalqs::temperature) {
       UNDEFINED_ERROR;
     }
     DensityEnergyFromPressureTemperature(press, temp, lambda, rho, sie);
   }
-  if (output&thermalqs::pressure && output&thermalqs::specific_internal_energy) {
-    if (output&thermalqs::density || output&thermalqs::temperature) {
+  if (output & thermalqs::pressure && output & thermalqs::specific_internal_energy) {
+    if (output & thermalqs::density || output & thermalqs::temperature) {
       UNDEFINED_ERROR;
     }
     sie = InternalEnergyFromDensityTemperature(rho, temp, lambda);
   }
-  if (output&thermalqs::temperature && output&thermalqs::specific_internal_energy) {
-    sie = press / ( _gm1 * rho );
+  if (output & thermalqs::temperature && output & thermalqs::specific_internal_energy) {
+    sie = press / (_gm1 * rho);
   }
-  if (output&thermalqs::pressure) press=PressureFromDensityInternalEnergy(rho,sie);
-  if (output&thermalqs::temperature) temp = TemperatureFromDensityInternalEnergy(rho,sie);
-  if (output&thermalqs::bulk_modulus) bmod = BulkModulusFromDensityInternalEnergy(rho,sie);
-  if (output&thermalqs::specific_heat) cv=SpecificHeatFromDensityInternalEnergy(rho,sie);
+  if (output & thermalqs::pressure) press = PressureFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::temperature)
+    temp = TemperatureFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::bulk_modulus)
+    bmod = BulkModulusFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::specific_heat)
+    cv = SpecificHeatFromDensityInternalEnergy(rho, sie);
 }
 
 PORTABLE_FUNCTION
-void IdealGas::ValuesAtReferenceState(Real& rho, Real& temp, Real& sie, Real& press,
-                                      Real& cv, Real& bmod, Real& dpde, Real& dvdt,
+void IdealGas::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press,
+                                      Real &cv, Real &bmod, Real &dpde, Real &dvdt,
                                       Real *lambda) const {
   // use STP: 1 atmosphere, room temperature
   rho = _rho0;
@@ -100,31 +100,24 @@ void IdealGas::ValuesAtReferenceState(Real& rho, Real& temp, Real& sie, Real& pr
 
 PORTABLE_FUNCTION
 Real IdealGas::PressureFromDensityTemperature(const Real rho, const Real temp,
-                                              Real* lambda) const
-{
-  return MYMAX(0.0,_gm1*rho*_Cv*temp);
+                                              Real *lambda) const {
+  return MYMAX(0.0, _gm1 * rho * _Cv * temp);
 }
 
 PORTABLE_FUNCTION
-Real IdealGas::SpecificHeatFromDensityTemperature(const Real rho,
-                                                  const Real temp,
-                                                  Real* lambda) const
-{
+Real IdealGas::SpecificHeatFromDensityTemperature(const Real rho, const Real temp,
+                                                  Real *lambda) const {
   return _Cv;
 }
 PORTABLE_FUNCTION
-Real IdealGas::BulkModulusFromDensityTemperature(const Real rho,
-                                                 const Real temp,
-                                                 Real* lambda) const
-{
-  return MYMAX(0.0,(_gm1+1)*_gm1*rho*_Cv*temp);
+Real IdealGas::BulkModulusFromDensityTemperature(const Real rho, const Real temp,
+                                                 Real *lambda) const {
+  return MYMAX(0.0, (_gm1 + 1) * _gm1 * rho * _Cv * temp);
 }
 
 PORTABLE_FUNCTION
-Real IdealGas::GruneisenParamFromDensityTemperature(const Real rho,
-                                                    const Real temp,
-                                                    Real* lambda) const
-{
+Real IdealGas::GruneisenParamFromDensityTemperature(const Real rho, const Real temp,
+                                                    Real *lambda) const {
   return _gm1;
 }
 

--- a/singularity-eos/eos/eos_jwl.cpp
+++ b/singularity-eos/eos/eos_jwl.cpp
@@ -12,112 +12,128 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
-#include <singularity-eos/eos/eos.hpp>
 #include <cmath>
+#include <singularity-eos/eos/eos.hpp>
 
 namespace singularity {
 
-PORTABLE_FUNCTION Real JWL::ReferenceEnergy(const Real rho) const
-{
-    const Real x = _rho0/rho;
-    return _A*std::exp(-_R1*x)+_B*std::exp(-_R2*x);
+PORTABLE_FUNCTION Real JWL::ReferenceEnergy(const Real rho) const {
+  const Real x = _rho0 / rho;
+  return _A * std::exp(-_R1 * x) + _B * std::exp(-_R2 * x);
 }
-PORTABLE_FUNCTION Real JWL::ReferencePressure(const Real rho) const
-{
-    const Real x = _rho0/rho;
-    return _A/(_rho0*_R1)*std::exp(-_R1*x)+_B/(_rho0*_R2)*std::exp(-_R2*x);
+PORTABLE_FUNCTION Real JWL::ReferencePressure(const Real rho) const {
+  const Real x = _rho0 / rho;
+  return _A / (_rho0 * _R1) * std::exp(-_R1 * x) +
+         _B / (_rho0 * _R2) * std::exp(-_R2 * x);
 }
-PORTABLE_FUNCTION Real JWL::InternalEnergyFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    return ReferenceEnergy(rho) + _Cv*temp;
+PORTABLE_FUNCTION Real JWL::InternalEnergyFromDensityTemperature(const Real rho,
+                                                                 const Real temp,
+                                                                 Real *lambda) const {
+  return ReferenceEnergy(rho) + _Cv * temp;
 }
-PORTABLE_FUNCTION Real JWL::PressureFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    return ReferencePressure(rho)+_w*rho*(sie-ReferenceEnergy(rho));
+PORTABLE_FUNCTION Real JWL::PressureFromDensityInternalEnergy(const Real rho,
+                                                              const Real sie,
+                                                              Real *lambda) const {
+  return ReferencePressure(rho) + _w * rho * (sie - ReferenceEnergy(rho));
 }
-PORTABLE_FUNCTION Real JWL::TemperatureFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    return (sie-ReferenceEnergy(rho))/_Cv;
+PORTABLE_FUNCTION Real JWL::TemperatureFromDensityInternalEnergy(const Real rho,
+                                                                 const Real sie,
+                                                                 Real *lambda) const {
+  return (sie - ReferenceEnergy(rho)) / _Cv;
 }
-PORTABLE_FUNCTION Real JWL::SpecificHeatFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    return _Cv;
+PORTABLE_FUNCTION Real JWL::SpecificHeatFromDensityInternalEnergy(const Real rho,
+                                                                  const Real sie,
+                                                                  Real *lambda) const {
+  return _Cv;
 }
-PORTABLE_FUNCTION Real JWL::BulkModulusFromDensityInternalEnergy(const Real rho, const Real sie, Real *lambda) const
-{
-    const Real x = _rho0/rho;
-    //return (_w+1)*(PressureFromDensityInternalEnergy(rho,sie)-ReferencePressure(rho))+x*(_A*_R1*std::exp(-_R1*x)+_B*_R2*std::exp(-_R2*x));
-    return (_w+1)*_w*rho*(sie-ReferenceEnergy(rho))+x*(_A*_R1*std::exp(-_R1*x)+_B*_R2*std::exp(-_R2*x));
+PORTABLE_FUNCTION Real JWL::BulkModulusFromDensityInternalEnergy(const Real rho,
+                                                                 const Real sie,
+                                                                 Real *lambda) const {
+  const Real x = _rho0 / rho;
+  // return
+  // (_w+1)*(PressureFromDensityInternalEnergy(rho,sie)-ReferencePressure(rho))+x*(_A*_R1*std::exp(-_R1*x)+_B*_R2*std::exp(-_R2*x));
+  return (_w + 1) * _w * rho * (sie - ReferenceEnergy(rho)) +
+         x * (_A * _R1 * std::exp(-_R1 * x) + _B * _R2 * std::exp(-_R2 * x));
 }
 PORTABLE_FUNCTION
-Real JWL::GruneisenParamFromDensityInternalEnergy(const Real rho,
-                                                  const Real sie,
-                                                  Real *lambda) const
-{
+Real JWL::GruneisenParamFromDensityInternalEnergy(const Real rho, const Real sie,
+                                                  Real *lambda) const {
   return _w;
 }
 // Below are "unimplemented" routines
-PORTABLE_FUNCTION Real JWL::PressureFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    return PressureFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real JWL::PressureFromDensityTemperature(const Real rho,
+                                                           const Real temp,
+                                                           Real *lambda) const {
+  return PressureFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
-PORTABLE_FUNCTION Real JWL::SpecificHeatFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    return SpecificHeatFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real JWL::SpecificHeatFromDensityTemperature(const Real rho,
+                                                               const Real temp,
+                                                               Real *lambda) const {
+  return SpecificHeatFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
-PORTABLE_FUNCTION Real JWL::BulkModulusFromDensityTemperature(const Real rho, const Real temp, Real *lambda) const
-{
-    return BulkModulusFromDensityInternalEnergy(rho,InternalEnergyFromDensityTemperature(rho,temp));
+PORTABLE_FUNCTION Real JWL::BulkModulusFromDensityTemperature(const Real rho,
+                                                              const Real temp,
+                                                              Real *lambda) const {
+  return BulkModulusFromDensityInternalEnergy(
+      rho, InternalEnergyFromDensityTemperature(rho, temp));
 }
 PORTABLE_FUNCTION
-Real JWL::GruneisenParamFromDensityTemperature(const Real rho,
-                                               const Real temp,
-                                               Real *lambda) const
-{
+Real JWL::GruneisenParamFromDensityTemperature(const Real rho, const Real temp,
+                                               Real *lambda) const {
   return _w;
 }
-PORTABLE_FUNCTION void JWL::DensityEnergyFromPressureTemperature(const Real press, const Real temp, Real * lambda, Real & rho, Real & sie) const
-{
-    // sie = sie_r + cv*T;  Thus sie-sie_r = cv*T
-    // Thus P = P_r +_w*rho*cv*T ==> Invertable?
-    // Turns out not to be exactly invertible
-    Real rhoguess = (rho < 1e-8) ? _rho0 : rho;
-    // Does this define a lambda correctly?
-    auto residual = [&](const Real r){return _Cv*temp*r*_w+ReferencePressure(r) - press;};
-    Real res;
-    for(int iter=0;iter<20;++iter){
-	res = residual(rhoguess);
-	if(std::abs(res/press)<1e-8) break;
-	rhoguess -= res/(ReferenceEnergy(rhoguess)/(rhoguess*rhoguess)+_Cv*_w*temp);
-    }
-    rho = rhoguess;
-    sie = InternalEnergyFromDensityTemperature(rho,temp);
+PORTABLE_FUNCTION void JWL::DensityEnergyFromPressureTemperature(const Real press,
+                                                                 const Real temp,
+                                                                 Real *lambda, Real &rho,
+                                                                 Real &sie) const {
+  // sie = sie_r + cv*T;  Thus sie-sie_r = cv*T
+  // Thus P = P_r +_w*rho*cv*T ==> Invertable?
+  // Turns out not to be exactly invertible
+  Real rhoguess = (rho < 1e-8) ? _rho0 : rho;
+  // Does this define a lambda correctly?
+  auto residual = [&](const Real r) {
+    return _Cv * temp * r * _w + ReferencePressure(r) - press;
+  };
+  Real res;
+  for (int iter = 0; iter < 20; ++iter) {
+    res = residual(rhoguess);
+    if (std::abs(res / press) < 1e-8) break;
+    rhoguess -=
+        res / (ReferenceEnergy(rhoguess) / (rhoguess * rhoguess) + _Cv * _w * temp);
+  }
+  rho = rhoguess;
+  sie = InternalEnergyFromDensityTemperature(rho, temp);
 }
-PORTABLE_FUNCTION void JWL::FillEos(Real & rho, Real & temp, Real & sie, Real & press, Real & cv, Real & bmod, const unsigned long output, Real * lambda) const
-{
-    if(output&thermalqs::pressure) press=PressureFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::temperature) temp = TemperatureFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::bulk_modulus) bmod = BulkModulusFromDensityInternalEnergy(rho,sie);
-    if(output&thermalqs::specific_heat) cv=SpecificHeatFromDensityInternalEnergy(rho,sie);
+PORTABLE_FUNCTION void JWL::FillEos(Real &rho, Real &temp, Real &sie, Real &press,
+                                    Real &cv, Real &bmod, const unsigned long output,
+                                    Real *lambda) const {
+  if (output & thermalqs::pressure) press = PressureFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::temperature)
+    temp = TemperatureFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::bulk_modulus)
+    bmod = BulkModulusFromDensityInternalEnergy(rho, sie);
+  if (output & thermalqs::specific_heat)
+    cv = SpecificHeatFromDensityInternalEnergy(rho, sie);
 }
 
 // TODO(JMM): pre-cache these rather than recomputing them each time
 // TODO: Chad, please decide if STP is actually right here. Should it be
 // based on the reference energy and pressure instead?
 PORTABLE_FUNCTION
-void JWL::ValuesAtReferenceState(Real& rho, Real& temp, Real& sie, Real& press,
-                          Real& cv, Real& bmod, Real& dpde, Real& dvdt,
-                          Real *lambda) const {
+void JWL::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                                 Real &bmod, Real &dpde, Real &dvdt, Real *lambda) const {
   rho = _rho0;
   temp = ROOM_TEMPERATURE;
-  sie = InternalEnergyFromDensityTemperature(rho,temp,lambda);
+  sie = InternalEnergyFromDensityTemperature(rho, temp, lambda);
   press = ATMOSPHERIC_PRESSURE;
   cv = _Cv;
-  bmod = BulkModulusFromDensityInternalEnergy(rho,sie,lambda);
-  dpde = _w*_rho0;
+  bmod = BulkModulusFromDensityInternalEnergy(rho, sie, lambda);
+  dpde = _w * _rho0;
   // TODO: chad please fix this one for me. This is wrong.
-  Real gm1 = GruneisenParamFromDensityInternalEnergy(rho,sie,lambda)*rho;
-  dvdt = gm1*cv / bmod;
+  Real gm1 = GruneisenParamFromDensityInternalEnergy(rho, sie, lambda) * rho;
+  dvdt = gm1 * cv / bmod;
 }
 
 } // namespace singularity

--- a/singularity-eos/eos/eos_spiner.cpp
+++ b/singularity-eos/eos/eos_spiner.cpp
@@ -14,25 +14,24 @@
 
 #ifdef SPINER_USE_HDF
 
-#include <string>
-#include <sstream>
-#include <vector>
-#include <cstdlib>
 #include <algorithm>
+#include <cstdlib>
+#include <sstream>
+#include <string>
+#include <vector>
 // #include <iostream> // debug
 // #include <stdio.h> // debug
 
 #include <hdf5.h>
 #include <hdf5_hl.h>
 
+#include <ports-of-call/portability.hpp>
+#include <root-finding-1d/root_finding.hpp>
 #include <singularity-eos/eos/eos.hpp>
 #include <sp5/singularity_eos_sp5.hpp>
 #include <spiner/databox.hpp>
 #include <spiner/interpolation.hpp>
 #include <spiner/sp5.hpp>
-#include <sp5/singularity_eos_sp5.hpp>
-#include <root-finding-1d/root_finding.hpp>
-#include <ports-of-call/portability.hpp>
 
 #define SPINER_EOS_VERBOSE (0)
 
@@ -46,75 +45,69 @@ namespace singularity {
 
 // replace lambdas with callable
 namespace callable_interp {
-  
-  class l_interp {
-  private:
-    const Spiner::DataBox& field;
-    const Real fixed;
-  public:
-    PORTABLE_INLINE_FUNCTION
-    l_interp(const Spiner::DataBox& field_, const Real fixed_)
-      : field{field_},
-        fixed{fixed_}
-    { }
-    
-    PORTABLE_INLINE_FUNCTION Real operator()(const Real x) const {
-      return field.interpToReal(x, fixed);
-    }
-  };
-  
-  class r_interp {
-  private:
-    const Spiner::DataBox& field;
-    const Real fixed;
-  public:
-    PORTABLE_INLINE_FUNCTION
-    r_interp(const Spiner::DataBox& field_, const Real fixed_)
-      : field{field_},
-        fixed{fixed_}
-    { }
-    
-    PORTABLE_INLINE_FUNCTION Real operator()(const Real x) const {
-      return field.interpToReal(fixed, x);
-    }
-  };
 
-  class prod_interp_1d {
-  private:
-    const Spiner::DataBox& field1, field2;
-    const Real r;
-  public:
-    PORTABLE_INLINE_FUNCTION
-    prod_interp_1d(const Spiner::DataBox& field1_,
-                   const Spiner::DataBox& field2_,
-                   const Real r_)
-      : field1{field1_}, field2{field2_}, r{r_}
-    { }
-    PORTABLE_INLINE_FUNCTION Real operator()(const Real x) const {
-      return field1.interpToReal(x)*field2.interpToReal(x)*r*x;
-    }
-  };
+class l_interp {
+ private:
+  const Spiner::DataBox &field;
+  const Real fixed;
 
-  class interp {
-  private:
-    const Spiner::DataBox& field;
-  public:
-    PORTABLE_INLINE_FUNCTION
-    interp(const Spiner::DataBox& field_) : field(field_) { }
-    PORTABLE_INLINE_FUNCTION Real operator()(const Real x) const {
-      return field.interpToReal(x);
-    }
-  };
+ public:
+  PORTABLE_INLINE_FUNCTION
+  l_interp(const Spiner::DataBox &field_, const Real fixed_)
+      : field{field_}, fixed{fixed_} {}
+
+  PORTABLE_INLINE_FUNCTION Real operator()(const Real x) const {
+    return field.interpToReal(x, fixed);
+  }
+};
+
+class r_interp {
+ private:
+  const Spiner::DataBox &field;
+  const Real fixed;
+
+ public:
+  PORTABLE_INLINE_FUNCTION
+  r_interp(const Spiner::DataBox &field_, const Real fixed_)
+      : field{field_}, fixed{fixed_} {}
+
+  PORTABLE_INLINE_FUNCTION Real operator()(const Real x) const {
+    return field.interpToReal(fixed, x);
+  }
+};
+
+class prod_interp_1d {
+ private:
+  const Spiner::DataBox &field1, field2;
+  const Real r;
+
+ public:
+  PORTABLE_INLINE_FUNCTION
+  prod_interp_1d(const Spiner::DataBox &field1_, const Spiner::DataBox &field2_,
+                 const Real r_)
+      : field1{field1_}, field2{field2_}, r{r_} {}
+  PORTABLE_INLINE_FUNCTION Real operator()(const Real x) const {
+    return field1.interpToReal(x) * field2.interpToReal(x) * r * x;
+  }
+};
+
+class interp {
+ private:
+  const Spiner::DataBox &field;
+
+ public:
+  PORTABLE_INLINE_FUNCTION
+  interp(const Spiner::DataBox &field_) : field(field_) {}
+  PORTABLE_INLINE_FUNCTION Real operator()(const Real x) const {
+    return field.interpToReal(x);
+  }
+};
 } // namespace callable_interp
 
-SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string& filename,
-                                           int matid,
+SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string &filename, int matid,
                                            bool reproducibility_mode)
-  : filename_(filename.c_str())
-  , matid_(matid)
-  , reproducible_(reproducibility_mode)
-  , status_(RootFinding1D::Status::SUCCESS)
-  , memoryStatus_(DataStatus::OnHost) {
+    : filename_(filename.c_str()), matid_(matid), reproducible_(reproducibility_mode),
+      status_(RootFinding1D::Status::SUCCESS), memoryStatus_(DataStatus::OnHost) {
 
   std::string matid_str = std::to_string(matid);
   hsize_t dims;
@@ -124,19 +117,16 @@ SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string& filename,
   herr_t status = H5_SUCCESS;
   std::vector<char> materialName;
 
-  file = H5Fopen(filename.c_str(),
-                 H5F_ACC_RDONLY, H5P_DEFAULT);
+  file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   matGroup = H5Gopen(file, matid_str.c_str(), H5P_DEFAULT);
-  lTGroup = H5Gopen(matGroup,   SP5::Depends::logRhoLogT,   H5P_DEFAULT);
-  coldGroup = H5Gopen(matGroup, SP5::Depends::coldCurve,    H5P_DEFAULT);
+  lTGroup = H5Gopen(matGroup, SP5::Depends::logRhoLogT, H5P_DEFAULT);
+  coldGroup = H5Gopen(matGroup, SP5::Depends::coldCurve, H5P_DEFAULT);
 
   // This works because chars are 1 byte. ~ JMM
-  status += H5LTget_attribute_info(file, matid_str.c_str(),
-                                   SP5::Material::name,
-                                   &dims,&tclass,&size);
-  materialName.resize((int)size+1);
-  status += H5LTget_attribute_string(file, matid_str.c_str(),
-                                     SP5::Material::name,
+  status += H5LTget_attribute_info(file, matid_str.c_str(), SP5::Material::name, &dims,
+                                   &tclass, &size);
+  materialName.resize((int)size + 1);
+  status += H5LTget_attribute_string(file, matid_str.c_str(), SP5::Material::name,
                                      materialName.data());
   materialName_ = materialName.data();
 
@@ -148,32 +138,28 @@ SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string& filename,
   status += H5Fclose(file);
 
   if (status != H5_SUCCESS) {
-    EOS_ERROR("SpinerDependsRHoT: HDF5 error\n"); //TODO: make this better
+    EOS_ERROR("SpinerDependsRHoT: HDF5 error\n"); // TODO: make this better
   }
 }
 
-SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string& filename,
-                                           const std::string& materialName,
+SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string &filename,
+                                           const std::string &materialName,
                                            bool reproducibility_mode)
-  : filename_(filename.c_str())
-  , materialName_(materialName.c_str())
-  , reproducible_(reproducibility_mode)
-  , status_(RootFinding1D::Status::SUCCESS)
-  , memoryStatus_(DataStatus::OnHost) {
+    : filename_(filename.c_str()), materialName_(materialName.c_str()),
+      reproducible_(reproducibility_mode), status_(RootFinding1D::Status::SUCCESS),
+      memoryStatus_(DataStatus::OnHost) {
 
   std::string matid_str;
   hid_t file, matGroup, lTGroup, coldGroup;
   herr_t status = H5_SUCCESS;
 
-  file = H5Fopen(filename.c_str(),
-                 H5F_ACC_RDONLY, H5P_DEFAULT);
+  file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   matGroup = H5Gopen(file, materialName.c_str(), H5P_DEFAULT);
-  lTGroup = H5Gopen(matGroup,   SP5::Depends::logRhoLogT,   H5P_DEFAULT);
-  coldGroup = H5Gopen(matGroup, SP5::Depends::coldCurve,    H5P_DEFAULT);
+  lTGroup = H5Gopen(matGroup, SP5::Depends::logRhoLogT, H5P_DEFAULT);
+  coldGroup = H5Gopen(matGroup, SP5::Depends::coldCurve, H5P_DEFAULT);
 
-  status += H5LTget_attribute_int(file, materialName.c_str(),
-                                  SP5::Material::matid,
-                                  &matid_);
+  status +=
+      H5LTget_attribute_int(file, materialName.c_str(), SP5::Material::matid, &matid_);
   matid_str = std::to_string(matid_);
 
   status += loadDataboxes_(matid_str, file, lTGroup, coldGroup);
@@ -264,59 +250,54 @@ void SpinerEOSDependsRhoT::Finalize() {
   memoryStatus_ = DataStatus::Deallocated;
 }
 
-herr_t SpinerEOSDependsRhoT::loadDataboxes_(const std::string& matid_str,
-                                            hid_t file, hid_t lTGroup,
-                                            hid_t coldGroup) {
+herr_t SpinerEOSDependsRhoT::loadDataboxes_(const std::string &matid_str, hid_t file,
+                                            hid_t lTGroup, hid_t coldGroup) {
   herr_t status = H5_SUCCESS;
 
   // offsets
-  status += H5LTget_attribute_double(file, matid_str.c_str(),
-                                     SP5::Offsets::rho,
-                                     &lRhoOffset_);
-  status += H5LTget_attribute_double(file, matid_str.c_str(),
-                                     SP5::Offsets::T,
-                                     &lTOffset_);
+  status +=
+      H5LTget_attribute_double(file, matid_str.c_str(), SP5::Offsets::rho, &lRhoOffset_);
+  status +=
+      H5LTget_attribute_double(file, matid_str.c_str(), SP5::Offsets::T, &lTOffset_);
   lRhoOffset_ = std::abs(lRhoOffset_);
-  lTOffset_   = std::abs(lTOffset_);
+  lTOffset_ = std::abs(lTOffset_);
   // normal density
   status += H5LTget_attribute_double(file, matid_str.c_str(),
-                                     SP5::Material::normalDensity,
-                                     &rhoNormal_);
+                                     SP5::Material::normalDensity, &rhoNormal_);
   rhoNormal_ = std::abs(rhoNormal_);
 
   // tables
-  status += P_.loadHDF(lTGroup,      SP5::Fields::P);
-  status += sie_.loadHDF(lTGroup,    SP5::Fields::sie);
-  status += bMod_.loadHDF(lTGroup,   SP5::Fields::bMod);
+  status += P_.loadHDF(lTGroup, SP5::Fields::P);
+  status += sie_.loadHDF(lTGroup, SP5::Fields::sie);
+  status += bMod_.loadHDF(lTGroup, SP5::Fields::bMod);
   status += dPdRho_.loadHDF(lTGroup, SP5::Fields::dPdRho);
-  status += dPdE_.loadHDF(lTGroup,   SP5::Fields::dPdE);
+  status += dPdE_.loadHDF(lTGroup, SP5::Fields::dPdE);
   status += dTdRho_.loadHDF(lTGroup, SP5::Fields::dTdRho);
-  status += dTdE_.loadHDF(lTGroup,   SP5::Fields::dTdE);
+  status += dTdE_.loadHDF(lTGroup, SP5::Fields::dTdE);
   status += dEdRho_.loadHDF(lTGroup, SP5::Fields::dEdRho);
-  status += dEdT_.loadHDF(lTGroup,   SP5::Fields::dEdT);
+  status += dEdT_.loadHDF(lTGroup, SP5::Fields::dEdT);
 
   // cold curves
-  status += PCold_.loadHDF(coldGroup,      SP5::Fields::P);
-  status += sieCold_.loadHDF(coldGroup,    SP5::Fields::sie);
-  status += bModCold_.loadHDF(coldGroup,   SP5::Fields::bMod);
+  status += PCold_.loadHDF(coldGroup, SP5::Fields::P);
+  status += sieCold_.loadHDF(coldGroup, SP5::Fields::sie);
+  status += bModCold_.loadHDF(coldGroup, SP5::Fields::bMod);
   status += dPdRhoCold_.loadHDF(coldGroup, SP5::Fields::dPdRho);
 
   numRho_ = bMod_.dim(2);
-  numT_   = bMod_.dim(1);
+  numT_ = bMod_.dim(1);
 
   // set bounds
   lRhoMin_ = P_.range(1).min();
   lRhoMax_ = P_.range(1).max();
-  rhoMax_  = fromLog_(lRhoMax_,lRhoOffset_);
-  lTMin_   = P_.range(0).min();
-  lTMax_   = P_.range(0).max();
-  TMax_    = fromLog_(lTMax_,lTOffset_);
+  rhoMax_ = fromLog_(lRhoMax_, lRhoOffset_);
+  lTMin_ = P_.range(0).min();
+  lTMax_ = P_.range(0).max();
+  TMax_ = fromLog_(lTMax_, lTOffset_);
 
-  Real rhoMin = fromLog_(lRhoMin_,lRhoOffset_);
-  Real rhoMinSearch = std::max(rhoMin,
-                               std::max(std::abs(EPS)*10,
-                                        std::abs(EPS*rhoMin)));
-  lRhoMinSearch_ = toLog_(rhoMinSearch,lRhoOffset_);
+  Real rhoMin = fromLog_(lRhoMin_, lRhoOffset_);
+  Real rhoMinSearch =
+      std::max(rhoMin, std::max(std::abs(EPS) * 10, std::abs(EPS * rhoMin)));
+  lRhoMinSearch_ = toLog_(rhoMinSearch, lRhoOffset_);
 
   // bulk modulus can be wrong in the tables. Use FLAG's approach to
   // fix the table.
@@ -344,13 +325,13 @@ herr_t SpinerEOSDependsRhoT::loadDataboxes_(const std::string& matid_str,
     Real lRho = bModCold_.range(0).x(j);
     Real lT = lTColdCrit_(j);
     Real rho = rho_(lRho);
-    bModCold_(j)   = bMod_.interpToReal(lRho,lT);
-    dPdECold_(j)   = dPdE_.interpToReal(lRho,lT);
-    dTdRhoCold_(j) = dTdRho_.interpToReal(lRho,lT);
-    dTdECold_(j)   = dTdE_.interpToReal(lRho,lT);
-    dEdTCold_(j)   = dEdT_.interpToReal(lRho,lT);
+    bModCold_(j) = bMod_.interpToReal(lRho, lT);
+    dPdECold_(j) = dPdE_.interpToReal(lRho, lT);
+    dTdRhoCold_(j) = dTdRho_.interpToReal(lRho, lT);
+    dTdECold_(j) = dTdE_.interpToReal(lRho, lT);
+    dEdTCold_(j) = dEdT_.interpToReal(lRho, lT);
   }
-  
+
   // major vs. minor axes change, so this must be done by hand
   PMax_.resize(numRho_);
   PMax_.setRange(0, bMod_.range(1));
@@ -359,34 +340,34 @@ herr_t SpinerEOSDependsRhoT::loadDataboxes_(const std::string& matid_str,
   sielTMax_.copyMetadata(PMax_);
   for (int j = 0; j < numRho_; j++) {
     Real rho = PMax_.range(0).x(j);
-    PMax_(j) = P_(j,numT_-1);
-    dEdTMax_(j) = dEdT_(j, numT_-1);
-    gm1Max_(j) = dPdE_(j, numT_-1)/(rho + EPS); // max gruneisen
-    sielTMax_(j) = sie_(j, numT_-1);
+    PMax_(j) = P_(j, numT_ - 1);
+    dEdTMax_(j) = dEdT_(j, numT_ - 1);
+    gm1Max_(j) = dPdE_(j, numT_ - 1) / (rho + EPS); // max gruneisen
+    sielTMax_(j) = sie_(j, numT_ - 1);
   }
 
   // reference state
   Real lRhoNormal = lRho_(rhoNormal_);
   // if rho normal not on the table, set it to the middle
-  if ( !(lRhoMin_ < lRhoNormal && lRhoNormal < lRhoMax_) ) {
-    lRhoNormal = 0.5*(lRhoMin_ + lRhoMax_);
+  if (!(lRhoMin_ < lRhoNormal && lRhoNormal < lRhoMax_)) {
+    lRhoNormal = 0.5 * (lRhoMin_ + lRhoMax_);
     rhoNormal_ = rho_(lRhoNormal);
   }
   // Same for temperature. Use room temperature if it's available
   TNormal_ = ROOM_TEMPERATURE;
   Real lTNormal = lT_(TNormal_);
-  if ( !(lTMin_ < lTNormal && lTNormal < lTMax_) ) {
-    lTNormal = 0.5*(lTMin_ + lTMax_);
+  if (!(lTMin_ < lTNormal && lTNormal < lTMax_)) {
+    lTNormal = 0.5 * (lTMin_ + lTMax_);
     TNormal_ = T_(lTNormal);
   }
-  sieNormal_ = sie_.interpToReal(lRhoNormal,lTNormal);
-  PNormal_ = P_.interpToReal(lRhoNormal,lTNormal);
-  CvNormal_ = dEdT_.interpToReal(lRhoNormal,lTNormal);
-  bModNormal_ = bMod_.interpToReal(lRhoNormal,lTNormal);
-  dPdENormal_ = dPdE_.interpToReal(lRhoNormal,lTNormal);
-  Real dPdR = dPdRho_.interpToReal(lRhoNormal,lTNormal);
-  dVdTNormal_ = dPdENormal_*CvNormal_/(rhoNormal_*rhoNormal_*dPdR);
-  
+  sieNormal_ = sie_.interpToReal(lRhoNormal, lTNormal);
+  PNormal_ = P_.interpToReal(lRhoNormal, lTNormal);
+  CvNormal_ = dEdT_.interpToReal(lRhoNormal, lTNormal);
+  bModNormal_ = bMod_.interpToReal(lRhoNormal, lTNormal);
+  dPdENormal_ = dPdE_.interpToReal(lRhoNormal, lTNormal);
+  Real dPdR = dPdRho_.interpToReal(lRhoNormal, lTNormal);
+  dVdTNormal_ = dPdENormal_ * CvNormal_ / (rhoNormal_ * rhoNormal_ * dPdR);
+
   return status;
 }
 
@@ -399,20 +380,20 @@ void SpinerEOSDependsRhoT::fixBulkModulus_() {
     Real rho = rho_(lRho);
     for (int i = 0; i < numT_; i++) {
       Real lT = bMod_.range(0).x(i);
-      Real press = P_.interpToReal(lRho,lT);
-      Real DPDR = dPdRho_.interpToReal(lRho,lT);
-      Real DPDE = dPdE_.interpToReal(lRho,lT);
-      Real DEDR = dEdRho_.interpToReal(lRho,lT);
-      Real DTDE = dTdE_.interpToReal(lRho,lT);
+      Real press = P_.interpToReal(lRho, lT);
+      Real DPDR = dPdRho_.interpToReal(lRho, lT);
+      Real DPDE = dPdE_.interpToReal(lRho, lT);
+      Real DEDR = dEdRho_.interpToReal(lRho, lT);
+      Real DTDE = dTdE_.interpToReal(lRho, lT);
       Real bMod;
       if (DPDE > 0.0 && rho > 0.0) {
-        bMod = rho*DPDR + DPDE*(press/rho - rho*DEDR);
+        bMod = rho * DPDR + DPDE * (press / rho - rho * DEDR);
       } else if (rho > 0.0) {
-        bMod = std::max(rho*DPDR,0.0);
+        bMod = std::max(rho * DPDR, 0.0);
       } else {
         bMod = 0.0;
       }
-      bMod_(j,i) = std::max(bMod,std::abs(EPS));
+      bMod_(j, i) = std::max(bMod, std::abs(EPS));
     }
   }
 }
@@ -437,14 +418,14 @@ void SpinerEOSDependsRhoT::setlTColdCrit_() {
     std::vector<int> crossings;
     std::vector<int> directions;
     int last_pos_crossing = -1;
-    for (int i = 0; i < numT_-1; i++) {
-      Real sign_curr = sie_(j,i) - sieCold;
-      Real sign_next = sie_(j,i+1) - sieCold;
-      if ( sign_curr < 0 && sign_next > 0 ) {
+    for (int i = 0; i < numT_ - 1; i++) {
+      Real sign_curr = sie_(j, i) - sieCold;
+      Real sign_next = sie_(j, i + 1) - sieCold;
+      if (sign_curr < 0 && sign_next > 0) {
         crossings.push_back(i);
         directions.push_back(1);
-        last_pos_crossing = crossings.size()-1;
-      } else if ( sign_curr > 0 && sign_next < 0 ) {
+        last_pos_crossing = crossings.size() - 1;
+      } else if (sign_curr > 0 && sign_next < 0) {
         crossings.push_back(i);
         directions.push_back(-1);
       }
@@ -462,18 +443,16 @@ void SpinerEOSDependsRhoT::setlTColdCrit_() {
       int ilast = crossings[last_pos_crossing];
       Real lTlower = bMod_.range(0).x(ilast);
       Real lTupper = bMod_.range(0).x(ilast + 1);
-      Real lTGuess = 0.5*(lTlower + lTupper);
-      auto status = findRoot(sieFunc, sieCold, lTGuess,
-                             lTlower, lTupper,
-                             ROOT_THRESH, ROOT_THRESH,
-                             lT, counts);
+      Real lTGuess = 0.5 * (lTlower + lTupper);
+      auto status = findRoot(sieFunc, sieCold, lTGuess, lTlower, lTupper, ROOT_THRESH,
+                             ROOT_THRESH, lT, counts);
       if (status != RootFinding1D::Status::SUCCESS) {
         lT = lTGuess;
       }
       lTColdCrit_(j) = lT;
       // lTColdCrit_(j) = lTMin_;
     }
-    lTColdCrit_(j) = std::max(lTMin_,lTColdCrit_(j));
+    lTColdCrit_(j) = std::max(lTMin_, lTColdCrit_(j));
   }
 }
 
@@ -483,7 +462,7 @@ Real SpinerEOSDependsRhoT::TemperatureFromDensityInternalEnergy(const Real rho,
                                                                 Real *lambda) const {
   TableStatus whereAmI;
   const Real lRho = lRho_(rho);
-  const Real lT = lTFromlRhoSie_(lRho,sie,whereAmI,lambda);
+  const Real lT = lTFromlRhoSie_(lRho, sie, whereAmI, lambda);
   return T_(lT);
 }
 
@@ -493,8 +472,8 @@ Real SpinerEOSDependsRhoT::InternalEnergyFromDensityTemperature(const Real rho,
                                                                 Real *lambda) const {
   Real lRho, lT;
   getLogsRhoT_(rho, temperature, lRho, lT, lambda);
-  TableStatus whereAmI = getLocDependsRhoT_(lRho,lT);
-  return sieFromlRhoTlT_(lRho,temperature,lT,whereAmI);
+  TableStatus whereAmI = getLocDependsRhoT_(lRho, lT);
+  return sieFromlRhoTlT_(lRho, temperature, lT, whereAmI);
 }
 
 PORTABLE_FUNCTION
@@ -503,8 +482,8 @@ Real SpinerEOSDependsRhoT::PressureFromDensityTemperature(const Real rho,
                                                           Real *lambda) const {
   Real lRho, lT;
   getLogsRhoT_(rho, temperature, lRho, lT, lambda);
-  TableStatus whereAmI = getLocDependsRhoT_(lRho,lT);
-  return PFromRholRhoTlT_(rho,lRho,temperature,lT,whereAmI);
+  TableStatus whereAmI = getLocDependsRhoT_(lRho, lT);
+  return PFromRholRhoTlT_(rho, lRho, temperature, lT, whereAmI);
 }
 
 PORTABLE_FUNCTION
@@ -513,15 +492,15 @@ Real SpinerEOSDependsRhoT::PressureFromDensityInternalEnergy(const Real rho,
                                                              Real *lambda) const {
   TableStatus whereAmI;
   Real lRho = lRho_(rho);
-  Real lT = lTFromlRhoSie_(lRho,sie,whereAmI,lambda);
+  Real lT = lTFromlRhoSie_(lRho, sie, whereAmI, lambda);
   Real P;
-  if ( whereAmI == TableStatus::OffBottom ) { // cold curve
+  if (whereAmI == TableStatus::OffBottom) { // cold curve
     P = PCold_.interpToReal(lRho);
-  } else if ( whereAmI == TableStatus::OffTop ) { // ideal gas
+  } else if (whereAmI == TableStatus::OffTop) { // ideal gas
     const Real gm1 = gm1Max_.interpToReal(lRho);
-    P = gm1*rho*sie;
+    P = gm1 * rho * sie;
   } else { // on table
-    P = P_.interpToReal(lRho,lT);
+    P = P_.interpToReal(lRho, lT);
   }
   return P;
 }
@@ -532,8 +511,8 @@ Real SpinerEOSDependsRhoT::SpecificHeatFromDensityTemperature(const Real rho,
                                                               Real *lambda) const {
   Real lRho, lT;
   getLogsRhoT_(rho, temperature, lRho, lT, lambda);
-  TableStatus whereAmI = getLocDependsRhoT_(lRho,lT);
-  return CvFromlRholT_(lRho,lT,whereAmI);
+  TableStatus whereAmI = getLocDependsRhoT_(lRho, lT);
+  return CvFromlRholT_(lRho, lT, whereAmI);
 }
 
 PORTABLE_FUNCTION
@@ -543,15 +522,15 @@ Real SpinerEOSDependsRhoT::SpecificHeatFromDensityInternalEnergy(const Real rho,
   TableStatus whereAmI;
   Real Cv;
   const Real lRho = lRho_(rho);
-  const Real lT = lTFromlRhoSie_(lRho,sie,whereAmI,lambda);
-  if ( whereAmI == TableStatus::OffBottom ) { // cold curve
+  const Real lT = lTFromlRhoSie_(lRho, sie, whereAmI, lambda);
+  if (whereAmI == TableStatus::OffBottom) { // cold curve
     // on cold curve. Currently, we assume constant extrapolation.
     // TODO(JMM): Do something more sophisticated
     Cv = dEdTCold_.interpToReal(lRho);
-  } else if ( whereAmI == TableStatus::OffTop ) { // ideal gas
-    Cv = dEdTMax_.interpToReal(lRho); // Cv assumed constant in T
-  } else { // on table
-    Cv = dEdT_.interpToReal(lRho,lT);
+  } else if (whereAmI == TableStatus::OffTop) { // ideal gas
+    Cv = dEdTMax_.interpToReal(lRho);           // Cv assumed constant in T
+  } else {                                      // on table
+    Cv = dEdT_.interpToReal(lRho, lT);
   }
   return Cv > EPS ? Cv : EPS;
 }
@@ -559,33 +538,30 @@ Real SpinerEOSDependsRhoT::SpecificHeatFromDensityInternalEnergy(const Real rho,
 PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoT::BulkModulusFromDensityTemperature(const Real rho,
                                                              const Real temperature,
-                                                             Real *lambda) const 
-{
+                                                             Real *lambda) const {
   Real lRho, lT;
   getLogsRhoT_(rho, temperature, lRho, lT, lambda);
-  TableStatus whereAmI = getLocDependsRhoT_(lRho,lT);
-  return bModFromRholRhoTlT_(rho,lRho,temperature,lT,whereAmI);
+  TableStatus whereAmI = getLocDependsRhoT_(lRho, lT);
+  return bModFromRholRhoTlT_(rho, lRho, temperature, lT, whereAmI);
 }
 
 PORTABLE_FUNCTION
-Real
-SpinerEOSDependsRhoT::GruneisenParamFromDensityTemperature(const Real rho,
-                                                           const Real temp,
-                                                           Real *lambda) const 
-{
+Real SpinerEOSDependsRhoT::GruneisenParamFromDensityTemperature(const Real rho,
+                                                                const Real temp,
+                                                                Real *lambda) const {
   Real lRho, lT, gm1;
   getLogsRhoT_(rho, temp, lRho, lT, lambda);
 
   TableStatus whereAmI = getLocDependsRhoT_(lRho, lT);
-  if ( whereAmI == TableStatus::OffBottom ) {
+  if (whereAmI == TableStatus::OffBottom) {
     // use cold curves
     Real dpde = dPdECold_.interpToReal(lRho);
-    gm1 = std::abs(dpde)/(std::abs(rho) + EPS);
-  } else if ( whereAmI == TableStatus::OffTop ) {
+    gm1 = std::abs(dpde) / (std::abs(rho) + EPS);
+  } else if (whereAmI == TableStatus::OffTop) {
     gm1 = gm1Max_.interpToReal(lRho);
   } else { // on table
-    const Real dpde = dPdE_.interpToReal(lRho,lT);
-    gm1 = std::abs(dpde)/(std::abs(rho) + EPS);
+    const Real dpde = dPdE_.interpToReal(lRho, lT);
+    gm1 = std::abs(dpde) / (std::abs(rho) + EPS);
   }
   return gm1;
 }
@@ -598,34 +574,33 @@ Real SpinerEOSDependsRhoT::BulkModulusFromDensityInternalEnergy(const Real rho,
   Real bMod;
   const Real lRho = lRho_(rho);
   const Real lT = lTFromlRhoSie_(lRho, sie, whereAmI, lambda);
-  if ( whereAmI == TableStatus::OffBottom) {
+  if (whereAmI == TableStatus::OffBottom) {
     bMod = bModCold_.interpToReal(lRho);
-  } else if ( whereAmI == TableStatus::OffTop ) {
+  } else if (whereAmI == TableStatus::OffTop) {
     const Real gm1 = gm1Max_.interpToReal(lRho);
-    bMod = (gm1 + 1)*gm1*rho*sie;
+    bMod = (gm1 + 1) * gm1 * rho * sie;
   } else { // on table
-    bMod = bMod_.interpToReal(rho,sie);
+    bMod = bMod_.interpToReal(rho, sie);
   }
   return bMod;
 }
 
 PORTABLE_FUNCTION
-Real
-SpinerEOSDependsRhoT::GruneisenParamFromDensityInternalEnergy(const Real rho,
-                                                              const Real sie,
-                                                              Real *lambda) const {
+Real SpinerEOSDependsRhoT::GruneisenParamFromDensityInternalEnergy(const Real rho,
+                                                                   const Real sie,
+                                                                   Real *lambda) const {
   TableStatus whereAmI;
   Real gm1;
   const Real lRho = lRho_(rho);
   const Real lT = lTFromlRhoSie_(lRho, sie, whereAmI, lambda);
-  if ( whereAmI == TableStatus::OffBottom ) {
+  if (whereAmI == TableStatus::OffBottom) {
     Real dpde = dPdECold_.interpToReal(lRho);
-    gm1 = std::abs(dpde)/(std::abs(rho) + EPS);
-  } else if ( whereAmI == TableStatus::OffTop ) {
+    gm1 = std::abs(dpde) / (std::abs(rho) + EPS);
+  } else if (whereAmI == TableStatus::OffTop) {
     gm1 = gm1Max_.interpToReal(lRho);
   } else {
-    const Real dpde = dPdE_.interpToReal(lRho,lT);
-    gm1 = std::abs(dpde)/(std::abs(rho) + EPS);
+    const Real dpde = dPdE_.interpToReal(lRho, lT);
+    gm1 = std::abs(dpde) / (std::abs(rho) + EPS);
   }
   return gm1;
 }
@@ -634,9 +609,8 @@ SpinerEOSDependsRhoT::GruneisenParamFromDensityInternalEnergy(const Real rho,
 PORTABLE_FUNCTION
 void SpinerEOSDependsRhoT::DensityEnergyFromPressureTemperature(const Real press,
                                                                 const Real temp,
-                                                                Real *lambda,
-                                                                Real& rho,
-                                                                Real& sie) const {
+                                                                Real *lambda, Real &rho,
+                                                                Real &sie) const {
   TableStatus whereAmI;
   Real lT = lT_(temp);
   Real lRho = lRhoFromPlT_(press, lT, whereAmI, lambda);
@@ -645,44 +619,41 @@ void SpinerEOSDependsRhoT::DensityEnergyFromPressureTemperature(const Real press
 }
 
 PORTABLE_FUNCTION
-void SpinerEOSDependsRhoT::PTofRE(const Real rho, const Real sie,
-                                  Real * lambda, Real& press, Real& temp,
-                                  Real & dpdr, Real & dpde,
-                                  Real & dtdr, Real & dtde) const {
+void SpinerEOSDependsRhoT::PTofRE(const Real rho, const Real sie, Real *lambda,
+                                  Real &press, Real &temp, Real &dpdr, Real &dpde,
+                                  Real &dtdr, Real &dtde) const {
   TableStatus whereAmI;
   const Real lRho = lRho_(rho);
   const Real lT = lTFromlRhoSie_(lRho, sie, whereAmI, lambda);
   temp = T_(lT);
-  if ( whereAmI == TableStatus::OffBottom ) {
+  if (whereAmI == TableStatus::OffBottom) {
     press = PCold_.interpToReal(lRho);
     dpdr = dPdRhoCold_.interpToReal(lRho);
     dpde = dPdECold_.interpToReal(lRho);
     dtdr = dTdRhoCold_.interpToReal(lRho);
     dtde = dTdECold_.interpToReal(lRho);
-  } else if ( whereAmI == TableStatus::OffTop ) {
+  } else if (whereAmI == TableStatus::OffTop) {
     const Real Cv = dEdTMax_.interpToReal(lRho);
     const Real gm1 = gm1Max_.interpToReal(lRho);
     const Real e0 = sielTMax_.interpToReal(lRho);
-    const Real e = e0 + Cv*(temp - TMax_);
-    press = gm1*rho*e;
-    dpdr =  gm1*e;
-    dpde = gm1*rho;
-    dtdr = -press/(gm1*Cv*rho*rho);
-    dtde = 1./Cv;
+    const Real e = e0 + Cv * (temp - TMax_);
+    press = gm1 * rho * e;
+    dpdr = gm1 * e;
+    dpde = gm1 * rho;
+    dtdr = -press / (gm1 * Cv * rho * rho);
+    dtde = 1. / Cv;
   } else { // on table
-    press = P_.interpToReal(lRho,lT);
-    dpdr = dPdRho_.interpToReal(lRho,lT);
-    dpde = dPdE_.interpToReal(lRho,lT);
-    dtdr = dTdRho_.interpToReal(lRho,lT);
-    dtde = dTdE_.interpToReal(lRho,lT);
+    press = P_.interpToReal(lRho, lT);
+    dpdr = dPdRho_.interpToReal(lRho, lT);
+    dpde = dPdE_.interpToReal(lRho, lT);
+    dtdr = dTdRho_.interpToReal(lRho, lT);
+    dtde = dTdE_.interpToReal(lRho, lT);
   }
 }
 
 PORTABLE_FUNCTION
-void SpinerEOSDependsRhoT::FillEos(Real& rho, Real& temp,
-                                   Real& energy, Real& press,
-                                   Real& cv, Real& bmod,
-                                   const unsigned long output,
+void SpinerEOSDependsRhoT::FillEos(Real &rho, Real &temp, Real &energy, Real &press,
+                                   Real &cv, Real &bmod, const unsigned long output,
                                    Real *lambda) const {
   Real lRho, lT;
   TableStatus whereAmI;
@@ -690,10 +661,10 @@ void SpinerEOSDependsRhoT::FillEos(Real& rho, Real& temp,
   if (output == thermalqs::none) {
     UNDEFINED_ERROR;
   }
-  if (output&thermalqs::density) {
-    if (input&thermalqs::pressure && input&thermalqs::temperature) {
+  if (output & thermalqs::density) {
+    if (input & thermalqs::pressure && input & thermalqs::temperature) {
       lT = lT_(temp);
-      lRho = lRhoFromPlT_(press,lT,whereAmI,lambda);
+      lRho = lRhoFromPlT_(press, lT, whereAmI, lambda);
       rho = rho_(lRho);
     } else {
       UNDEFINED_ERROR;
@@ -701,43 +672,41 @@ void SpinerEOSDependsRhoT::FillEos(Real& rho, Real& temp,
   } else {
     lRho = lRho_(rho);
   }
-  if (output&thermalqs::temperature) {
-    if (input&thermalqs::density && input&thermalqs::specific_internal_energy) {
+  if (output & thermalqs::temperature) {
+    if (input & thermalqs::density && input & thermalqs::specific_internal_energy) {
       lT = lTFromlRhoSie_(lRho, energy, whereAmI, lambda);
-    } else if (input&thermalqs::density && input&thermalqs::pressure) {
+    } else if (input & thermalqs::density && input & thermalqs::pressure) {
       lT = lTFromlRhoP_(lRho, press, whereAmI, lambda);
-     }
-    else {
+    } else {
       UNDEFINED_ERROR;
     }
     temp = T_(lT);
   } else {
     lT = lT_(temp);
   }
-  whereAmI = getLocDependsRhoT_(lRho,lT);
-  if (output&thermalqs::specific_internal_energy) {
-    energy = sieFromlRhoTlT_(lRho,temp,lT,whereAmI);
+  whereAmI = getLocDependsRhoT_(lRho, lT);
+  if (output & thermalqs::specific_internal_energy) {
+    energy = sieFromlRhoTlT_(lRho, temp, lT, whereAmI);
   }
-  if (output&thermalqs::pressure) {
-    press = PFromRholRhoTlT_(rho,lRho,temp,lT,whereAmI);
+  if (output & thermalqs::pressure) {
+    press = PFromRholRhoTlT_(rho, lRho, temp, lT, whereAmI);
   }
-  if (output&thermalqs::specific_heat) {
-    cv = CvFromlRholT_(lRho,lT,whereAmI);
+  if (output & thermalqs::specific_heat) {
+    cv = CvFromlRholT_(lRho, lT, whereAmI);
   }
-  if (output&thermalqs::bulk_modulus) {
-    bmod = bModFromRholRhoTlT_(rho,lRho,temp,lT,whereAmI);
+  if (output & thermalqs::bulk_modulus) {
+    bmod = bModFromRholRhoTlT_(rho, lRho, temp, lT, whereAmI);
   }
   if (lambda != nullptr) {
     lambda[Lambda::lRho] = lRho;
-    lambda[Lambda::lT]   = lT;
+    lambda[Lambda::lT] = lT;
   }
 }
 
 PORTABLE_FUNCTION
-void SpinerEOSDependsRhoT::ValuesAtReferenceState(Real& rho, Real& temp,
-                                                  Real& sie, Real& press,
-                                                  Real& cv, Real& bmod,
-                                                  Real& dpde, Real& dvdt,
+void SpinerEOSDependsRhoT::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie,
+                                                  Real &press, Real &cv, Real &bmod,
+                                                  Real &dpde, Real &dvdt,
                                                   Real *lambda) const {
   rho = rhoNormal_;
   temp = TNormal_;
@@ -750,61 +719,47 @@ void SpinerEOSDependsRhoT::ValuesAtReferenceState(Real& rho, Real& temp,
 }
 
 PORTABLE_FUNCTION
-void SpinerEOSDependsRhoT::getLogsRhoT_(const Real rho,
-                                        const Real temperature,
-                                        Real& lRho, Real& lT,
-                                        Real* lambda) const {
+void SpinerEOSDependsRhoT::getLogsRhoT_(const Real rho, const Real temperature,
+                                        Real &lRho, Real &lT, Real *lambda) const {
   lRho = lRho_(rho);
   lT = lT_(temperature);
   if (lambda != nullptr) {
     lambda[Lambda::lRho] = lRho;
-    lambda[Lambda::lT]   = lT;
+    lambda[Lambda::lT] = lT;
   }
 }
 
 PORTABLE_FUNCTION
-Real SpinerEOSDependsRhoT::lRhoFromPlT_(const Real P,
-                                        const Real lT,
-                                        TableStatus& whereAmI,
-                                        Real* lambda) const {
+Real SpinerEOSDependsRhoT::lRhoFromPlT_(const Real P, const Real lT,
+                                        TableStatus &whereAmI, Real *lambda) const {
   using RootFinding1D::findRoot;
   RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
 
   Real lRho;
-  Real lRhoGuess = reproducible_ ? lRhoMax_ : 0.5*(lRhoMin_ + lRhoMax_);
+  Real lRhoGuess = reproducible_ ? lRhoMax_ : 0.5 * (lRhoMin_ + lRhoMax_);
   // Real lRhoGuess = lRhoMin_ + 0.9*(lRhoMax_ - lRhoMin_);
-  if (lambda != nullptr
-      && lRhoMin_ <= lambda[Lambda::lRho]
-      && lambda[Lambda::lRho] <= lRhoMax_) {
+  if (lambda != nullptr && lRhoMin_ <= lambda[Lambda::lRho] &&
+      lambda[Lambda::lRho] <= lRhoMax_) {
     lRhoGuess = lambda[Lambda::lRho];
   }
-  if ( lT <= lTMin_ ) { // cold curve
+  if (lT <= lTMin_) { // cold curve
     whereAmI = TableStatus::OffBottom;
     const callable_interp::interp PFunc(PCold_);
-    status = findRoot(PFunc,
-                      P, lRhoGuess,
-                      //lRhoMin_, lRhoMax_,
-                      lRhoMinSearch_, lRhoMax_,
-                      ROOT_THRESH, ROOT_THRESH,
-                      lRho, counts);
-  } else if ( lT >= lTMax_ ) { // ideal gas
+    status = findRoot(PFunc, P, lRhoGuess,
+                      // lRhoMin_, lRhoMax_,
+                      lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, counts);
+  } else if (lT >= lTMax_) { // ideal gas
     whereAmI = TableStatus::OffTop;
-    const callable_interp::prod_interp_1d PFunc(gm1Max_,dEdTMax_,lT);
-    status = findRoot(PFunc,
-                      P, lRhoGuess,
-                      //lRhoMin_, lRhoMax_,
-                      lRhoMinSearch_, lRhoMax_,
-                      ROOT_THRESH, ROOT_THRESH,
-                      lRho, counts);
+    const callable_interp::prod_interp_1d PFunc(gm1Max_, dEdTMax_, lT);
+    status = findRoot(PFunc, P, lRhoGuess,
+                      // lRhoMin_, lRhoMax_,
+                      lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, counts);
   } else { // on table
     whereAmI = TableStatus::OnTable;
     const callable_interp::l_interp PFunc(P_, lT);
-    status = findRoot(PFunc,
-                      P, lRhoGuess,
-                      //lRhoMin_, lRhoMax_,
-                      lRhoMinSearch_, lRhoMax_,
-                      ROOT_THRESH, ROOT_THRESH,
-                      lRho, counts);
+    status = findRoot(PFunc, P, lRhoGuess,
+                      // lRhoMin_, lRhoMax_,
+                      lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, counts);
   }
   if (status_ != RootFinding1D::Status::SUCCESS) {
 #if EPINER_EOS_VERBOSE
@@ -813,15 +768,14 @@ Real SpinerEOSDependsRhoT::lRhoFromPlT_(const Real P,
                  << "matid     = " << matid_ << "\n"
                  << "lT        = " << lT << "\n"
                  << "P         = " << P << "\n"
-                 << "lRhoGuess = " << lRhoGuess
-                 << std::endl;
+                 << "lRhoGuess = " << lRhoGuess << std::endl;
     EOS_ERROR(errorMessage.str().c_str());
-#endif //SPINER_EOS_VERBOSE
+#endif // SPINER_EOS_VERBOSE
     lRho = reproducible_ ? lRhoMax_ : lRhoGuess;
   }
   if (lambda != nullptr) {
-    lambda[Lambda::lRho]   = lRho;
-    lambda[Lambda::lT]     = lT;
+    lambda[Lambda::lRho] = lRho;
+    lambda[Lambda::lT] = lT;
   }
   status_ = status;
   whereAmI_ = whereAmI;
@@ -829,39 +783,34 @@ Real SpinerEOSDependsRhoT::lRhoFromPlT_(const Real P,
 }
 
 PORTABLE_FUNCTION
-Real SpinerEOSDependsRhoT::lTFromlRhoSie_(const Real lRho,
-                                          const Real sie,
-                                          TableStatus& whereAmI,
-                                          Real* lambda) const {
+Real SpinerEOSDependsRhoT::lTFromlRhoSie_(const Real lRho, const Real sie,
+                                          TableStatus &whereAmI, Real *lambda) const {
 
   RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
   using RootFinding1D::findRoot;
   Real lT;
 
-  whereAmI = getLocDependsRhoSie_(lRho,sie);
-  if ( whereAmI == TableStatus::OffBottom ) {
+  whereAmI = getLocDependsRhoSie_(lRho, sie);
+  if (whereAmI == TableStatus::OffBottom) {
     // On the cold curve. No unique temperature.
     // return the minimum temperature in the table.
-    lT = lTMin_; 
+    lT = lTMin_;
     counts.increment(0);
-  } else if ( whereAmI == TableStatus::OffTop ) { // Assume ideal gas
+  } else if (whereAmI == TableStatus::OffTop) { // Assume ideal gas
     const Real Cv = dEdTMax_.interpToReal(lRho);
     const Real e0 = sielTMax_.interpToReal(lRho);
-    const Real T = TMax_ + (sie - e0)/(Cv+EPS);
+    const Real T = TMax_ + (sie - e0) / (Cv + EPS);
     lT = lT_(T);
     counts.increment(0);
   } else {
-    Real lTGuess = reproducible_ ? lTMin_ : 0.5*(lTMin_ + lTMax_);
-    if (lambda != nullptr
-        && lTMin_ <= lambda[Lambda::lT] && lambda[Lambda::lT] <= lTMax_) {
+    Real lTGuess = reproducible_ ? lTMin_ : 0.5 * (lTMin_ + lTMax_);
+    if (lambda != nullptr && lTMin_ <= lambda[Lambda::lT] &&
+        lambda[Lambda::lT] <= lTMax_) {
       lTGuess = lambda[Lambda::lT];
     }
     const callable_interp::r_interp sieFunc(sie_, lRho);
-    status = findRoot(sieFunc,
-                      sie, lTGuess,
-                      lTMin_, lTMax_,
-                      ROOT_THRESH, ROOT_THRESH,
-                      lT, counts);
+    status = findRoot(sieFunc, sie, lTGuess, lTMin_, lTMax_, ROOT_THRESH, ROOT_THRESH, lT,
+                      counts);
 
     if (status != RootFinding1D::Status::SUCCESS) {
 #if SPINER_EOS_VERBOSE
@@ -870,16 +819,15 @@ Real SpinerEOSDependsRhoT::lTFromlRhoSie_(const Real lRho,
                    << "matid   = " << matid_ << "\n"
                    << "lRho    = " << lRho << "\n"
                    << "sie     = " << sie << "\n"
-                   << "lTGuess = " << lTGuess
-                   << std::endl;
+                   << "lTGuess = " << lTGuess << std::endl;
       EOS_ERROR(errorMessage.str().c_str());
 #endif // SPINER_EOS_VERBOSE
       lT = reproducible_ ? lTMin_ : lTGuess;
     }
   }
   if (lambda != nullptr) {
-    lambda[Lambda::lRho]   = lRho;
-    lambda[Lambda::lT]     = lT;
+    lambda[Lambda::lRho] = lRho;
+    lambda[Lambda::lT] = lT;
   }
   status_ = status;
   whereAmI_ = whereAmI;
@@ -887,10 +835,8 @@ Real SpinerEOSDependsRhoT::lTFromlRhoSie_(const Real lRho,
 }
 
 PORTABLE_FUNCTION
-Real SpinerEOSDependsRhoT::lTFromlRhoP_(const Real lRho,
-                                        const Real press,
-                                        TableStatus& whereAmI,
-                                        Real* lambda) const {
+Real SpinerEOSDependsRhoT::lTFromlRhoP_(const Real lRho, const Real press,
+                                        TableStatus &whereAmI, Real *lambda) const {
   RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
   using RootFinding1D::findRoot;
   Real lT, lTGuess;
@@ -898,29 +844,25 @@ Real SpinerEOSDependsRhoT::lTFromlRhoP_(const Real lRho,
   // Assumes P is monotone in T
   const Real PCold = PCold_.interpToReal(lRho);
   const Real PMax = PMax_.interpToReal(lRho);
-  if ( press <= PCold ) {
+  if (press <= PCold) {
     whereAmI = TableStatus::OffBottom;
     lT = lTMin_;
     counts.increment(0);
-  } else if ( press >= PMax ) {
+  } else if (press >= PMax) {
     whereAmI = TableStatus::OffTop;
     lT = lTMax_;
     counts.increment(0);
   } else {
     whereAmI = TableStatus::OnTable;
-    if (lambda != nullptr
-        && lTMin_ <= lambda[Lambda::lT]
-        && lambda[Lambda::lT] <= lTMax_) {
+    if (lambda != nullptr && lTMin_ <= lambda[Lambda::lT] &&
+        lambda[Lambda::lT] <= lTMax_) {
       lTGuess = lambda[Lambda::lT];
     } else {
-      lTGuess = 0.5*(lTMin_ + lTMax_);
+      lTGuess = 0.5 * (lTMin_ + lTMax_);
     }
     const callable_interp::r_interp PFunc(P_, lRho);
-    status = findRoot(PFunc,
-                      press, lTGuess,
-                      lTMin_, lTMax_,
-                      ROOT_THRESH, ROOT_THRESH,
-                      lT, counts);
+    status = findRoot(PFunc, press, lTGuess, lTMin_, lTMax_, ROOT_THRESH, ROOT_THRESH, lT,
+                      counts);
     if (status != RootFinding1D::Status::SUCCESS) {
 #if SPINER_EOS_VERBOSE
       std::stringstream errorMessage;
@@ -928,16 +870,15 @@ Real SpinerEOSDependsRhoT::lTFromlRhoP_(const Real lRho,
                    << "matid   = " << matid_ << "\n"
                    << "lRho    = " << lRho << "\n"
                    << "P       = " << press << "\n"
-                   << "lTGuess = " << lTGuess
-                   << std::endl;
+                   << "lTGuess = " << lTGuess << std::endl;
       EOS_ERROR(errorMessage.str().c_str());
 #endif // SPINER_EOS_VERBOSE
       lT = reproducible_ ? lTMin_ : lTGuess;
     }
   }
   if (lambda != nullptr) {
-    lambda[Lambda::lRho]   = lRho;
-    lambda[Lambda::lT]     = lT;
+    lambda[Lambda::lRho] = lRho;
+    lambda[Lambda::lT] = lT;
   }
   status_ = status;
   whereAmI_ = whereAmI;
@@ -945,16 +886,15 @@ Real SpinerEOSDependsRhoT::lTFromlRhoP_(const Real lRho,
 }
 
 PORTABLE_FUNCTION
-Real SpinerEOSDependsRhoT::sieFromlRhoTlT_(const Real lRho,
-                                           const Real T, const Real lT,
-                                           const TableStatus& whereAmI) const {
+Real SpinerEOSDependsRhoT::sieFromlRhoTlT_(const Real lRho, const Real T, const Real lT,
+                                           const TableStatus &whereAmI) const {
   Real sie;
-  if ( whereAmI == TableStatus::OffBottom ) { // cold curve
+  if (whereAmI == TableStatus::OffBottom) { // cold curve
     sie = sieCold_.interpToReal(lRho);
-  } else if ( whereAmI == TableStatus::OffTop ) { // ideal gas
+  } else if (whereAmI == TableStatus::OffTop) { // ideal gas
     const Real Cv = dEdTMax_.interpToReal(lRho);
     const Real e0 = sielTMax_.interpToReal(lRho);
-    sie = e0 + Cv*(T - TMax_);
+    sie = e0 + Cv * (T - TMax_);
   } else { // on table
     sie = sie_.interpToReal(lRho, lT);
   }
@@ -962,18 +902,18 @@ Real SpinerEOSDependsRhoT::sieFromlRhoTlT_(const Real lRho,
 }
 
 PORTABLE_FUNCTION
-Real SpinerEOSDependsRhoT::PFromRholRhoTlT_(const Real rho, const Real lRho,
-                                            const Real T, const Real lT,
-                                            const TableStatus& whereAmI) const {
+Real SpinerEOSDependsRhoT::PFromRholRhoTlT_(const Real rho, const Real lRho, const Real T,
+                                            const Real lT,
+                                            const TableStatus &whereAmI) const {
   Real P;
-  if ( whereAmI == TableStatus::OffBottom ) { // cold curve
-    P =  PCold_.interpToReal(lRho);
-  } else if ( whereAmI == TableStatus::OffTop ) { // ideal gas
+  if (whereAmI == TableStatus::OffBottom) { // cold curve
+    P = PCold_.interpToReal(lRho);
+  } else if (whereAmI == TableStatus::OffTop) { // ideal gas
     const Real Cv = dEdTMax_.interpToReal(lRho);
     const Real gm1 = gm1Max_.interpToReal(lRho);
     const Real e0 = sielTMax_.interpToReal(lRho);
-    const Real e = e0 + Cv*(T - TMax_);
-    P = gm1*rho*e;
+    const Real e = e0 + Cv * (T - TMax_);
+    P = gm1 * rho * e;
   } else { // if ( whereAmI == TableStatus::OnTable) {
     P = P_.interpToReal(lRho, lT);
   }
@@ -982,16 +922,16 @@ Real SpinerEOSDependsRhoT::PFromRholRhoTlT_(const Real rho, const Real lRho,
 
 PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoT::CvFromlRholT_(const Real lRho, const Real lT,
-                                         const TableStatus& whereAmI) const {
+                                         const TableStatus &whereAmI) const {
   Real Cv;
-  if ( whereAmI == TableStatus::OffBottom ) { // cold curve
+  if (whereAmI == TableStatus::OffBottom) { // cold curve
     // on cold curve. Currently, we assume constant extrapolation.
     // TODO(JMM): Do something more sophisticated
     Cv = dEdTCold_.interpToReal(lRho);
-  } else if ( whereAmI == TableStatus::OffTop ) { // ideal gas
-    Cv = dEdTMax_.interpToReal(lRho); // Cv assumed constant in T
-  } else { // on table
-    Cv = dEdT_.interpToReal(lRho,lT);
+  } else if (whereAmI == TableStatus::OffTop) { // ideal gas
+    Cv = dEdTMax_.interpToReal(lRho);           // Cv assumed constant in T
+  } else {                                      // on table
+    Cv = dEdT_.interpToReal(lRho, lT);
   }
   return Cv > EPS ? Cv : EPS;
 }
@@ -999,29 +939,28 @@ Real SpinerEOSDependsRhoT::CvFromlRholT_(const Real lRho, const Real lT,
 PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoT::bModFromRholRhoTlT_(const Real rho, const Real lRho,
                                                const Real T, const Real lT,
-                                               const TableStatus& whereAmI) const {
+                                               const TableStatus &whereAmI) const {
   Real bMod;
-  if ( whereAmI == TableStatus::OffBottom ) {
+  if (whereAmI == TableStatus::OffBottom) {
     bMod = bModCold_.interpToReal(lRho);
-  } else if ( whereAmI == TableStatus::OffTop ) {
+  } else if (whereAmI == TableStatus::OffTop) {
     const Real Cv = dEdTMax_.interpToReal(lRho);
     const Real gm1 = gm1Max_.interpToReal(lRho);
     const Real e0 = sielTMax_.interpToReal(lRho);
-    const Real e = e0 + Cv*(T - TMax_);
-    bMod = (gm1 + 1)*gm1*rho*e;
+    const Real e = e0 + Cv * (T - TMax_);
+    bMod = (gm1 + 1) * gm1 * rho * e;
   } else { // on table
-    bMod = bMod_.interpToReal(lRho,lT);
+    bMod = bMod_.interpToReal(lRho, lT);
   }
   return bMod > EPS ? bMod : EPS;
 }
 
 PORTABLE_FUNCTION TableStatus
-SpinerEOSDependsRhoT::getLocDependsRhoSie_(const Real lRho,
-                                           const Real sie) const {
+SpinerEOSDependsRhoT::getLocDependsRhoSie_(const Real lRho, const Real sie) const {
   TableStatus whereAmI;
-  if ( sie >= sielTMax_.interpToReal(lRho) ) {
+  if (sie >= sielTMax_.interpToReal(lRho)) {
     whereAmI = TableStatus::OffTop;
-  } else if ( sie <= sieCold_.interpToReal(lRho) ) {
+  } else if (sie <= sieCold_.interpToReal(lRho)) {
     whereAmI = TableStatus::OffBottom;
   } else {
     whereAmI = TableStatus::OnTable;
@@ -1033,21 +972,20 @@ SpinerEOSDependsRhoT::getLocDependsRhoSie_(const Real lRho,
 PORTABLE_FUNCTION TableStatus
 SpinerEOSDependsRhoT::getLocDependsRhoT_(const Real lRho, const Real lT) const {
   TableStatus whereAmI;
-  if ( lT <= lTMin_ ) whereAmI = TableStatus::OffBottom;
-  else if ( lT >= lTMax_ ) whereAmI = TableStatus::OffTop;
-  else whereAmI = TableStatus::OnTable;
+  if (lT <= lTMin_)
+    whereAmI = TableStatus::OffBottom;
+  else if (lT >= lTMax_)
+    whereAmI = TableStatus::OffTop;
+  else
+    whereAmI = TableStatus::OnTable;
   whereAmI_ = whereAmI;
   return whereAmI;
 }
 
-SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string& filename,
-                                               int matid,
+SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string &filename, int matid,
                                                bool reproducibility_mode)
-  : filename_(filename.c_str())
-  , matid_(matid)
-  , reproducible_(reproducibility_mode)
-  , status_(RootFinding1D::Status::SUCCESS)
-  , memoryStatus_(DataStatus::OnHost) {
+    : filename_(filename.c_str()), matid_(matid), reproducible_(reproducibility_mode),
+      status_(RootFinding1D::Status::SUCCESS), memoryStatus_(DataStatus::OnHost) {
 
   std::string matid_str = std::to_string(matid);
   hsize_t dims;
@@ -1057,19 +995,16 @@ SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string& filename,
   herr_t status = H5_SUCCESS;
   std::vector<char> materialName;
 
-  file = H5Fopen(filename.c_str(),
-                 H5F_ACC_RDONLY, H5P_DEFAULT);
+  file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   matGroup = H5Gopen(file, matid_str.c_str(), H5P_DEFAULT);
-  lTGroup = H5Gopen(matGroup, SP5::Depends::logRhoLogT,   H5P_DEFAULT);
+  lTGroup = H5Gopen(matGroup, SP5::Depends::logRhoLogT, H5P_DEFAULT);
   lEGroup = H5Gopen(matGroup, SP5::Depends::logRhoLogSie, H5P_DEFAULT);
 
   // This works because chars are 1 byte. ~ JMM
-  status += H5LTget_attribute_info(file, matid_str.c_str(),
-                                   SP5::Material::name,
-                                   &dims,&tclass,&size);
-  materialName.resize((int)size+1);
-  status += H5LTget_attribute_string(file, matid_str.c_str(),
-                                     SP5::Material::name,
+  status += H5LTget_attribute_info(file, matid_str.c_str(), SP5::Material::name, &dims,
+                                   &tclass, &size);
+  materialName.resize((int)size + 1);
+  status += H5LTget_attribute_string(file, matid_str.c_str(), SP5::Material::name,
                                      materialName.data());
   materialName_ = materialName.data();
 
@@ -1079,34 +1014,30 @@ SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string& filename,
   status += H5Gclose(lEGroup);
   status += H5Gclose(matGroup);
   status += H5Fclose(file);
-  
+
   if (status != H5_SUCCESS) {
     EOS_ERROR("SpinerDependsTHoSIE: HDF5 error\n");
   }
 }
 
-SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string& filename,
-                                               const std::string& materialName,
+SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string &filename,
+                                               const std::string &materialName,
                                                bool reproducibility_mode)
-  : filename_(filename.c_str())
-  , materialName_(materialName.c_str())
-  , reproducible_(reproducibility_mode)
-  , status_(RootFinding1D::Status::SUCCESS)
-  , memoryStatus_(DataStatus::OnHost) {
+    : filename_(filename.c_str()), materialName_(materialName.c_str()),
+      reproducible_(reproducibility_mode), status_(RootFinding1D::Status::SUCCESS),
+      memoryStatus_(DataStatus::OnHost) {
 
   std::string matid_str;
   hid_t file, matGroup, lTGroup, lEGroup;
   herr_t status = H5_SUCCESS;
 
-  file = H5Fopen(filename.c_str(),
-                 H5F_ACC_RDONLY, H5P_DEFAULT);
+  file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   matGroup = H5Gopen(file, materialName.c_str(), H5P_DEFAULT);
-  lTGroup = H5Gopen(matGroup, SP5::Depends::logRhoLogT,   H5P_DEFAULT);
+  lTGroup = H5Gopen(matGroup, SP5::Depends::logRhoLogT, H5P_DEFAULT);
   lEGroup = H5Gopen(matGroup, SP5::Depends::logRhoLogSie, H5P_DEFAULT);
 
-  status += H5LTget_attribute_int(file, materialName.c_str(),
-                                  SP5::Material::matid,
-                                  &matid_);
+  status +=
+      H5LTget_attribute_int(file, materialName.c_str(), SP5::Material::matid, &matid_);
   matid_str = std::to_string(matid_);
 
   status += loadDataboxes_(matid_str, file, lTGroup, lEGroup);
@@ -1115,60 +1046,53 @@ SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string& filename,
   status += H5Gclose(lEGroup);
   status += H5Gclose(matGroup);
   status += H5Fclose(file);
-  
+
   if (status != H5_SUCCESS) {
     EOS_ERROR("SpinerDependsRhoSie: HDF5 error\n");
   }
 }
 
-herr_t SpinerEOSDependsRhoSie::loadDataboxes_(const std::string& matid_str,
-                                              hid_t file,
-                                              hid_t lTGroup,
-                                              hid_t lEGroup) {
+herr_t SpinerEOSDependsRhoSie::loadDataboxes_(const std::string &matid_str, hid_t file,
+                                              hid_t lTGroup, hid_t lEGroup) {
   herr_t status = H5_SUCCESS;
 
   // offsets
-  status += H5LTget_attribute_double(file, matid_str.c_str(),
-                                     SP5::Offsets::rho,
-                                     &lRhoOffset_);
-  status += H5LTget_attribute_double(file, matid_str.c_str(),
-                                     SP5::Offsets::T,
-                                     &lTOffset_);
-  status += H5LTget_attribute_double(file, matid_str.c_str(),
-                                     SP5::Offsets::sie,
-                                     &lEOffset_);
+  status +=
+      H5LTget_attribute_double(file, matid_str.c_str(), SP5::Offsets::rho, &lRhoOffset_);
+  status +=
+      H5LTget_attribute_double(file, matid_str.c_str(), SP5::Offsets::T, &lTOffset_);
+  status +=
+      H5LTget_attribute_double(file, matid_str.c_str(), SP5::Offsets::sie, &lEOffset_);
   lRhoOffset_ = std::abs(lRhoOffset_);
-  lTOffset_   = std::abs(lTOffset_);
-  lEOffset_   = std::abs(lEOffset_);
+  lTOffset_ = std::abs(lTOffset_);
+  lEOffset_ = std::abs(lEOffset_);
 
   // normal density
   status += H5LTget_attribute_double(file, matid_str.c_str(),
-                                     SP5::Material::normalDensity,
-                                     &rhoNormal_);
+                                     SP5::Material::normalDensity, &rhoNormal_);
   rhoNormal_ = std::abs(rhoNormal_);
 
   // sometimes independent variables
   status += sie_.loadHDF(lTGroup, SP5::Fields::sie);
-  status += T_.loadHDF(lEGroup,   SP5::Fields::T);
+  status += T_.loadHDF(lEGroup, SP5::Fields::T);
 
   // dependent variables
   // depends on rho and T
-  status += dependsRhoT_.P.loadHDF(lTGroup,       SP5::Fields::P);
-  status += dependsRhoT_.bMod.loadHDF(lTGroup,    SP5::Fields::bMod);
-  status += dependsRhoT_.dPdRho.loadHDF(lTGroup,  SP5::Fields::dPdRho);
-  status += dependsRhoT_.dPdE.loadHDF(lTGroup,    SP5::Fields::dPdE);
-  status += dependsRhoT_.dTdRho.loadHDF(lTGroup,  SP5::Fields::dTdRho);
-  status += dependsRhoT_.dTdE.loadHDF(lTGroup,    SP5::Fields::dTdE);
-  status += dependsRhoT_.dEdRho.loadHDF(lTGroup,  SP5::Fields::dEdRho);
+  status += dependsRhoT_.P.loadHDF(lTGroup, SP5::Fields::P);
+  status += dependsRhoT_.bMod.loadHDF(lTGroup, SP5::Fields::bMod);
+  status += dependsRhoT_.dPdRho.loadHDF(lTGroup, SP5::Fields::dPdRho);
+  status += dependsRhoT_.dPdE.loadHDF(lTGroup, SP5::Fields::dPdE);
+  status += dependsRhoT_.dTdRho.loadHDF(lTGroup, SP5::Fields::dTdRho);
+  status += dependsRhoT_.dTdE.loadHDF(lTGroup, SP5::Fields::dTdE);
+  status += dependsRhoT_.dEdRho.loadHDF(lTGroup, SP5::Fields::dEdRho);
   // depends on rho and e
-  status += dependsRhoSie_.P.loadHDF(lEGroup,       SP5::Fields::P);
-  status += dependsRhoSie_.bMod.loadHDF(lEGroup,    SP5::Fields::bMod);
-  status += dependsRhoSie_.dPdRho.loadHDF(lEGroup,  SP5::Fields::dPdRho);
-  status += dependsRhoSie_.dPdE.loadHDF(lEGroup,    SP5::Fields::dPdE);
-  status += dependsRhoSie_.dTdRho.loadHDF(lEGroup,  SP5::Fields::dTdRho);
-  status += dependsRhoSie_.dTdE.loadHDF(lEGroup,    SP5::Fields::dTdE);
-  status += dependsRhoSie_.dEdRho.loadHDF(lEGroup,  SP5::Fields::dEdRho);
-  
+  status += dependsRhoSie_.P.loadHDF(lEGroup, SP5::Fields::P);
+  status += dependsRhoSie_.bMod.loadHDF(lEGroup, SP5::Fields::bMod);
+  status += dependsRhoSie_.dPdRho.loadHDF(lEGroup, SP5::Fields::dPdRho);
+  status += dependsRhoSie_.dPdE.loadHDF(lEGroup, SP5::Fields::dPdE);
+  status += dependsRhoSie_.dTdRho.loadHDF(lEGroup, SP5::Fields::dTdRho);
+  status += dependsRhoSie_.dTdE.loadHDF(lEGroup, SP5::Fields::dTdE);
+  status += dependsRhoSie_.dEdRho.loadHDF(lEGroup, SP5::Fields::dEdRho);
 
   // Fix up bulk modulus
   calcBMod_(dependsRhoT_);
@@ -1178,58 +1102,58 @@ herr_t SpinerEOSDependsRhoSie::loadDataboxes_(const std::string& matid_str,
   numRho_ = sie_.dim(2);
   lRhoMin_ = sie_.range(1).min();
   lRhoMax_ = sie_.range(1).max();
-  rhoMax_  = fromLog_(lRhoMax_,lRhoOffset_);
+  rhoMax_ = fromLog_(lRhoMax_, lRhoOffset_);
 
   // slice to maximum of rho
-  PlRhoMax_  = dependsRhoT_.P.slice(numRho_-1);
-  dPdRhoMax_ = dependsRhoT_.dPdRho.slice(numRho_-1);
+  PlRhoMax_ = dependsRhoT_.P.slice(numRho_ - 1);
+  dPdRhoMax_ = dependsRhoT_.dPdRho.slice(numRho_ - 1);
 
   // reference state
-  Real lRhoNormal = toLog_(rhoNormal_,lRhoOffset_);
+  Real lRhoNormal = toLog_(rhoNormal_, lRhoOffset_);
   // if rho normal not on the table, set it to the middle
-  if ( !(lRhoMin_ < lRhoNormal && lRhoNormal < lRhoMax_) ) {
-    lRhoNormal = 0.5*(lRhoMin_ + lRhoMax_);
-    rhoNormal_ = fromLog_(lRhoNormal,lRhoOffset_);
+  if (!(lRhoMin_ < lRhoNormal && lRhoNormal < lRhoMax_)) {
+    lRhoNormal = 0.5 * (lRhoMin_ + lRhoMax_);
+    rhoNormal_ = fromLog_(lRhoNormal, lRhoOffset_);
   }
   // Same for temperature. Use room temperature if it's available
   TNormal_ = ROOM_TEMPERATURE;
-  Real lTNormal = toLog_(TNormal_,lTOffset_);
+  Real lTNormal = toLog_(TNormal_, lTOffset_);
   Real lTMin = sie_.range(0).min();
   Real lTMax = sie_.range(0).max();
-  if ( !(lTMin < lTNormal && lTNormal < lTMax) ) {
-    lTNormal = 0.5*(lTMin + lTMax);
-    TNormal_ = fromLog_(lTNormal,lTOffset_);
+  if (!(lTMin < lTNormal && lTNormal < lTMax)) {
+    lTNormal = 0.5 * (lTMin + lTMax);
+    TNormal_ = fromLog_(lTNormal, lTOffset_);
   }
-  sieNormal_ = sie_.interpToReal(lRhoNormal,lTNormal);
-  PNormal_ = dependsRhoT_.P.interpToReal(lRhoNormal,lTNormal);
-  CvNormal_ = 1./dependsRhoT_.dTdE.interpToReal(lRhoNormal,lTNormal);
-  bModNormal_ = dependsRhoT_.bMod.interpToReal(lRhoNormal,lTNormal);
-  dPdENormal_ = dependsRhoT_.dPdE.interpToReal(lRhoNormal,lTNormal);
-  Real dPdR = dependsRhoT_.dPdRho.interpToReal(lRhoNormal,lTNormal);
-  dVdTNormal_ = dPdENormal_*CvNormal_/(rhoNormal_*rhoNormal_*dPdR);
+  sieNormal_ = sie_.interpToReal(lRhoNormal, lTNormal);
+  PNormal_ = dependsRhoT_.P.interpToReal(lRhoNormal, lTNormal);
+  CvNormal_ = 1. / dependsRhoT_.dTdE.interpToReal(lRhoNormal, lTNormal);
+  bModNormal_ = dependsRhoT_.bMod.interpToReal(lRhoNormal, lTNormal);
+  dPdENormal_ = dependsRhoT_.dPdE.interpToReal(lRhoNormal, lTNormal);
+  Real dPdR = dependsRhoT_.dPdRho.interpToReal(lRhoNormal, lTNormal);
+  dVdTNormal_ = dPdENormal_ * CvNormal_ / (rhoNormal_ * rhoNormal_ * dPdR);
 
   return status;
 }
 
-void SpinerEOSDependsRhoSie::calcBMod_(SP5Tables& tables) {
+void SpinerEOSDependsRhoSie::calcBMod_(SP5Tables &tables) {
   for (int j = 0; j < tables.bMod.dim(2); j++) {
     Real lRho = tables.bMod.range(1).x(j);
-    Real rho = fromLog_(lRho,lRhoOffset_);
+    Real rho = fromLog_(lRho, lRhoOffset_);
     for (int i = 0; i < tables.bMod.dim(1); i++) {
-      Real press = tables.P(j,i);
-      Real DPDR  = tables.dPdRho(j,i);
-      Real DPDE  = tables.dPdE(j,i);
-      Real DEDR  = tables.dEdRho(j,i);
-      Real DTDE  = tables.dTdE(j,i);
+      Real press = tables.P(j, i);
+      Real DPDR = tables.dPdRho(j, i);
+      Real DPDE = tables.dPdE(j, i);
+      Real DEDR = tables.dEdRho(j, i);
+      Real DTDE = tables.dTdE(j, i);
       Real bMod;
       if (DPDE > 0.0 && rho > 0.0) {
-        bMod = rho*DPDR + DPDE*(press/rho - rho*DEDR);
+        bMod = rho * DPDR + DPDE * (press / rho - rho * DEDR);
       } else if (rho > 0.0) {
-        bMod = std::max(rho*DPDR,0.0);
+        bMod = std::max(rho * DPDR, 0.0);
       } else {
         bMod = 0.0;
       }
-      tables.bMod(j,i) = std::max(bMod,std::abs(Spiner::EPS));
+      tables.bMod(j, i) = std::max(bMod, std::abs(Spiner::EPS));
     }
   }
 }
@@ -1238,41 +1162,41 @@ SpinerEOSDependsRhoSie SpinerEOSDependsRhoSie::GetOnDevice() {
   SpinerEOSDependsRhoSie other;
   using Spiner::getOnDeviceDataBox;
   other.sie_ = getOnDeviceDataBox(sie_);
-  other.T_   = getOnDeviceDataBox(T_);
-  other.dependsRhoT_.P        = getOnDeviceDataBox(dependsRhoT_.P);
-  other.dependsRhoT_.bMod     = getOnDeviceDataBox(dependsRhoT_.bMod);
-  other.dependsRhoT_.dPdRho   = getOnDeviceDataBox(dependsRhoT_.dPdRho);
-  other.dependsRhoT_.dPdE     = getOnDeviceDataBox(dependsRhoT_.dPdE);
-  other.dependsRhoT_.dTdRho   = getOnDeviceDataBox(dependsRhoT_.dTdRho);
-  other.dependsRhoT_.dTdE     = getOnDeviceDataBox(dependsRhoT_.dTdE);
-  other.dependsRhoT_.dEdRho   = getOnDeviceDataBox(dependsRhoT_.dEdRho);
-  other.dependsRhoSie_.P      = getOnDeviceDataBox(dependsRhoSie_.P);
-  other.dependsRhoSie_.bMod   = getOnDeviceDataBox(dependsRhoSie_.bMod);
+  other.T_ = getOnDeviceDataBox(T_);
+  other.dependsRhoT_.P = getOnDeviceDataBox(dependsRhoT_.P);
+  other.dependsRhoT_.bMod = getOnDeviceDataBox(dependsRhoT_.bMod);
+  other.dependsRhoT_.dPdRho = getOnDeviceDataBox(dependsRhoT_.dPdRho);
+  other.dependsRhoT_.dPdE = getOnDeviceDataBox(dependsRhoT_.dPdE);
+  other.dependsRhoT_.dTdRho = getOnDeviceDataBox(dependsRhoT_.dTdRho);
+  other.dependsRhoT_.dTdE = getOnDeviceDataBox(dependsRhoT_.dTdE);
+  other.dependsRhoT_.dEdRho = getOnDeviceDataBox(dependsRhoT_.dEdRho);
+  other.dependsRhoSie_.P = getOnDeviceDataBox(dependsRhoSie_.P);
+  other.dependsRhoSie_.bMod = getOnDeviceDataBox(dependsRhoSie_.bMod);
   other.dependsRhoSie_.dPdRho = getOnDeviceDataBox(dependsRhoSie_.dPdRho);
-  other.dependsRhoSie_.dPdE   = getOnDeviceDataBox(dependsRhoSie_.dPdE);
+  other.dependsRhoSie_.dPdE = getOnDeviceDataBox(dependsRhoSie_.dPdE);
   other.dependsRhoSie_.dTdRho = getOnDeviceDataBox(dependsRhoSie_.dTdRho);
-  other.dependsRhoSie_.dTdE   = getOnDeviceDataBox(dependsRhoSie_.dTdE);
+  other.dependsRhoSie_.dTdE = getOnDeviceDataBox(dependsRhoSie_.dTdE);
   other.dependsRhoSie_.dEdRho = getOnDeviceDataBox(dependsRhoSie_.dEdRho);
-  other.numRho_       = numRho_;
-  other.lRhoMin_      = lRhoMin_;
-  other.lRhoMax_      = lRhoMax_;
-  other.rhoMax_       = rhoMax_;
-  other.PlRhoMax_     = getOnDeviceDataBox(PlRhoMax_);
-  other.dPdRhoMax_    = getOnDeviceDataBox(dPdRhoMax_);
-  other.lRhoOffset_   = lRhoOffset_;
-  other.lTOffset_     = lTOffset_;
-  other.lEOffset_     = lEOffset_;
-  other.rhoNormal_    = rhoNormal_;
-  other.TNormal_      = TNormal_;
-  other.sieNormal_    = sieNormal_;
-  other.PNormal_      = PNormal_;
-  other.CvNormal_     = CvNormal_;
-  other.bModNormal_   = bModNormal_;
-  other.dPdENormal_   = dPdENormal_;
-  other.dVdTNormal_   = dVdTNormal_;
-  other.matid_        = matid_;
+  other.numRho_ = numRho_;
+  other.lRhoMin_ = lRhoMin_;
+  other.lRhoMax_ = lRhoMax_;
+  other.rhoMax_ = rhoMax_;
+  other.PlRhoMax_ = getOnDeviceDataBox(PlRhoMax_);
+  other.dPdRhoMax_ = getOnDeviceDataBox(dPdRhoMax_);
+  other.lRhoOffset_ = lRhoOffset_;
+  other.lTOffset_ = lTOffset_;
+  other.lEOffset_ = lEOffset_;
+  other.rhoNormal_ = rhoNormal_;
+  other.TNormal_ = TNormal_;
+  other.sieNormal_ = sieNormal_;
+  other.PNormal_ = PNormal_;
+  other.CvNormal_ = CvNormal_;
+  other.bModNormal_ = bModNormal_;
+  other.dPdENormal_ = dPdENormal_;
+  other.dVdTNormal_ = dVdTNormal_;
+  other.matid_ = matid_;
   other.reproducible_ = reproducible_;
-  other.status_       = status_;
+  other.status_ = status_;
   other.memoryStatus_ = DataStatus::OnDevice;
   return other;
 }
@@ -1305,165 +1229,155 @@ PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoSie::TemperatureFromDensityInternalEnergy(const Real rho,
                                                                   const Real sie,
                                                                   Real *lambda) const {
-  return interpRhoSie_(rho,sie,T_,lambda);
+  return interpRhoSie_(rho, sie, T_, lambda);
 }
 
 PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoSie::InternalEnergyFromDensityTemperature(const Real rho,
                                                                   const Real T,
                                                                   Real *lambda) const {
-  return interpRhoT_(rho,T,sie_,lambda);
+  return interpRhoT_(rho, T, sie_, lambda);
 }
 
 PORTABLE_FUNCTION
-Real SpinerEOSDependsRhoSie::PressureFromDensityTemperature(const Real rho,
-                                                            const Real T,
+Real SpinerEOSDependsRhoSie::PressureFromDensityTemperature(const Real rho, const Real T,
                                                             Real *lambda) const {
-  return interpRhoT_(rho,T,dependsRhoT_.P,lambda);
+  return interpRhoT_(rho, T, dependsRhoT_.P, lambda);
 }
 
 PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoSie::PressureFromDensityInternalEnergy(const Real rho,
                                                                const Real sie,
                                                                Real *lambda) const {
-  return interpRhoSie_(rho,sie,dependsRhoSie_.P,lambda);
+  return interpRhoSie_(rho, sie, dependsRhoSie_.P, lambda);
 }
 
 PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoSie::SpecificHeatFromDensityTemperature(const Real rho,
                                                                 const Real T,
                                                                 Real *lambda) const {
-  return 1./interpRhoT_(rho,T,dependsRhoT_.dTdE,lambda);
+  return 1. / interpRhoT_(rho, T, dependsRhoT_.dTdE, lambda);
 }
 
 PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoSie::SpecificHeatFromDensityInternalEnergy(const Real rho,
                                                                    const Real sie,
                                                                    Real *lambda) const {
-  return 1./interpRhoSie_(rho,sie,dependsRhoSie_.dTdE,lambda);
+  return 1. / interpRhoSie_(rho, sie, dependsRhoSie_.dTdE, lambda);
 }
 
 PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoSie::BulkModulusFromDensityTemperature(const Real rho,
                                                                const Real T,
                                                                Real *lambda) const {
-  return interpRhoT_(rho,T,dependsRhoT_.bMod,lambda);
+  return interpRhoT_(rho, T, dependsRhoT_.bMod, lambda);
 }
 
 PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoSie::BulkModulusFromDensityInternalEnergy(const Real rho,
                                                                   const Real sie,
                                                                   Real *lambda) const {
-  return interpRhoSie_(rho,sie,dependsRhoSie_.bMod,lambda);
+  return interpRhoSie_(rho, sie, dependsRhoSie_.bMod, lambda);
 }
 
 PORTABLE_FUNCTION
-Real
-SpinerEOSDependsRhoSie::GruneisenParamFromDensityTemperature(const Real rho,
-                                                             const Real T,
-                                                             Real *lambda) 
-                                                             const {
+Real SpinerEOSDependsRhoSie::GruneisenParamFromDensityTemperature(const Real rho,
+                                                                  const Real T,
+                                                                  Real *lambda) const {
   const Real dpde = interpRhoT_(rho, T, dependsRhoT_.dPdE, lambda);
-  return dpde/rho;
+  return dpde / rho;
 }
 
 PORTABLE_FUNCTION
-Real
-SpinerEOSDependsRhoSie::GruneisenParamFromDensityInternalEnergy(const Real rho,
-                                                                const Real sie,
-                                                                Real *lambda)
-                                                                const {
-  const Real lRho = toLog_(rho,lRhoOffset_);
-  const Real lE = toLog_(sie,lEOffset_);
-  const Real dpde = dependsRhoSie_.dPdE.interpToReal(lRho,lE);
-  return dpde/rho;
+Real SpinerEOSDependsRhoSie::GruneisenParamFromDensityInternalEnergy(const Real rho,
+                                                                     const Real sie,
+                                                                     Real *lambda) const {
+  const Real lRho = toLog_(rho, lRhoOffset_);
+  const Real lE = toLog_(sie, lEOffset_);
+  const Real dpde = dependsRhoSie_.dPdE.interpToReal(lRho, lE);
+  return dpde / rho;
 }
 
 PORTABLE_FUNCTION
 void SpinerEOSDependsRhoSie::DensityEnergyFromPressureTemperature(const Real press,
                                                                   const Real temp,
-                                                                  Real *lambda,
-                                                                  Real& rho, Real& sie) const {
-  Real lT = toLog_(temp,lTOffset_);
-  Real lRho = lRhoFromPlT_(press,lT,lambda);
-  rho = fromLog_(lRho,lRhoOffset_);
-  sie = sie_.interpToReal(lRho,lT);
+                                                                  Real *lambda, Real &rho,
+                                                                  Real &sie) const {
+  Real lT = toLog_(temp, lTOffset_);
+  Real lRho = lRhoFromPlT_(press, lT, lambda);
+  rho = fromLog_(lRho, lRhoOffset_);
+  sie = sie_.interpToReal(lRho, lT);
 }
 
 PORTABLE_FUNCTION
-void SpinerEOSDependsRhoSie::PTofRE(const Real rho, const Real sie,
-                                    Real * lambda,
-                                    Real& press, Real& temp,
-                                    Real & dpdr, Real & dpde,
-                                    Real & dtdr, Real & dtde) const {
-  Real lRho = toLog_(rho,lRhoOffset_);
-  Real lE = toLog_(sie,lEOffset_);
-  press = dependsRhoSie_.P.interpToReal(lRho,lE);
-  temp = T_.interpToReal(lRho,lE);
-  dpdr = dependsRhoSie_.dPdRho.interpToReal(lRho,lE);
-  dpde = dependsRhoSie_.dPdE.interpToReal(lRho,lE);
-  dtdr = dependsRhoSie_.dTdRho.interpToReal(lRho,lE);
-  dtde = dependsRhoSie_.dTdE.interpToReal(lRho,lE);
+void SpinerEOSDependsRhoSie::PTofRE(const Real rho, const Real sie, Real *lambda,
+                                    Real &press, Real &temp, Real &dpdr, Real &dpde,
+                                    Real &dtdr, Real &dtde) const {
+  Real lRho = toLog_(rho, lRhoOffset_);
+  Real lE = toLog_(sie, lEOffset_);
+  press = dependsRhoSie_.P.interpToReal(lRho, lE);
+  temp = T_.interpToReal(lRho, lE);
+  dpdr = dependsRhoSie_.dPdRho.interpToReal(lRho, lE);
+  dpde = dependsRhoSie_.dPdE.interpToReal(lRho, lE);
+  dtdr = dependsRhoSie_.dTdRho.interpToReal(lRho, lE);
+  dtde = dependsRhoSie_.dTdE.interpToReal(lRho, lE);
 }
 
 PORTABLE_FUNCTION
-void SpinerEOSDependsRhoSie::FillEos(Real& rho, Real& temp,
-                                     Real& energy, Real& press,
-                                     Real& cv, Real& bmod,
-                                     const unsigned long output,
+void SpinerEOSDependsRhoSie::FillEos(Real &rho, Real &temp, Real &energy, Real &press,
+                                     Real &cv, Real &bmod, const unsigned long output,
                                      Real *lambda) const {
   Real lRho, lT, lE;
   if (output == thermalqs::none) {
     UNDEFINED_ERROR;
   }
-  if (output&thermalqs::temperature && output&thermalqs::specific_internal_energy) {
+  if (output & thermalqs::temperature && output & thermalqs::specific_internal_energy) {
     UNDEFINED_ERROR;
   }
-  if (output&thermalqs::density) {
-    if (!(output&thermalqs::pressure || output&thermalqs::temperature)) {
-      lT = toLog_(temp,lTOffset_);
-      lRho = lRhoFromPlT_(press,lT,lambda);
-      rho = fromLog_(lRho,lRhoOffset_);
+  if (output & thermalqs::density) {
+    if (!(output & thermalqs::pressure || output & thermalqs::temperature)) {
+      lT = toLog_(temp, lTOffset_);
+      lRho = lRhoFromPlT_(press, lT, lambda);
+      rho = fromLog_(lRho, lRhoOffset_);
     } else {
       UNDEFINED_ERROR;
-    } 
+    }
   } else {
-    lRho = toLog_(rho,lRhoOffset_);
+    lRho = toLog_(rho, lRhoOffset_);
     if (lambda != nullptr) *lambda = lRho;
   }
-  if (output&thermalqs::temperature) {
-    lE = toLog_(energy,lEOffset_);
-    temp = T_.interpToReal(lRho,lE);
-    if (output&thermalqs::pressure) {
-      press = dependsRhoSie_.P.interpToReal(lRho,lE);
+  if (output & thermalqs::temperature) {
+    lE = toLog_(energy, lEOffset_);
+    temp = T_.interpToReal(lRho, lE);
+    if (output & thermalqs::pressure) {
+      press = dependsRhoSie_.P.interpToReal(lRho, lE);
     }
-    if (output&thermalqs::specific_heat) {
-      cv = 1./dependsRhoSie_.dTdE.interpToReal(lRho,lE);
+    if (output & thermalqs::specific_heat) {
+      cv = 1. / dependsRhoSie_.dTdE.interpToReal(lRho, lE);
     }
-    if (output&thermalqs::bulk_modulus) {
-      bmod = dependsRhoSie_.bMod.interpToReal(lRho,lE);
+    if (output & thermalqs::bulk_modulus) {
+      bmod = dependsRhoSie_.bMod.interpToReal(lRho, lE);
     }
   }
-  if (output&thermalqs::specific_internal_energy) {
-    lT = toLog_(temp,lTOffset_);
-    energy = sie_.interpToReal(lRho,lT);
-    if (output&thermalqs::pressure) {
-      press = dependsRhoT_.P.interpToReal(lRho,lT);
+  if (output & thermalqs::specific_internal_energy) {
+    lT = toLog_(temp, lTOffset_);
+    energy = sie_.interpToReal(lRho, lT);
+    if (output & thermalqs::pressure) {
+      press = dependsRhoT_.P.interpToReal(lRho, lT);
     }
-    if (output&thermalqs::specific_heat) {
-      cv = 1./dependsRhoT_.dTdE.interpToReal(lRho,lT);
+    if (output & thermalqs::specific_heat) {
+      cv = 1. / dependsRhoT_.dTdE.interpToReal(lRho, lT);
     }
-    if (output&thermalqs::bulk_modulus) {
-      bmod = dependsRhoT_.bMod.interpToReal(lRho,lT);
+    if (output & thermalqs::bulk_modulus) {
+      bmod = dependsRhoT_.bMod.interpToReal(lRho, lT);
     }
   }
 }
 
 PORTABLE_FUNCTION
-void SpinerEOSDependsRhoSie::ValuesAtReferenceState(Real& rho, Real& temp,
-                                                    Real& sie, Real& press,
-                                                    Real& cv, Real& bmod,
-                                                    Real& dpde, Real& dvdt,
+void SpinerEOSDependsRhoSie::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie,
+                                                    Real &press, Real &cv, Real &bmod,
+                                                    Real &dpde, Real &dvdt,
                                                     Real *lambda) const {
   rho = rhoNormal_;
   temp = TNormal_;
@@ -1477,48 +1391,46 @@ void SpinerEOSDependsRhoSie::ValuesAtReferenceState(Real& rho, Real& temp,
 
 PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoSie::interpRhoT_(const Real rho, const Real T,
-                                         const Spiner::DataBox& db,
-                                         Real *lambda) const {
-  const Real lRho = toLog_(rho,lRhoOffset_);
-  const Real lT = toLog_(T,lTOffset_);
-  if (lambda != nullptr) { *lambda = lRho; }
+                                         const Spiner::DataBox &db, Real *lambda) const {
+  const Real lRho = toLog_(rho, lRhoOffset_);
+  const Real lT = toLog_(T, lTOffset_);
+  if (lambda != nullptr) {
+    *lambda = lRho;
+  }
   return db.interpToReal(lRho, lT);
 }
 
 PORTABLE_FUNCTION
 Real SpinerEOSDependsRhoSie::interpRhoSie_(const Real rho, const Real sie,
-                                           const Spiner::DataBox& db,
+                                           const Spiner::DataBox &db,
                                            Real *lambda) const {
-  const Real lRho = toLog_(rho,lRhoOffset_);
-  const Real lE = toLog_(sie,lEOffset_);
-  if (lambda != nullptr) { *lambda = lRho; }
+  const Real lRho = toLog_(rho, lRhoOffset_);
+  const Real lE = toLog_(sie, lEOffset_);
+  if (lambda != nullptr) {
+    *lambda = lRho;
+  }
   return db.interpToReal(lRho, lE);
 }
 
 PORTABLE_FUNCTION
-Real SpinerEOSDependsRhoSie::lRhoFromPlT_(const Real P,
-                                          const Real lT,
-                                          Real* lambda) const {
+Real SpinerEOSDependsRhoSie::lRhoFromPlT_(const Real P, const Real lT,
+                                          Real *lambda) const {
   using RootFinding1D::findRoot;
 
   Real lRho;
   Real dPdRhoMax = dPdRhoMax_.interpToReal(lT);
   Real PMax = PlRhoMax_.interpToReal(lT);
-  if ( dPdRhoMax > 0 && P > PMax) {
-    Real rho = (P - PMax)/dPdRhoMax + rhoMax_;
-    lRho = toLog_(rho,lRhoOffset_);
+  if (dPdRhoMax > 0 && P > PMax) {
+    Real rho = (P - PMax) / dPdRhoMax + rhoMax_;
+    lRho = toLog_(rho, lRhoOffset_);
     counts.increment(0);
   } else {
-    Real lRhoGuess = reproducible_ ? lRhoMin_ : 0.5*(lRhoMin_ + lRhoMax_);
+    Real lRhoGuess = reproducible_ ? lRhoMin_ : 0.5 * (lRhoMin_ + lRhoMax_);
     if (lambda != nullptr && lRhoMin_ <= *lambda && *lambda <= lRhoMax_) {
       lRhoGuess = *lambda;
     }
     const callable_interp::l_interp PFunc(dependsRhoT_.P, lT);
-    status_ = findRoot(PFunc,
-                       P, lRhoGuess,
-                       lRhoMin_, lRhoMax_,
-                       EPS, EPS,
-                       lRho, counts);
+    status_ = findRoot(PFunc, P, lRhoGuess, lRhoMin_, lRhoMax_, EPS, EPS, lRho, counts);
 
     if (status_ != RootFinding1D::Status::SUCCESS) {
 #if EPINER_EOS_VERBOSE
@@ -1527,10 +1439,9 @@ Real SpinerEOSDependsRhoSie::lRhoFromPlT_(const Real P,
                    << "matid     = " << matid_ << "\n"
                    << "lT        = " << lT << "\n"
                    << "P         = " << P << "\n"
-                   << "lRhoGuess = " << lRhoGuess
-                   << std::endl;
+                   << "lRhoGuess = " << lRhoGuess << std::endl;
       EOS_ERROR(errorMessage.str().c_str());
-#endif //SPINER_EOS_VERBOSE
+#endif // SPINER_EOS_VERBOSE
       lRho = reproducible_ ? lRhoMin_ : lRhoGuess;
     }
   }

--- a/singularity-eos/eos/eos_stellar_collapse.cpp
+++ b/singularity-eos/eos/eos_stellar_collapse.cpp
@@ -40,7 +40,7 @@
 namespace callable_interp {
 
 class LogT {
-public:
+ public:
   PORTABLE_INLINE_FUNCTION
   LogT(const Spiner::DataBox &field, const Real Ye, const Real lRho)
       : field_(field), Ye_(Ye), lRho_(lRho) {}
@@ -48,7 +48,7 @@ public:
     return field_.interpToReal(Ye_, lT, lRho_);
   }
 
-private:
+ private:
   const Spiner::DataBox &field_;
   const Real Ye_, lRho_;
 };
@@ -83,16 +83,14 @@ StellarCollapse::StellarCollapse(const std::string &filename, bool use_sp5,
 // Saves to an SP5 file
 void StellarCollapse::Save(const std::string &filename) {
   herr_t status = H5_SUCCESS;
-  hid_t file =
-      H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
   // Metadata
-  hid_t metadata =
-      H5Gcreate(file, METADATA_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  status += H5LTset_attribute_string(
-      file, METADATA_NAME, SP5::Offsets::messageName, SP5::Offsets::message);
-  status += H5LTset_attribute_double(file, METADATA_NAME, SP5::Offsets::sie,
-                                     &lEOffset_, 1);
+  hid_t metadata = H5Gcreate(file, METADATA_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  status += H5LTset_attribute_string(file, METADATA_NAME, SP5::Offsets::messageName,
+                                     SP5::Offsets::message);
+  status +=
+      H5LTset_attribute_double(file, METADATA_NAME, SP5::Offsets::sie, &lEOffset_, 1);
   H5Gclose(metadata);
 
   // Databoxes
@@ -174,8 +172,7 @@ void StellarCollapse::Finalize() {
 }
 
 PORTABLE_FUNCTION
-Real StellarCollapse::TemperatureFromDensityInternalEnergy(const Real rho,
-                                                           const Real sie,
+Real StellarCollapse::TemperatureFromDensityInternalEnergy(const Real rho, const Real sie,
                                                            Real *lambda) const {
   const Real lRho = lRho_(rho);
   const Real lT = lTFromlRhoSie_(lRho, sie, lambda);
@@ -203,8 +200,7 @@ Real StellarCollapse::PressureFromDensityTemperature(const Real rho,
 }
 
 PORTABLE_FUNCTION
-Real StellarCollapse::PressureFromDensityInternalEnergy(const Real rho,
-                                                        const Real sie,
+Real StellarCollapse::PressureFromDensityInternalEnergy(const Real rho, const Real sie,
                                                         Real *lambda) const {
   Real lRho, lT, Ye;
   getLogsFromRhoSie_(rho, sie, lambda, lRho, lT, Ye);
@@ -223,8 +219,9 @@ Real StellarCollapse::SpecificHeatFromDensityTemperature(const Real rho,
 }
 
 PORTABLE_FUNCTION
-Real StellarCollapse::SpecificHeatFromDensityInternalEnergy(
-    const Real rho, const Real sie, Real *lambda) const {
+Real StellarCollapse::SpecificHeatFromDensityInternalEnergy(const Real rho,
+                                                            const Real sie,
+                                                            Real *lambda) const {
   Real lRho, lT, Ye;
   getLogsFromRhoSie_(rho, sie, lambda, lRho, lT, Ye);
   const Real Cv = K2MeV_ * dEdT_.interpToReal(Ye, lT, lRho);
@@ -254,8 +251,7 @@ Real StellarCollapse::GruneisenParamFromDensityTemperature(const Real rho,
 }
 
 PORTABLE_FUNCTION
-Real StellarCollapse::BulkModulusFromDensityInternalEnergy(const Real rho,
-                                                           const Real sie,
+Real StellarCollapse::BulkModulusFromDensityInternalEnergy(const Real rho, const Real sie,
                                                            Real *lambda) const {
   Real lRho, lT, Ye;
   getLogsFromRhoSie_(rho, sie, lambda, lRho, lT, Ye);
@@ -265,8 +261,9 @@ Real StellarCollapse::BulkModulusFromDensityInternalEnergy(const Real rho,
 }
 
 PORTABLE_FUNCTION
-Real StellarCollapse::GruneisenParamFromDensityInternalEnergy(
-    const Real rho, const Real sie, Real *lambda) const {
+Real StellarCollapse::GruneisenParamFromDensityInternalEnergy(const Real rho,
+                                                              const Real sie,
+                                                              Real *lambda) const {
   Real lRho, lT, Ye;
   getLogsFromRhoSie_(rho, sie, lambda, lRho, lT, Ye);
   const Real dpde = dPdE_.interpToReal(Ye, lT, lRho);
@@ -277,16 +274,14 @@ Real StellarCollapse::GruneisenParamFromDensityInternalEnergy(
 // TODO(JMM): Fill in this stub if we ever use this EOS in a PTE code.
 PORTABLE_FUNCTION
 void StellarCollapse::DensityEnergyFromPressureTemperature(const Real press,
-                                                           const Real temp,
-                                                           Real *lambda,
-                                                           Real &rho,
-                                                           Real &sie) const {
+                                                           const Real temp, Real *lambda,
+                                                           Real &rho, Real &sie) const {
   EOS_ERROR("StellarCollapse::DensityEnergyFromPRessureTemperature is a stub");
 }
 
 PORTABLE_FUNCTION
-void StellarCollapse::FillEos(Real &rho, Real &temp, Real &energy, Real &press,
-                              Real &cv, Real &bmod, const unsigned long output,
+void StellarCollapse::FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv,
+                              Real &bmod, const unsigned long output,
                               Real *lambda) const {
   Real lRho, lT, Ye;
   const unsigned long input = ~output;
@@ -324,8 +319,7 @@ void StellarCollapse::FillEos(Real &rho, Real &temp, Real &energy, Real &press,
 PORTABLE_FUNCTION
 void StellarCollapse::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie,
                                              Real &press, Real &cv, Real &bmod,
-                                             Real &dpde, Real &dvdt,
-                                             Real *lambda) const {
+                                             Real &dpde, Real &dvdt, Real *lambda) const {
   rho = rhoNormal_;
   temp = TNormal_;
   sie = sieNormal_;
@@ -346,8 +340,7 @@ void StellarCollapse::LoadFromSP5File_(const std::string &filename) {
 
   // Offsets
   hid_t metadata = H5Gopen(file, METADATA_NAME, H5P_DEFAULT);
-  status += H5LTget_attribute_double(file, METADATA_NAME, SP5::Offsets::sie,
-                                     &lEOffset_);
+  status += H5LTget_attribute_double(file, METADATA_NAME, SP5::Offsets::sie, &lEOffset_);
   status += H5Gclose(metadata);
 
   // Databoxes
@@ -388,8 +381,7 @@ void StellarCollapse::LoadFromSP5File_(const std::string &filename) {
 }
 
 // Read data directly from a stellar collapse eos file
-void StellarCollapse::LoadFromStellarCollapseFile_(
-    const std::string &filename) {
+void StellarCollapse::LoadFromStellarCollapseFile_(const std::string &filename) {
   // Open the file.
   hid_t file_id = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   herr_t status = H5_SUCCESS;
@@ -439,8 +431,7 @@ int StellarCollapse::readSCInt_(const hid_t &file_id, const std::string &name) {
   hsize_t file_start[] = {0};
   hsize_t file_count[] = {1};
   hid_t filespace = H5Screate_simple(1, file_grid_dims, NULL);
-  H5Sselect_hyperslab(filespace, H5S_SELECT_SET, file_start, NULL, file_count,
-                      NULL);
+  H5Sselect_hyperslab(filespace, H5S_SELECT_SET, file_start, NULL, file_count, NULL);
   hid_t memspace = H5Screate_simple(1, &one, NULL);
 
   hid_t dset_id = H5Dopen(file_id, name.c_str(), H5P_DEFAULT);
@@ -459,8 +450,8 @@ int StellarCollapse::readSCInt_(const hid_t &file_id, const std::string &name) {
 // Read (inclusive) bounds on the independent variables Assumes
 // uniform tables in log-space. The file requires we read in the
 // array, but we only need the bounds themselves.
-void StellarCollapse::readBounds_(const hid_t &file_id, const std::string &name,
-                                  int size, Real &lo, Real &hi) {
+void StellarCollapse::readBounds_(const hid_t &file_id, const std::string &name, int size,
+                                  Real &lo, Real &hi) {
   std::vector<Real> table(size);
   herr_t status = H5LTread_dataset_double(file_id, name.c_str(), table.data());
   if (status != H5_SUCCESS) {
@@ -479,15 +470,13 @@ void StellarCollapse::readSCDset_(const hid_t &file_id, const std::string &name,
                                   Spiner::DataBox &db) {
   herr_t exists = H5LTfind_dataset(file_id, name.c_str());
   if (!exists) {
-    std::string msg =
-        "Tried to read dataset " + name + " but it doesn't exist\n";
+    std::string msg = "Tried to read dataset " + name + " but it doesn't exist\n";
     EOS_ERROR(msg.c_str());
   }
   db.resize(numYe_, numT_, numRho_);
   herr_t status = H5LTread_dataset(file_id, name.c_str(), H5T_REAL, db.data());
   if (status != H5_SUCCESS) {
-    std::string msg =
-        "Tried to read dataset " + name + " but it failed exist\n";
+    std::string msg = "Tried to read dataset " + name + " but it failed exist\n";
     EOS_ERROR(msg.c_str());
   }
 
@@ -503,8 +492,7 @@ void StellarCollapse::medianFilter_(Spiner::DataBox &db) {
   medianFilter_(tmp, db);
 }
 
-void StellarCollapse::medianFilter_(const Spiner::DataBox &in,
-                                    Spiner::DataBox &out) {
+void StellarCollapse::medianFilter_(const Spiner::DataBox &in, Spiner::DataBox &out) {
   Real buffer[MF_S];
   // filter, overwriting as needed
   for (int iY = MF_W; iY < numYe_ - MF_W; ++iY) {
@@ -515,16 +503,14 @@ void StellarCollapse::medianFilter_(const Spiner::DataBox &in,
         Real point = in(iY, iT, irho);
         Real avg = findMedian_(buffer, MF_S);
         int bad = std::abs(avg - point) / std::abs(avg) > EPSSMOOTH;
-        if (bad)
-          out(iY, iT, irho) = avg;
+        if (bad) out(iY, iT, irho) = avg;
       }
     }
   }
 }
 
-void StellarCollapse::fillMedianBuffer_(Real buffer[], int width, int iY,
-                                        int iT, int irho,
-                                        const Spiner::DataBox &tab) const {
+void StellarCollapse::fillMedianBuffer_(Real buffer[], int width, int iY, int iT,
+                                        int irho, const Spiner::DataBox &tab) const {
   int i = 0;
   for (int iWy = -width; iWy <= width; iWy++) {
     for (int iWt = -width; iWt <= width; iWt++) {
@@ -563,8 +549,7 @@ void StellarCollapse::computeBulkModulus_() {
         Real PoR = fromLog_(lPoR, 0.0);
         // assume table is hardened
         Real bMod = rho * dPdRho_(iY, iT, irho) + PoR * dPdE_(iY, iT, irho);
-        if (bMod < EPS)
-          bMod = EPS;
+        if (bMod < EPS) bMod = EPS;
         lBMod_(iY, iT, irho) = B2lB_(bMod);
       }
     }
@@ -642,8 +627,8 @@ Real StellarCollapse::lTFromlRhoSie_(const Real lRho, const Real sie,
     // Get log(sie)
     Real lE = e2le_(sie);
     const callable_interp::LogT lEFunc(lE_, Ye, lRho);
-    status = findRoot(lEFunc, lE, lTGuess, lTMin_, lTMax_, ROOT_THRESH,
-                      ROOT_THRESH, lT, counts);
+    status = findRoot(lEFunc, lE, lTGuess, lTMin_, lTMax_, ROOT_THRESH, ROOT_THRESH, lT,
+                      counts);
     if (status != RootFinding1D::Status::SUCCESS) {
 #if STELLAR_COLLAPSE_EOS_VERBOSE
       std::stringstream errorMessage;

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -15,281 +15,243 @@
 #ifndef EOS_VARIANT_HPP
 #define EOS_VARIANT_HPP
 
-#include <variant/include/mpark/variant.hpp>
 #include <ports-of-call/portability.hpp>
+#include <variant/include/mpark/variant.hpp>
 
 using Real = double;
 
 namespace singularity {
 
-template<typename... Ts>
+template <typename... Ts>
 using eos_variant = mpark::variant<Ts...>;
 
-template<typename... EOSs>
+template <typename... EOSs>
 class Variant {
-private:
+ private:
   eos_variant<EOSs...> eos_;
 
-public:
-
-  template<typename EOSChoice,
-           typename
-           std::enable_if< !std::is_same<Variant,
-                                         typename std::decay<EOSChoice>::type
-                                        >::value,
-                           bool>::type = true
-          >
-  PORTABLE_FUNCTION
-  Variant(EOSChoice&& choice):
-    eos_( std::move(std::forward<EOSChoice>(choice)) )
-  {}
+ public:
+  template <typename EOSChoice,
+            typename std::enable_if<
+                !std::is_same<Variant, typename std::decay<EOSChoice>::type>::value,
+                bool>::type = true>
+  PORTABLE_FUNCTION Variant(EOSChoice &&choice)
+      : eos_(std::move(std::forward<EOSChoice>(choice))) {}
 
   Variant() noexcept = default;
-  
-  template<typename EOSChoice,
-           typename
-           std::enable_if< !std::is_same<Variant,
-                                         typename std::decay<EOSChoice>::type
-                                        >::value,
-                           bool>::type = true
-	   >
-  PORTABLE_FUNCTION
-  Variant & operator=(EOSChoice && eos)
-  {
+
+  template <typename EOSChoice,
+            typename std::enable_if<
+                !std::is_same<Variant, typename std::decay<EOSChoice>::type>::value,
+                bool>::type = true>
+  PORTABLE_FUNCTION Variant &operator=(EOSChoice &&eos) {
     eos_ = std::move(std::forward<EOSChoice>(eos));
     return *this;
   }
 
-  template<typename EOSChoice,
-           typename
-           std::enable_if< !std::is_same<Variant,
-                                         typename std::decay<EOSChoice>::type
-                                        >::value,
-                           bool>::type = true
-	   >
+  template <typename EOSChoice,
+            typename std::enable_if<
+                !std::is_same<Variant, typename std::decay<EOSChoice>::type>::value,
+                bool>::type = true>
   EOSChoice get() {
     return mpark::get<EOSChoice>(eos_);
   }
 
-  Variant GetOnDevice()
-  {
-    return mpark::visit( [](auto & eos)
-    {
-      return eos_variant<EOSs...>(eos.GetOnDevice());
-    }, eos_);
+  Variant GetOnDevice() {
+    return mpark::visit([](auto &eos) { return eos_variant<EOSs...>(eos.GetOnDevice()); },
+                        eos_);
   }
 
   // Place member functions here
   PORTABLE_INLINE_FUNCTION
   Real TemperatureFromDensityInternalEnergy(const Real rho, const Real sie,
-                                            Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &sie, &lambda] (const auto & eos) 
-    { 
-      return eos.TemperatureFromDensityInternalEnergy(rho, sie, lambda);
-    }, eos_);
+                                            Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &sie, &lambda](const auto &eos) {
+          return eos.TemperatureFromDensityInternalEnergy(rho, sie, lambda);
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real InternalEnergyFromDensityTemperature(const Real rho,
-                                            const Real temperature,
-                                            Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &temperature, &lambda] (const auto & eos) 
-    { 
-      return eos.InternalEnergyFromDensityTemperature(rho, temperature,
-                                                      lambda);
-    }, eos_);
+  Real InternalEnergyFromDensityTemperature(const Real rho, const Real temperature,
+                                            Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &temperature, &lambda](const auto &eos) {
+          return eos.InternalEnergyFromDensityTemperature(rho, temperature, lambda);
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
   Real PressureFromDensityTemperature(const Real rho, const Real temperature,
-                                      Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &temperature, &lambda] (const auto & eos) 
-    { 
-      return eos.PressureFromDensityTemperature(rho, temperature, lambda);
-    }, eos_);
+                                      Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &temperature, &lambda](const auto &eos) {
+          return eos.PressureFromDensityTemperature(rho, temperature, lambda);
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
   Real PressureFromDensityInternalEnergy(const Real rho, const Real sie,
-                                         Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &sie, &lambda] (const auto & eos) 
-    { 
-      return eos.PressureFromDensityInternalEnergy(rho, sie, lambda);
-    }, eos_);
+                                         Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &sie, &lambda](const auto &eos) {
+          return eos.PressureFromDensityInternalEnergy(rho, sie, lambda);
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real SpecificHeatFromDensityTemperature(const Real rho,
-                                          const Real temperature,
-                                          Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &temperature, &lambda] (const auto & eos) 
-    { 
-      return eos.SpecificHeatFromDensityTemperature(rho, temperature, lambda);
-    }, eos_);
+  Real SpecificHeatFromDensityTemperature(const Real rho, const Real temperature,
+                                          Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &temperature, &lambda](const auto &eos) {
+          return eos.SpecificHeatFromDensityTemperature(rho, temperature, lambda);
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
   Real SpecificHeatFromDensityInternalEnergy(const Real rho, const Real sie,
-                                             Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &sie, &lambda] (const auto & eos) 
-    { 
-      return eos.SpecificHeatFromDensityInternalEnergy(rho, sie, lambda);
-    }, eos_);
+                                             Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &sie, &lambda](const auto &eos) {
+          return eos.SpecificHeatFromDensityInternalEnergy(rho, sie, lambda);
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real BulkModulusFromDensityTemperature(const Real rho,
-                                         const Real temperature,
-                                         Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &temperature, &lambda] (const auto & eos) 
-    { 
-      return eos.BulkModulusFromDensityTemperature(rho, temperature, lambda);
-    }, eos_);
+  Real BulkModulusFromDensityTemperature(const Real rho, const Real temperature,
+                                         Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &temperature, &lambda](const auto &eos) {
+          return eos.BulkModulusFromDensityTemperature(rho, temperature, lambda);
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
   Real BulkModulusFromDensityInternalEnergy(const Real rho, const Real sie,
-                                            Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &sie, &lambda] (const auto & eos) 
-    { 
-      return eos.BulkModulusFromDensityInternalEnergy(rho, sie, lambda);
-    }, eos_);
+                                            Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &sie, &lambda](const auto &eos) {
+          return eos.BulkModulusFromDensityInternalEnergy(rho, sie, lambda);
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real GruneisenParamFromDensityTemperature(const Real rho,
-                                            const Real temperature,
-                                            Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &temperature, &lambda] (const auto & eos) 
-    { 
-      return eos.GruneisenParamFromDensityTemperature(rho, temperature, lambda);
-    }, eos_);
+  Real GruneisenParamFromDensityTemperature(const Real rho, const Real temperature,
+                                            Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &temperature, &lambda](const auto &eos) {
+          return eos.GruneisenParamFromDensityTemperature(rho, temperature, lambda);
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
   Real GruneisenParamFromDensityInternalEnergy(const Real rho, const Real sie,
-                                               Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &sie, &lambda] (const auto & eos) 
-    { 
-      return eos.GruneisenParamFromDensityInternalEnergy(rho, sie, lambda);
-    }, eos_);
-  }
-
-  PORTABLE_INLINE_FUNCTION
-  void FillEos(Real& rho, Real& temp, Real& energy, Real& press, Real& cv,
-               Real& bmod, const unsigned long output,
-               Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &temp, &energy, &press, &cv, &bmod, &output,
-                          &lambda] (const auto & eos) 
-    { 
-      return eos.FillEos(rho, temp, energy, press, cv, bmod, output, lambda);
-    }, eos_);
-  }
-
-  PORTABLE_INLINE_FUNCTION
-  void ReferenceDensityTemperature(Real& rho, Real& T,
-                                   Real *lambda=nullptr) const
-  {
-    return mpark::visit( [&rho, &T, &lambda] (const auto & eos)
-    {
-      return eos.ReferenceDensityTemperature(rho, T, lambda);
-    }, eos_);
-  }
-
-  PORTABLE_INLINE_FUNCTION
-  void ValuesAtReferenceState(Real& rho, Real& temp, Real& sie, Real& press,
-                              Real& cv, Real& bmod, Real& dpde, Real& dvdt,
-                              Real *lambda=nullptr) const
-  {
+                                               Real *lambda = nullptr) const {
     return mpark::visit(
-      [&rho, &temp, &sie, &press, &cv, &bmod, &dpde, &dvdt, &lambda]
-      (const auto & eos)
-    {
-      return eos.ValuesAtReferenceState(rho, temp, sie, press, cv, bmod, dpde,
-                                        dvdt, lambda);
-    }, eos_);
+        [&rho, &sie, &lambda](const auto &eos) {
+          return eos.GruneisenParamFromDensityInternalEnergy(rho, sie, lambda);
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
-  void PTofRE(Real& rho, Real& sie, Real* lambda, Real& press, Real& temp,
-              Real& dpdr, Real& dpde, Real& dtdr, Real& dtde) const
-  {
-    return mpark::visit( [&rho, &sie, &lambda, &press, &temp, &dpdr, &dpde,
-                          &dtdr, &dtde] (const auto & eos) 
-    {
-      press = eos.PressureFromDensityInternalEnergy(rho,sie,lambda);
-      temp = eos.TemperatureFromDensityInternalEnergy(rho,sie,lambda);
-      const Real drho = rho*1.0e-6;
-      const Real de = sie*1.0e-6;
-      const Real Pr = eos.PressureFromDensityInternalEnergy(rho+drho,sie,lambda);
-      const Real Pe = eos.PressureFromDensityInternalEnergy(rho,sie+de,lambda);
-      const Real Tr = eos.TemperatureFromDensityInternalEnergy(rho+drho,sie,lambda);
-      const Real Te = eos.TemperatureFromDensityInternalEnergy(rho,sie+de,lambda);
-      dpdr = (Pr-press)/drho;
-      dpde = (Pe-press)/de;
-      dtdr = (Tr-temp)/drho;
-      dtde = (Te-temp)/de; // Would it be better to skip the calculation of Te and return 1/cv?
-      return;
-    }, eos_);
+  void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, Real &bmod,
+               const unsigned long output, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &temp, &energy, &press, &cv, &bmod, &output, &lambda](const auto &eos) {
+          return eos.FillEos(rho, temp, energy, press, cv, bmod, output, lambda);
+        },
+        eos_);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  void ReferenceDensityTemperature(Real &rho, Real &T, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &T, &lambda](const auto &eos) {
+          return eos.ReferenceDensityTemperature(rho, T, lambda);
+        },
+        eos_);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
+                              Real &bmod, Real &dpde, Real &dvdt,
+                              Real *lambda = nullptr) const {
+    return mpark::visit(
+        [&rho, &temp, &sie, &press, &cv, &bmod, &dpde, &dvdt, &lambda](const auto &eos) {
+          return eos.ValuesAtReferenceState(rho, temp, sie, press, cv, bmod, dpde, dvdt,
+                                            lambda);
+        },
+        eos_);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  void PTofRE(Real &rho, Real &sie, Real *lambda, Real &press, Real &temp, Real &dpdr,
+              Real &dpde, Real &dtdr, Real &dtde) const {
+    return mpark::visit(
+        [&rho, &sie, &lambda, &press, &temp, &dpdr, &dpde, &dtdr,
+         &dtde](const auto &eos) {
+          press = eos.PressureFromDensityInternalEnergy(rho, sie, lambda);
+          temp = eos.TemperatureFromDensityInternalEnergy(rho, sie, lambda);
+          const Real drho = rho * 1.0e-6;
+          const Real de = sie * 1.0e-6;
+          const Real Pr = eos.PressureFromDensityInternalEnergy(rho + drho, sie, lambda);
+          const Real Pe = eos.PressureFromDensityInternalEnergy(rho, sie + de, lambda);
+          const Real Tr =
+              eos.TemperatureFromDensityInternalEnergy(rho + drho, sie, lambda);
+          const Real Te = eos.TemperatureFromDensityInternalEnergy(rho, sie + de, lambda);
+          dpdr = (Pr - press) / drho;
+          dpde = (Pe - press) / de;
+          dtdr = (Tr - temp) / drho;
+          dtde = (Te - temp) /
+                 de; // Would it be better to skip the calculation of Te and return 1/cv?
+          return;
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
   void DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                            Real *lambda, Real& rho,
-                                            Real& sie) const
-  {
-    return mpark::visit( [&press, &temp, &lambda, &rho, &sie]
-                         (const auto & eos) 
-    {
-      return eos.DensityEnergyFromPressureTemperature(press, temp, lambda,
-                                                      rho, sie);
-    }, eos_);
+                                            Real *lambda, Real &rho, Real &sie) const {
+    return mpark::visit(
+        [&press, &temp, &lambda, &rho, &sie](const auto &eos) {
+          return eos.DensityEnergyFromPressureTemperature(press, temp, lambda, rho, sie);
+        },
+        eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
-  unsigned long PreferredInput() const noexcept
-  {
-    return mpark::visit([](const auto & eos) { return eos.PreferredInput(); },
-                        eos_);
+  unsigned long PreferredInput() const noexcept {
+    return mpark::visit([](const auto &eos) { return eos.PreferredInput(); }, eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
-  int nlambda() const noexcept
-  {
-    return mpark::visit([](const auto & eos) { return eos.nlambda(); },
-                        eos_);
+  int nlambda() const noexcept {
+    return mpark::visit([](const auto &eos) { return eos.nlambda(); }, eos_);
   }
 
   template <typename T>
-  PORTABLE_INLINE_FUNCTION
-  bool IsType() const noexcept {
+  PORTABLE_INLINE_FUNCTION bool IsType() const noexcept {
     return mpark::holds_alternative<T>(eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
-  void PrintParams() const noexcept
-  {
-    return mpark::visit([](const auto & eos) { return eos.PrintParams(); },
-                        eos_);
+  void PrintParams() const noexcept {
+    return mpark::visit([](const auto &eos) { return eos.PrintParams(); }, eos_);
   }
 
-  inline void Finalize() noexcept
-  {
-    return mpark::visit([](auto & eos) { return eos.Finalize(); },
-                        eos_);
+  inline void Finalize() noexcept {
+    return mpark::visit([](auto &eos) { return eos.Finalize(); }, eos_);
   }
-
 };
 } // namespace singularity
 

--- a/singularity-eos/eos/singularity_eos.cpp
+++ b/singularity-eos/eos/singularity_eos.cpp
@@ -12,172 +12,157 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
-#include <singularity-eos/eos/singularity_eos.hpp>
-#include <singularity-eos/eos/eos_builder.hpp>
-#include <map>
 #include <algorithm>
 #include <cassert>
+#include <map>
+#include <singularity-eos/eos/eos_builder.hpp>
+#include <singularity-eos/eos/singularity_eos.hpp>
 
 using namespace singularity;
 
-template<typename T,
-         typename = typename std::enable_if<std::is_floating_point<T>::value>::type>
-constexpr bool isfinite(const T& a)
-{ return (a == a) && ((a == 0) || (a != 2*a)); }
+template <typename T,
+          typename = typename std::enable_if<std::is_floating_point<T>::value>::type>
+constexpr bool isfinite(const T &a) {
+  return (a == a) && ((a == 0) || (a != 2 * a));
+}
 
-int init_sg_eos(const int nmat, EOS* &eos) {
+int init_sg_eos(const int nmat, EOS *&eos) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  if (!Kokkos::is_initialized())
-    Kokkos::initialize();
+  if (!Kokkos::is_initialized()) Kokkos::initialize();
 #endif // PORTABILITY_STRATEGY_KOKKOS
-  EOS* eos_p = new EOS[nmat];
+  EOS *eos_p = new EOS[nmat];
   eos = eos_p;
   return 0;
 }
 
-#define SGAPPLYMOD(A) \
-  EOSBuilder::applyShiftAndScale(A, enabled[0] == 1, enabled[1] == 1,\
-                                 vals[0], vals[1])
+#define SGAPPLYMOD(A)                                                                    \
+  EOSBuilder::applyShiftAndScale(A, enabled[0] == 1, enabled[1] == 1, vals[0], vals[1])
 
 constexpr const int def_en[2] = {0, 0};
 constexpr const double def_v[2] = {0.0, 0.0};
 
-int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
-                     const double Cv,
-                     int const * const enabled, double const * const vals) {
+int init_sg_IdealGas(const int matindex, EOS *eos, const double gm1, const double Cv,
+                     int const *const enabled, double const *const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(IdealGas(gm1, Cv));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 
-int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
-                     const double Cv) {
+int init_sg_IdealGas(const int matindex, EOS *eos, const double gm1, const double Cv) {
   return init_sg_IdealGas(matindex, eos, gm1, Cv, def_en, def_v);
 }
 
-int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
-                      const double s1, const double s2, const double s3,
-                      const double G0, const double b, const double rho0,
-                      const double T0, const double P0, const double Cv,
-                      int const * const enabled, double const * const vals) {
+int init_sg_Gruneisen(const int matindex, EOS *eos, const double C0, const double s1,
+                      const double s2, const double s3, const double G0, const double b,
+                      const double rho0, const double T0, const double P0,
+                      const double Cv, int const *const enabled,
+                      double const *const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(Gruneisen(C0, s1, s2, s3, G0, b, rho0, T0, P0, Cv));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 
-int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
-                      const double s1, const double s2, const double s3,
-                      const double G0, const double b, const double rho0,
-                      const double T0, const double P0, const double Cv) {
-  return init_sg_Gruneisen(matindex, eos, C0, s1, s2, s3, G0, b, rho0, T0, P0,
-                           Cv, def_en, def_v);
+int init_sg_Gruneisen(const int matindex, EOS *eos, const double C0, const double s1,
+                      const double s2, const double s3, const double G0, const double b,
+                      const double rho0, const double T0, const double P0,
+                      const double Cv) {
+  return init_sg_Gruneisen(matindex, eos, C0, s1, s2, s3, G0, b, rho0, T0, P0, Cv, def_en,
+                           def_v);
 }
 
-int init_sg_JWL(const int matindex, EOS* eos, const double A,
-                const double B, const double R1, const double R2,
-                const double w, const double rho0, const double Cv,
-                int const * const enabled, double const * const vals) {
+int init_sg_JWL(const int matindex, EOS *eos, const double A, const double B,
+                const double R1, const double R2, const double w, const double rho0,
+                const double Cv, int const *const enabled, double const *const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(JWL(A, B, R1, R2, w, rho0, Cv));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 
-int init_sg_JWL(const int matindex, EOS* eos, const double A,
-                const double B, const double R1, const double R2,
-                const double w, const double rho0, const double Cv) {
-  return init_sg_JWL(matindex, eos, A, B, R1, R2, w, rho0, Cv, def_en,
-                     def_v);
+int init_sg_JWL(const int matindex, EOS *eos, const double A, const double B,
+                const double R1, const double R2, const double w, const double rho0,
+                const double Cv) {
+  return init_sg_JWL(matindex, eos, A, B, R1, R2, w, rho0, Cv, def_en, def_v);
 }
 
-int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
-                          const double b, const double k, const double n,
-                          const double vc, const double pc, const double Cv,
-                          const double E0,
-                          int const * const enabled,
-                          double const * const vals) {
+int init_sg_DavisProducts(const int matindex, EOS *eos, const double a, const double b,
+                          const double k, const double n, const double vc,
+                          const double pc, const double Cv, const double E0,
+                          int const *const enabled, double const *const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(DavisProducts(a, b, k, n, vc, pc, Cv, E0));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 
-int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
-                          const double b, const double k, const double n,
-                          const double vc, const double pc, const double Cv,
-                          const double E0) {
-  return init_sg_DavisProducts(matindex, eos, a, b, k, n, vc, pc, Cv, E0,
-                               def_en, def_v);
+int init_sg_DavisProducts(const int matindex, EOS *eos, const double a, const double b,
+                          const double k, const double n, const double vc,
+                          const double pc, const double Cv, const double E0) {
+  return init_sg_DavisProducts(matindex, eos, a, b, k, n, vc, pc, Cv, E0, def_en, def_v);
 }
 
-int init_sg_DavisReactants(const int matindex, EOS* eos,
-                           const double rho0, const double e0, const double P0,
-                           const double T0, const double A, const double B,
-                           const double C, const double G0, const double Z,
-                           const double alpha, const double Cv0,
-                           int const * const enabled,
-                           double const * const vals) {
+int init_sg_DavisReactants(const int matindex, EOS *eos, const double rho0,
+                           const double e0, const double P0, const double T0,
+                           const double A, const double B, const double C,
+                           const double G0, const double Z, const double alpha,
+                           const double Cv0, int const *const enabled,
+                           double const *const vals) {
   assert(matindex >= 0);
-  EOS eos_ =
-  SGAPPLYMOD(DavisReactants(rho0, e0, P0, T0, A, B, C, G0, Z, alpha, Cv0));
+  EOS eos_ = SGAPPLYMOD(DavisReactants(rho0, e0, P0, T0, A, B, C, G0, Z, alpha, Cv0));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 
-int init_sg_DavisReactants(const int matindex, EOS* eos,
-                           const double rho0, const double e0, const double P0,
-                           const double T0, const double A, const double B,
-                           const double C, const double G0, const double Z,
-                           const double alpha, const double Cv0) {
-  return init_sg_DavisReactants(matindex, eos, rho0, e0, P0, T0, A, B, C, G0, Z,
-                                alpha, Cv0, def_en, def_v);
+int init_sg_DavisReactants(const int matindex, EOS *eos, const double rho0,
+                           const double e0, const double P0, const double T0,
+                           const double A, const double B, const double C,
+                           const double G0, const double Z, const double alpha,
+                           const double Cv0) {
+  return init_sg_DavisReactants(matindex, eos, rho0, e0, P0, T0, A, B, C, G0, Z, alpha,
+                                Cv0, def_en, def_v);
 }
 
 #ifdef SPINER_USE_HDF
-int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
-                              const char* filename, const int matid,
-                              int const * const enabled,
-                              double const * const vals) {
+int init_sg_SpinerDependsRhoT(const int matindex, EOS *eos, const char *filename,
+                              const int matid, int const *const enabled,
+                              double const *const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(SpinerEOSDependsRhoT(std::string(filename), matid));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 
-int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
-                              const char* filename, const int matid) {
-  return init_sg_SpinerDependsRhoT(matindex, eos, filename, matid, def_en,
-                                   def_v);
+int init_sg_SpinerDependsRhoT(const int matindex, EOS *eos, const char *filename,
+                              const int matid) {
+  return init_sg_SpinerDependsRhoT(matindex, eos, filename, matid, def_en, def_v);
 }
 
-int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
-                                const char* filename, const int matid,
-                                int const * const enabled,
-                                double const * const vals) {
+int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filename,
+                                const int matid, int const *const enabled,
+                                double const *const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(SpinerEOSDependsRhoSie(std::string(filename), matid));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
-int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
-                                const char* filename, const int matid) {
-  return init_sg_SpinerDependsRhoSie(matindex, eos, filename, matid, def_en,
-                                     def_v);
+int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filename,
+                                const int matid) {
+  return init_sg_SpinerDependsRhoSie(matindex, eos, filename, matid, def_en, def_v);
 }
 #endif
 
 #ifdef SINGULARITY_USE_EOSPAC
-int init_sg_eospac(const int matindex, EOS* eos, const int id,
-                   int const * const enabled, double const * const vals) {
+int init_sg_eospac(const int matindex, EOS *eos, const int id, int const *const enabled,
+                   double const *const vals) {
   assert(matindex >= 0);
   EOS eos_ = SGAPPLYMOD(EOSPAC(id));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
-int init_sg_eospac(const int matindex, EOS* eos, const int id) {
-  return init_sg_eospac(matindex, eos, id, def_en, def_v); 
+int init_sg_eospac(const int matindex, EOS *eos, const int id) {
+  return init_sg_eospac(matindex, eos, id, def_en, def_v);
 }
 #endif // SINGULARITY_USE_EOSPAC
 
@@ -185,80 +170,75 @@ int init_sg_eospac(const int matindex, EOS* eos, const int id) {
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
 using Lrgt = Kokkos::LayoutRight;
-template< typename T>
-using ScratchV = Kokkos::View<T**, Lrgt>;
+template <typename T>
+using ScratchV = Kokkos::View<T **, Lrgt>;
 #endif // PORTABILITY_STRATEGY_KOKKOS
 
-// mapping from EAP integer to 
-static const std::map<const int, const unsigned long>
-  EAPInputToBD = {
-                   {-3, thermalqs::temperature | thermalqs::density},
-                   {-2, thermalqs::density | thermalqs::pressure},
-                   {-1, thermalqs::pressure | thermalqs::temperature},
-                   { 0, thermalqs::specific_internal_energy | thermalqs::density},
-                   { 1, thermalqs::specific_internal_energy | thermalqs::density},
-                 };
+// mapping from EAP integer to
+static const std::map<const int, const unsigned long> EAPInputToBD = {
+    {-3, thermalqs::temperature | thermalqs::density},
+    {-2, thermalqs::density | thermalqs::pressure},
+    {-1, thermalqs::pressure | thermalqs::temperature},
+    {0, thermalqs::specific_internal_energy | thermalqs::density},
+    {1, thermalqs::specific_internal_energy | thermalqs::density},
+};
 
 // EAP centric arguments and function signature
-int get_sg_eos(// sizing information
-               int nmat, int ncell, int cell_dim,
-               // Input parameters
-               int input_int,
-               // eos index offsets
-               int* eos_offsets,
-               // equation of state array
-               EOS* eos,
-               // index offsets
-               int* offsets,
-               // per cell quantities
-               double* press, double* pmax, double* vol, double* spvol,
-               double* sie, double* temp, double* bmod, double* dpde,
-               double* cv,
-               // per material quantities
-               double* frac_mass, double* frac_vol, double* frac_sie,
-               // optional per material quantities
-               double* frac_bmod, double* frac_dpde, double* frac_cv) {
+int get_sg_eos( // sizing information
+    int nmat, int ncell, int cell_dim,
+    // Input parameters
+    int input_int,
+    // eos index offsets
+    int *eos_offsets,
+    // equation of state array
+    EOS *eos,
+    // index offsets
+    int *offsets,
+    // per cell quantities
+    double *press, double *pmax, double *vol, double *spvol, double *sie, double *temp,
+    double *bmod, double *dpde, double *cv,
+    // per material quantities
+    double *frac_mass, double *frac_vol, double *frac_sie,
+    // optional per material quantities
+    double *frac_bmod, double *frac_dpde, double *frac_cv) {
   // kernel return value will be the number of failures
-  int ret {0};
+  int ret{0};
   // handle optionals
-  bool do_frac_bmod {true};
-  if (frac_bmod == NULL || frac_bmod == nullptr)
-    do_frac_bmod = false;
-  bool do_frac_dpde {true};
-  if (frac_dpde == NULL || frac_dpde == nullptr)
-    do_frac_dpde = false;
-  bool do_frac_cv {true};
-  if (frac_dpde == NULL || frac_dpde == nullptr)
-    do_frac_cv = false;
+  bool do_frac_bmod{true};
+  if (frac_bmod == NULL || frac_bmod == nullptr) do_frac_bmod = false;
+  bool do_frac_dpde{true};
+  if (frac_dpde == NULL || frac_dpde == nullptr) do_frac_dpde = false;
+  bool do_frac_cv{true};
+  if (frac_dpde == NULL || frac_dpde == nullptr) do_frac_cv = false;
   // get inputs
-  const auto input {EAPInputToBD.at(input_int)};
+  const auto input{EAPInputToBD.at(input_int)};
   const auto output = thermalqs::all_values - input;
-  const bool p_is_inp {static_cast<bool>(input & thermalqs::pressure)};
-  const bool r_is_inp {static_cast<bool>(input & thermalqs::density)};
-  const bool t_is_inp {static_cast<bool>(input & thermalqs::temperature)};
-  const bool s_is_inp {static_cast<bool>(input & thermalqs::specific_internal_energy)};
-  constexpr const Real min_guess_density {1.e-20};
+  const bool p_is_inp{static_cast<bool>(input & thermalqs::pressure)};
+  const bool r_is_inp{static_cast<bool>(input & thermalqs::density)};
+  const bool t_is_inp{static_cast<bool>(input & thermalqs::temperature)};
+  const bool s_is_inp{static_cast<bool>(input & thermalqs::specific_internal_energy)};
+  constexpr const Real min_guess_density{1.e-20};
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   // convenience aliases
   using Llft = Kokkos::LayoutLeft;
   using Unmgd = Kokkos::MemoryUnmanaged;
   using HS = Kokkos::HostSpace;
   using Kokkos::create_mirror_view_and_copy;
-  using host_v = Kokkos::View<double*, Llft, HS, Unmgd>;
-  using dev_v = Kokkos::View<double*, Llft>;
-  using host_frac_v = Kokkos::View<double**, Llft, HS, Unmgd>;
-  using dev_frac_v = Kokkos::View<double**, Llft>;
+  using host_v = Kokkos::View<double *, Llft, HS, Unmgd>;
+  using dev_v = Kokkos::View<double *, Llft>;
+  using host_frac_v = Kokkos::View<double **, Llft, HS, Unmgd>;
+  using dev_frac_v = Kokkos::View<double **, Llft>;
   using DES = Kokkos::DefaultExecutionSpace;
   using DMS = DES::memory_space;
   using Kokkos::MemoryTraits;
-  constexpr const unsigned int ra {0 | Kokkos::RandomAccess};
-  constexpr const unsigned int ra_u {Kokkos::Unmanaged | Kokkos::RandomAccess};
+  constexpr const unsigned int ra{0 | Kokkos::RandomAccess};
+  constexpr const unsigned int ra_u{Kokkos::Unmanaged | Kokkos::RandomAccess};
   using VAWI = Kokkos::ViewAllocateWithoutInitializing;
   using Kokkos::deep_copy;
   static constexpr const double ev2k = 1.160451930280894026e4;
   // convert pointers to host side views
-  Kokkos::View<int*, Llft, HS, Unmgd> eos_offsets_hv(eos_offsets, nmat);
-  Kokkos::View<int*, Llft, HS, Unmgd> offsets_hv(offsets, ncell);
+  Kokkos::View<int *, Llft, HS, Unmgd> eos_offsets_hv(eos_offsets, nmat);
+  Kokkos::View<int *, Llft, HS, Unmgd> offsets_hv(offsets, ncell);
   host_v press_hv(press, cell_dim);
   host_v pmax_hv(pmax, cell_dim);
   host_v vol_hv(vol, cell_dim);
@@ -275,80 +255,73 @@ int get_sg_eos(// sizing information
   if (do_frac_bmod) frac_bmod_hv = host_frac_v(frac_bmod, cell_dim, nmat);
   if (do_frac_dpde) frac_dpde_hv = host_frac_v(frac_dpde, cell_dim, nmat);
   if (do_frac_cv) frac_cv_hv = host_frac_v(frac_cv, cell_dim, nmat);
-  
+
   // get device views if necessary
-  Kokkos::View<const int*, Llft, MemoryTraits<ra> >
-    offsets_v {create_mirror_view_and_copy(DMS(), offsets_hv)};
-  Kokkos::View<const int*, Llft, MemoryTraits<ra> >
-    eos_offsets_v {create_mirror_view_and_copy(DMS(), eos_offsets_hv)};
-  dev_v press_v {create_mirror_view_and_copy(DMS(), press_hv)};
-  dev_v pmax_v {create_mirror_view_and_copy(DMS(), pmax_hv)};
-  dev_v spvol_v {create_mirror_view_and_copy(DMS(), spvol_hv)};
-  dev_v vol_v {create_mirror_view_and_copy(DMS(), vol_hv)};
-  dev_v sie_v {create_mirror_view_and_copy(DMS(), sie_hv)};
-  dev_v temp_v {create_mirror_view_and_copy(DMS(), temp_hv)};
-  dev_v bmod_v {create_mirror_view_and_copy(DMS(), bmod_hv)};
-  dev_v dpde_v {create_mirror_view_and_copy(DMS(), dpde_hv)};
-  dev_v cv_v {create_mirror_view_and_copy(DMS(), cv_hv)};
-  dev_frac_v frac_mass_v {create_mirror_view_and_copy(DMS(), frac_mass_hv)};
-  dev_frac_v frac_vol_v {create_mirror_view_and_copy(DMS(), frac_vol_hv)};
-  dev_frac_v frac_sie_v {create_mirror_view_and_copy(DMS(), frac_sie_hv)};
+  Kokkos::View<const int *, Llft, MemoryTraits<ra>> offsets_v{
+      create_mirror_view_and_copy(DMS(), offsets_hv)};
+  Kokkos::View<const int *, Llft, MemoryTraits<ra>> eos_offsets_v{
+      create_mirror_view_and_copy(DMS(), eos_offsets_hv)};
+  dev_v press_v{create_mirror_view_and_copy(DMS(), press_hv)};
+  dev_v pmax_v{create_mirror_view_and_copy(DMS(), pmax_hv)};
+  dev_v spvol_v{create_mirror_view_and_copy(DMS(), spvol_hv)};
+  dev_v vol_v{create_mirror_view_and_copy(DMS(), vol_hv)};
+  dev_v sie_v{create_mirror_view_and_copy(DMS(), sie_hv)};
+  dev_v temp_v{create_mirror_view_and_copy(DMS(), temp_hv)};
+  dev_v bmod_v{create_mirror_view_and_copy(DMS(), bmod_hv)};
+  dev_v dpde_v{create_mirror_view_and_copy(DMS(), dpde_hv)};
+  dev_v cv_v{create_mirror_view_and_copy(DMS(), cv_hv)};
+  dev_frac_v frac_mass_v{create_mirror_view_and_copy(DMS(), frac_mass_hv)};
+  dev_frac_v frac_vol_v{create_mirror_view_and_copy(DMS(), frac_vol_hv)};
+  dev_frac_v frac_sie_v{create_mirror_view_and_copy(DMS(), frac_sie_hv)};
   dev_frac_v frac_bmod_v, frac_dpde_v, frac_cv_v;
-  if (do_frac_bmod)
-    frac_bmod_v = create_mirror_view_and_copy(DMS(), frac_bmod_hv);
-  if (do_frac_dpde)
-    frac_dpde_v = create_mirror_view_and_copy(DMS(), frac_dpde_hv);
-  if (do_frac_cv)
-    frac_cv_v = create_mirror_view_and_copy(DMS(), frac_cv_hv);
+  if (do_frac_bmod) frac_bmod_v = create_mirror_view_and_copy(DMS(), frac_bmod_hv);
+  if (do_frac_dpde) frac_dpde_v = create_mirror_view_and_copy(DMS(), frac_dpde_hv);
+  if (do_frac_cv) frac_cv_v = create_mirror_view_and_copy(DMS(), frac_cv_hv);
   // array of eos's
-  const auto eos_nmat {*std::max_element(eos_offsets, eos_offsets+nmat)};
-  Kokkos::View<EOS*, Llft, HS, Unmgd> eos_hv(eos, eos_nmat);
-  Kokkos::View<EOS*, Llft> eos_v {create_mirror_view_and_copy(DMS(),
-                                                                    eos_hv)};
-  double** lambda_map = (double**)PORTABLE_MALLOC(sizeof(double*)*nmat);
-  portableFor("filling lambda ptrs", 0, nmat, PORTABLE_LAMBDA (const int& i)
-  {
-    //const int lambda_size = eos_v(i).nlambda();
-    lambda_map[i] = nullptr;//(double*)malloc(sizeof(double)*lambda_size);
-  });
+  const auto eos_nmat{*std::max_element(eos_offsets, eos_offsets + nmat)};
+  Kokkos::View<EOS *, Llft, HS, Unmgd> eos_hv(eos, eos_nmat);
+  Kokkos::View<EOS *, Llft> eos_v{create_mirror_view_and_copy(DMS(), eos_hv)};
+  double **lambda_map = (double **)PORTABLE_MALLOC(sizeof(double *) * nmat);
+  portableFor(
+      "filling lambda ptrs", 0, nmat, PORTABLE_LAMBDA(const int &i) {
+        // const int lambda_size = eos_v(i).nlambda();
+        lambda_map[i] = nullptr; //(double*)malloc(sizeof(double)*lambda_size);
+      });
   // TODO: make this a scatter view
-  constexpr auto at_int_full {0 | Kokkos::Atomic};
+  constexpr auto at_int_full{0 | Kokkos::Atomic};
 #ifdef KOKKOS_ENABLE_SERIAL
-  constexpr auto at_int {std::is_same<DES,
-                                      Kokkos::Serial>::value
-                         ? 0 : at_int_full};
-#else // KOKKOS_ENABLE_SERIAL
+  constexpr auto at_int{std::is_same<DES, Kokkos::Serial>::value ? 0 : at_int_full};
+#else  // KOKKOS_ENABLE_SERIAL
   // assume atomics are required for correctness if serial not even enabled
-  constexpr auto at_int {at_int_full};
+  constexpr auto at_int{at_int_full};
 #endif // KOKKOS_ENABLE_SERIAL
-  Kokkos::View<int*> nmat_cell_init(VAWI("nmat_cell"), ncell);
+  Kokkos::View<int *> nmat_cell_init(VAWI("nmat_cell"), ncell);
   // minimum mass fraction necessary to participate
-  constexpr const Real min_frac {1.e-4};
+  constexpr const Real min_frac{1.e-4};
   int nmat_local;
-  Kokkos::parallel_reduce("prePTE", ncell,
-    PORTABLE_LAMBDA (const int& iloop, int& maxmat)
-  {
-    const int i {offsets_v(iloop) - 1};
-    nmat_cell_init(iloop) = 0;
-    Real mass_sum = 0.0;
-    for (int m = 0; m < nmat; ++m) {
-      mass_sum += frac_mass_v(i,m);
-    }
-    for (int m = 0; m < nmat; ++m) {
-      if(frac_mass_v(i,m)/mass_sum > min_frac)
-        nmat_cell_init(iloop) += 1;
-    }
-    const int nmat_cell_loc = nmat_cell_init(iloop);
-    maxmat = nmat_cell_loc > maxmat ? nmat_cell_loc : maxmat;
-  }, Kokkos::Max<int>(nmat_local));
-  Kokkos::View<const int*, MemoryTraits<ra> > nmat_cell(nmat_cell_init);
+  Kokkos::parallel_reduce(
+      "prePTE", ncell,
+      PORTABLE_LAMBDA(const int &iloop, int &maxmat) {
+        const int i{offsets_v(iloop) - 1};
+        nmat_cell_init(iloop) = 0;
+        Real mass_sum = 0.0;
+        for (int m = 0; m < nmat; ++m) {
+          mass_sum += frac_mass_v(i, m);
+        }
+        for (int m = 0; m < nmat; ++m) {
+          if (frac_mass_v(i, m) / mass_sum > min_frac) nmat_cell_init(iloop) += 1;
+        }
+        const int nmat_cell_loc = nmat_cell_init(iloop);
+        maxmat = nmat_cell_loc > maxmat ? nmat_cell_loc : maxmat;
+      },
+      Kokkos::Max<int>(nmat_local));
+  Kokkos::View<const int *, MemoryTraits<ra>> nmat_cell(nmat_cell_init);
   // set up scratch arrays
   constexpr auto KGlobal = Kokkos::Experimental::UniqueTokenScope::Global;
   Kokkos::Experimental::UniqueToken<DES, KGlobal> tokens{};
 
-  const bool small_loop {tokens.size() > ncell};
-  const decltype(tokens)::size_type scratch_size {std::min(tokens.size(),
-                                                           ncell)};
+  const bool small_loop{tokens.size() > ncell};
+  const decltype(tokens)::size_type scratch_size{std::min(tokens.size(), ncell)};
   ScratchV<int> pte_mats("PTE::scratch mats", scratch_size, nmat_local);
   ScratchV<int> pte_idxs("PTE::scratch idxs", scratch_size, nmat_local);
   ScratchV<double> mass_pte("PTE::scratch mass", scratch_size, nmat_local);
@@ -357,262 +330,258 @@ int get_sg_eos(// sizing information
   ScratchV<double> temp_pte("PTE::scratch temp", scratch_size, nmat_local);
   ScratchV<double> press_pte("PTE::scratch press", scratch_size, nmat_local);
   ScratchV<double> rho_pte("PTE::scratch rho", scratch_size, nmat_local);
-  //ScratchV<EOS> eos_pte("PTE::scratch eos", scratch_size, nmat);
+  // ScratchV<EOS> eos_pte("PTE::scratch eos", scratch_size, nmat);
 
-  Kokkos::View<int, MemoryTraits<at_int> > res("PTE::num fails");
-  Kokkos::View<int, MemoryTraits<at_int> > n_solves("PTE::num solves");
+  Kokkos::View<int, MemoryTraits<at_int>> res("PTE::num fails");
+  Kokkos::View<int, MemoryTraits<at_int>> n_solves("PTE::num solves");
   // loop over cells
-  portableFor("PTE", 0, ncell, PORTABLE_LAMBDA (const int& iloop)
-  {
-    // cell offset
-    const int i {offsets_v(iloop)-1};
-    // get "thread-id" like thing with optimization
-    // for small loops
-    const int32_t token {tokens.acquire()};
-    const int32_t tid {small_loop ? iloop : token};
-    // caching mechanism
-    Real cache[MAX_NUM_LAMBDAS];
-    // calculate total mass in the cell
-    Real mass_sum {0.0};
-    for (int m = 0; m < nmat; ++m) mass_sum += frac_mass_v(i, m);
-    // validate specific volume
-    spvol_v(i) = r_is_inp ? spvol_v(i) : vol_v(i) / mass_sum;
-    // calculate specific internal energy if not already known
-    if (!s_is_inp) {
-      Real eng_sum {0.0};
-      Real vol_sum {0.0};
-      for (int m = 0; m < nmat; ++m) {
-        Real rho = 1.0 / spvol_v(i);
-        Real T = temp_v(i)*ev2k;
-        Real press_mat = press_v(i);
-        Real spie = sie_v(i);
-        Real cv_mat, bmod_mat;
-        int mid = eos_offsets_v(m) - 1;
-        eos_v(mid).FillEos(rho, T, spie, press_mat, cv_mat, bmod_mat,
-                           output, cache);
-        eng_sum += spie*frac_mass_v(i, m);
-        vol_sum += frac_mass_v(i, m) / rho;
-        if (vol_sum < 0.0)
-          printf("Neg. Volume:\ninput: %i mat: %i r: %e t: %e s: %e p: %e\n",
-                 input_int, mid+1, rho, T, spie, press_mat);
-        //if (!r_is_inp) printf("mat: %i rho lookup: %e\n", eos_offsets_v(m), rho);
-      }
-      spvol_v(i) = r_is_inp ? spvol_v(i) : vol_sum / mass_sum;
-      sie_v(i) = eng_sum / mass_sum;
-    }
-    // calculate component volumes and energies
-    // figure out participating materials, get everything
-    // set up to feed in to solver
-    int npte = 0;
-    double vsum_nopte = 0.0;
-    double esum_nopte = 0.0;
-    double rhoavg_pte = 0.0;
-    for (int m = 0; m < nmat; ++m) {
-      const bool something = frac_mass_v(i, m)/mass_sum > min_frac;
-      frac_sie_v(i, m) = sie_v(i) * frac_mass_v(i, m);
-      frac_vol_v(i, m) = spvol_v(i) * frac_mass_v(i, m);
-      if (something) {
-        // vfrac true
-        int midx = eos_offsets_v(m) - 1;
-        pte_mats(tid, npte) = midx;
-        pte_idxs(tid, npte) = m;
-        mass_pte(tid, npte) = frac_mass_v(i, m);
-        sie_pte(tid, npte) = frac_sie_v(i, m) / frac_mass_v(i, m);
-        vfrac_pte(tid, npte) = frac_vol_v(i, m);
-        npte += 1;
-      } else {
-        vsum_nopte += frac_vol_v(i, m);
-        esum_nopte += frac_sie_v(i, m);
-      }
-    }
-    // call solver to get correct volume fractions
-    // component masses, total energy, and total volume are conserved
-    const double vfrac_tot = r_is_inp ? spvol_v(i) * mass_sum : vol_v(i);
-    const double sie_tot = sie_v(i);// - esum_nopte / rhoavg_pte;
-    // calculate initial guess for mixed cells
-    if (npte > 1) {
-      n_solves() += 1;
-      // find the most common material
-      int common_mat_id = 0;
-      Real max_mass = 0.0;
-      for (int m = 0; m < nmat; ++m) {
-        if (frac_mass_v(i, m) > max_mass) {
-          max_mass = frac_mass_v(i, m);
-          common_mat_id = m;
-        }
-      }
-      int common_mid = eos_offsets_v(common_mat_id) - 1;
-      // eos lookup of most common material
-      Real common_rho {1.0/spvol_v(i)};
-      Real common_temp {0.};
-      Real common_sie {frac_sie_v(i, common_mat_id)
-                       / frac_mass_v(i, common_mat_id)};
-      Real common_press {0.};
-      Real common_cv {0.0};
-      Real common_bmod {0.0};
-      Real ref_p, ref_dpde, ref_dvdt, ref_sie;
-      eos_v(common_mid).ValuesAtReferenceState(common_rho, common_temp,
-                                               ref_sie, ref_p, common_cv,
-                                               common_bmod, ref_dpde, ref_dvdt);
-      const auto pt_output = thermalqs::all_values
-                           - (thermalqs::density | thermalqs::specific_internal_energy);
-      eos_v(common_mid).FillEos(common_rho, common_temp, common_sie,
-                                common_press, common_cv, common_bmod,
-                                pt_output, cache);
-      common_press = common_press < 0.0 ? press_v(i) : common_press;
-      // PT lookup of all other materials at PT of common material
-      const auto guess_output = thermalqs::all_values
-                              - (thermalqs::pressure | thermalqs::temperature);
-      for (int m = 0; m < npte; ++m) {
-        int mid = pte_mats(tid, m);
-        int midx = pte_idxs(tid, m);
-        Real matrho {0.0}, mat_sie{0.0};
-        press_pte(tid, m) = common_press;
-        rho_pte(tid, m) = common_rho;
-        temp_pte(tid, m) = common_temp;
-        sie_pte(tid, m) = common_sie;
-        vfrac_pte(tid, m) = frac_mass_v(i, midx) / common_rho;
-        if (mid != common_mid) {
-          // reuse common cv and bmod b/c the values aren't needed
-          eos_v(mid).FillEos(matrho, common_temp, mat_sie, common_press,
-                             common_cv, common_bmod, guess_output,
-                             cache);
-          // get rid of 0 density issues
-          Real guess_density = matrho;
-          if (matrho < min_guess_density) {
-            Real ref_T, ref_dpde, ref_dvdt;
-            eos_v(mid).ValuesAtReferenceState(guess_density, ref_T, ref_sie, ref_p,
-                                              common_cv, common_bmod, ref_dpde, ref_dvdt);
-            press_pte(tid, m) = ref_p;
-            temp_pte(tid, m) = ref_T;
-            //sie_pte(tid, m) = ref_sie;
+  portableFor(
+      "PTE", 0, ncell, PORTABLE_LAMBDA(const int &iloop) {
+        // cell offset
+        const int i{offsets_v(iloop) - 1};
+        // get "thread-id" like thing with optimization
+        // for small loops
+        const int32_t token{tokens.acquire()};
+        const int32_t tid{small_loop ? iloop : token};
+        // caching mechanism
+        Real cache[MAX_NUM_LAMBDAS];
+        // calculate total mass in the cell
+        Real mass_sum{0.0};
+        for (int m = 0; m < nmat; ++m)
+          mass_sum += frac_mass_v(i, m);
+        // validate specific volume
+        spvol_v(i) = r_is_inp ? spvol_v(i) : vol_v(i) / mass_sum;
+        // calculate specific internal energy if not already known
+        if (!s_is_inp) {
+          Real eng_sum{0.0};
+          Real vol_sum{0.0};
+          for (int m = 0; m < nmat; ++m) {
+            Real rho = 1.0 / spvol_v(i);
+            Real T = temp_v(i) * ev2k;
+            Real press_mat = press_v(i);
+            Real spie = sie_v(i);
+            Real cv_mat, bmod_mat;
+            int mid = eos_offsets_v(m) - 1;
+            eos_v(mid).FillEos(rho, T, spie, press_mat, cv_mat, bmod_mat, output, cache);
+            eng_sum += spie * frac_mass_v(i, m);
+            vol_sum += frac_mass_v(i, m) / rho;
+            if (vol_sum < 0.0)
+              printf("Neg. Volume:\ninput: %i mat: %i r: %e t: %e s: %e p: %e\n",
+                     input_int, mid + 1, rho, T, spie, press_mat);
+            // if (!r_is_inp) printf("mat: %i rho lookup: %e\n", eos_offsets_v(m), rho);
           }
-          vfrac_pte(tid, m) = frac_mass_v(i, midx) / guess_density;
-          rho_pte(tid, m) = guess_density;
-          sie_pte(tid, m) = mat_sie;
+          spvol_v(i) = r_is_inp ? spvol_v(i) : vol_sum / mass_sum;
+          sie_v(i) = eng_sum / mass_sum;
         }
-      }
-      // loop over materials to calc temperature, per material quantities
-      //Real sum_mu_cvt {0.0}, sum_mu_e0 {0.0}, sum_mu_cv {0.0};
-      //for (int m = 0; m < npte; ++m) {
-      //  const int mid = pte_mats(tid, m);
-      //  const int midx = pte_idxs(tid, m);
-      //  const Real mu = frac_mass_v(i, midx)/mass_sum;
-      //  Real ref_rho {0.0}, ref_T {0.0}, ref_sie {0.0}, ref_p{0.0};
-      //  Real ref_cv {0.0}, ref_bmod {0.0}, ref_dpde {0.0}, ref_dvdt {0.0};
-      //  eos_v(mid).ValuesAtReferenceState(ref_rho, ref_T, ref_sie, ref_p,
-      //                                    ref_cv, ref_bmod, ref_dpde, ref_dvdt);
-      //  sum_mu_cvt += mu*ref_cv*ref_T;
-      //  sum_mu_e0 += mu*ref_sie;
-      //  sum_mu_cv += mu*ref_cv;
-      //}
-      //const Real temp_est {(sie_v(i) + sum_mu_cvt - sum_mu_e0) / sum_mu_cv};
-      //const bool temp_est_pos {temp_est > 0.0};
-      //Real vol_sum{0.0}, eng_sum{0.0};
-      //for (int m = 0; m < npte; ++m) {
-      //  const int mid = pte_mats(tid, m);
-      //  const int midx = pte_idxs(tid, m);
-      //  const Real mu = frac_mass_v(i, midx)/mass_sum;
-      //  Real ref_rho {0.0}, ref_T {0.0}, ref_sie {0.0}, ref_p{0.0};
-      //  Real ref_cv {0.0}, ref_bmod {0.0}, ref_dpde {0.0}, ref_dvdt {0.0};
-      //  eos_v(mid).ValuesAtReferenceState(ref_rho, ref_T, ref_sie, ref_p,
-      //                                    ref_cv, ref_bmod, ref_dpde, ref_dvdt);
-      //  //const Real delta_T {temp_est_pos ? temp_est - ref_T : 0.0};
-      //  //sie_pte(tid, m) = ref_sie;//temp_est_pos ? ref_cv*delta_T + ref_sie : mu*sie_v(i);
-      //  //const Real guess_rho = (1.0 - ref_rho*ref_dvdt*delta_T) <= 0.0 
-      //  //                     ? ref_rho
-      //  //                     : ref_rho*(1.0 - ref_rho*ref_dvdt*delta_T);
-      //  vfrac_pte(tid, m) = frac_mass_v(i, midx) / ref_rho;
-      //  rho_pte(tid, m) = ref_rho;
-      //  temp_pte(tid, m) = ref_T;//temp_v(i);
-      //  press_pte(tid, m) = ref_p;
-      //  //sie_pte(tid, m) = ref_sie;
-      //  //printf("ref vals:\nv r t p s\n%e %e %e %e %e\n",
-      //  //       vfrac_pte(tid, m), ref_rho, ref_T, ref_p, ref_sie);
-      //  //mass_pte(tid, m) = ref_rho;
-      //  //rho_pte(tid, m) = 1.0/spvol_v(i);
-      //  //const auto guess_output = thermalqs::all_values
-      //  //                        - (thermalqs::pressure | thermalqs::temperature);
-      //  //Real mat_sie {frac_sie_v(i, midx) / frac_mass_v(i, midx)};
-      //  //Real mat_press {press_v(i)};
-      //  //Real mat_cv, mat_bmod, mat_dpde;
-      //  //temp_pte(tid, m) = temp_v(i);
-      //  //eos_v(mid).FillEos(rho_pte(tid, m), temp_pte(tid, m), mat_sie,
-      //  //                   mat_press, mat_cv, mat_bmod, mat_dpde);
-      //  //vfrac_pte(tid, m) = frac_mass_v(i, midx) / rho_pte(tid, m);
-      //  //press_pte(tid, m) = press_v(i);
-      //  //sie_pte(tid, m) = mat_sie;
-      //  //vfrac_pte(tid, m) = rho_pte(tid, m) / frac_mass_v(i, midx);
-      //  //vol_sum += vfrac_pte(tid, m);
-      //  //eng_sum += mu*sie_pte(tid, m);
-      //}
-    }
-    int niter;
-    const bool res_
-      {pte_closure_josh_offset(npte, eos_v.data(), vfrac_tot, sie_tot,
-                               &pte_mats(tid, 0), &rho_pte(tid, 0),
-                               &vfrac_pte(tid, 0), &sie_pte(tid, 0),
-                               &temp_pte(tid, 0), &press_pte(tid, 0),
-                               lambda_map)};
-    // assign local values to global
-    press_v(i) = p_is_inp ? press_v(i) : 0.0;
-    sie_v(i) = s_is_inp ? sie_v(i) : 0.0;
-    temp_v(i) = t_is_inp ? temp_v(i) : 0.0;
-    bmod_v(i) = 0.0;
-    cv_v(i) = 0.0;
-    dpde_v(i) = 0.0;
-    Real vol_sum = 0.0;
-    for (int m = 0; m < npte; ++m) {
-      int mid = pte_mats(tid, m);
-      int midx = pte_idxs(tid, m);
-      Real rho = mass_pte(tid, m) / vfrac_pte(tid, m);
-      Real spie = sie_pte(tid, m);
-      Real press_mat = press_v(i);
-      Real T = temp_v(i)*ev2k;
-      Real cv_mat = 0.0;
-      Real bmod_mat = 0.0;
-      eos_v(mid).FillEos(rho, T, spie, press_mat, cv_mat, bmod_mat,
-                         output, cache);
-      frac_sie_v(i, midx) = spie * frac_mass_v(i, midx);
-      frac_vol_v(i, midx) = frac_mass_v(i, midx) / rho;
-      vol_sum += frac_vol_v(i, midx);
-      temp_v(i) += t_is_inp ? 0.0 : frac_vol_v(i, midx)/ev2k*T;
-      press_v(i) += p_is_inp ? 0.0 : frac_vol_v(i, midx)*press_mat;
-      // optional cv and bmod
-      const Real dpde_mat = rho*
-        eos_v(mid).GruneisenParamFromDensityInternalEnergy(rho,
-                                                           spie,
-                                                           cache);
-      sie_v(i) += s_is_inp ? 0.0 : frac_sie_v(i, midx);
-      bmod_v(i) += frac_vol_v(i, midx)*bmod_mat;
-      cv_v(i) += frac_mass_v(i, midx)*cv_mat;
-      dpde_v(i) += frac_vol_v(i, midx)*dpde_mat;
-      if (do_frac_bmod) {
-        frac_bmod_v(i, midx) = bmod_mat;
-      }
-      if (do_frac_cv) {
-        frac_cv_v(i, midx) = cv_mat;
-      }
-      if (do_frac_dpde) {
-        frac_dpde_v(i, midx) = dpde_mat;
-      }
-    }
-    press_v(i) /= p_is_inp ? 1.0 : vol_sum;
-    sie_v(i) /= s_is_inp ? 1.0 : mass_sum;
-    temp_v(i) /= t_is_inp ? 1.0 : vol_sum;
-    bmod_v(i) /= vol_sum;
-    cv_v(i) *= ev2k/mass_sum;
-    dpde_v(i) /= vol_sum;
-    spvol_v(i) = r_is_inp ? spvol_v(i) : vol_sum / mass_sum;
-    pmax_v(i) = press_v(i) > pmax_v(i) ? press_v(i) : pmax_v(i);
-    // if failed, increment return value by 1
-    // use if rather than ternary to reduce contention
-    if (!res_) {
-      res() += 1;
-    }
-    // release token
-    tokens.release(token);
-  });
+        // calculate component volumes and energies
+        // figure out participating materials, get everything
+        // set up to feed in to solver
+        int npte = 0;
+        double vsum_nopte = 0.0;
+        double esum_nopte = 0.0;
+        double rhoavg_pte = 0.0;
+        for (int m = 0; m < nmat; ++m) {
+          const bool something = frac_mass_v(i, m) / mass_sum > min_frac;
+          frac_sie_v(i, m) = sie_v(i) * frac_mass_v(i, m);
+          frac_vol_v(i, m) = spvol_v(i) * frac_mass_v(i, m);
+          if (something) {
+            // vfrac true
+            int midx = eos_offsets_v(m) - 1;
+            pte_mats(tid, npte) = midx;
+            pte_idxs(tid, npte) = m;
+            mass_pte(tid, npte) = frac_mass_v(i, m);
+            sie_pte(tid, npte) = frac_sie_v(i, m) / frac_mass_v(i, m);
+            vfrac_pte(tid, npte) = frac_vol_v(i, m);
+            npte += 1;
+          } else {
+            vsum_nopte += frac_vol_v(i, m);
+            esum_nopte += frac_sie_v(i, m);
+          }
+        }
+        // call solver to get correct volume fractions
+        // component masses, total energy, and total volume are conserved
+        const double vfrac_tot = r_is_inp ? spvol_v(i) * mass_sum : vol_v(i);
+        const double sie_tot = sie_v(i); // - esum_nopte / rhoavg_pte;
+        // calculate initial guess for mixed cells
+        if (npte > 1) {
+          n_solves() += 1;
+          // find the most common material
+          int common_mat_id = 0;
+          Real max_mass = 0.0;
+          for (int m = 0; m < nmat; ++m) {
+            if (frac_mass_v(i, m) > max_mass) {
+              max_mass = frac_mass_v(i, m);
+              common_mat_id = m;
+            }
+          }
+          int common_mid = eos_offsets_v(common_mat_id) - 1;
+          // eos lookup of most common material
+          Real common_rho{1.0 / spvol_v(i)};
+          Real common_temp{0.};
+          Real common_sie{frac_sie_v(i, common_mat_id) / frac_mass_v(i, common_mat_id)};
+          Real common_press{0.};
+          Real common_cv{0.0};
+          Real common_bmod{0.0};
+          Real ref_p, ref_dpde, ref_dvdt, ref_sie;
+          eos_v(common_mid)
+              .ValuesAtReferenceState(common_rho, common_temp, ref_sie, ref_p, common_cv,
+                                      common_bmod, ref_dpde, ref_dvdt);
+          const auto pt_output =
+              thermalqs::all_values -
+              (thermalqs::density | thermalqs::specific_internal_energy);
+          eos_v(common_mid)
+              .FillEos(common_rho, common_temp, common_sie, common_press, common_cv,
+                       common_bmod, pt_output, cache);
+          common_press = common_press < 0.0 ? press_v(i) : common_press;
+          // PT lookup of all other materials at PT of common material
+          const auto guess_output =
+              thermalqs::all_values - (thermalqs::pressure | thermalqs::temperature);
+          for (int m = 0; m < npte; ++m) {
+            int mid = pte_mats(tid, m);
+            int midx = pte_idxs(tid, m);
+            Real matrho{0.0}, mat_sie{0.0};
+            press_pte(tid, m) = common_press;
+            rho_pte(tid, m) = common_rho;
+            temp_pte(tid, m) = common_temp;
+            sie_pte(tid, m) = common_sie;
+            vfrac_pte(tid, m) = frac_mass_v(i, midx) / common_rho;
+            if (mid != common_mid) {
+              // reuse common cv and bmod b/c the values aren't needed
+              eos_v(mid).FillEos(matrho, common_temp, mat_sie, common_press, common_cv,
+                                 common_bmod, guess_output, cache);
+              // get rid of 0 density issues
+              Real guess_density = matrho;
+              if (matrho < min_guess_density) {
+                Real ref_T, ref_dpde, ref_dvdt;
+                eos_v(mid).ValuesAtReferenceState(guess_density, ref_T, ref_sie, ref_p,
+                                                  common_cv, common_bmod, ref_dpde,
+                                                  ref_dvdt);
+                press_pte(tid, m) = ref_p;
+                temp_pte(tid, m) = ref_T;
+                // sie_pte(tid, m) = ref_sie;
+              }
+              vfrac_pte(tid, m) = frac_mass_v(i, midx) / guess_density;
+              rho_pte(tid, m) = guess_density;
+              sie_pte(tid, m) = mat_sie;
+            }
+          }
+          // loop over materials to calc temperature, per material quantities
+          // Real sum_mu_cvt {0.0}, sum_mu_e0 {0.0}, sum_mu_cv {0.0};
+          // for (int m = 0; m < npte; ++m) {
+          //  const int mid = pte_mats(tid, m);
+          //  const int midx = pte_idxs(tid, m);
+          //  const Real mu = frac_mass_v(i, midx)/mass_sum;
+          //  Real ref_rho {0.0}, ref_T {0.0}, ref_sie {0.0}, ref_p{0.0};
+          //  Real ref_cv {0.0}, ref_bmod {0.0}, ref_dpde {0.0}, ref_dvdt {0.0};
+          //  eos_v(mid).ValuesAtReferenceState(ref_rho, ref_T, ref_sie, ref_p,
+          //                                    ref_cv, ref_bmod, ref_dpde, ref_dvdt);
+          //  sum_mu_cvt += mu*ref_cv*ref_T;
+          //  sum_mu_e0 += mu*ref_sie;
+          //  sum_mu_cv += mu*ref_cv;
+          //}
+          // const Real temp_est {(sie_v(i) + sum_mu_cvt - sum_mu_e0) / sum_mu_cv};
+          // const bool temp_est_pos {temp_est > 0.0};
+          // Real vol_sum{0.0}, eng_sum{0.0};
+          // for (int m = 0; m < npte; ++m) {
+          //  const int mid = pte_mats(tid, m);
+          //  const int midx = pte_idxs(tid, m);
+          //  const Real mu = frac_mass_v(i, midx)/mass_sum;
+          //  Real ref_rho {0.0}, ref_T {0.0}, ref_sie {0.0}, ref_p{0.0};
+          //  Real ref_cv {0.0}, ref_bmod {0.0}, ref_dpde {0.0}, ref_dvdt {0.0};
+          //  eos_v(mid).ValuesAtReferenceState(ref_rho, ref_T, ref_sie, ref_p,
+          //                                    ref_cv, ref_bmod, ref_dpde, ref_dvdt);
+          //  //const Real delta_T {temp_est_pos ? temp_est - ref_T : 0.0};
+          //  //sie_pte(tid, m) = ref_sie;//temp_est_pos ? ref_cv*delta_T + ref_sie :
+          //  mu*sie_v(i);
+          //  //const Real guess_rho = (1.0 - ref_rho*ref_dvdt*delta_T) <= 0.0
+          //  //                     ? ref_rho
+          //  //                     : ref_rho*(1.0 - ref_rho*ref_dvdt*delta_T);
+          //  vfrac_pte(tid, m) = frac_mass_v(i, midx) / ref_rho;
+          //  rho_pte(tid, m) = ref_rho;
+          //  temp_pte(tid, m) = ref_T;//temp_v(i);
+          //  press_pte(tid, m) = ref_p;
+          //  //sie_pte(tid, m) = ref_sie;
+          //  //printf("ref vals:\nv r t p s\n%e %e %e %e %e\n",
+          //  //       vfrac_pte(tid, m), ref_rho, ref_T, ref_p, ref_sie);
+          //  //mass_pte(tid, m) = ref_rho;
+          //  //rho_pte(tid, m) = 1.0/spvol_v(i);
+          //  //const auto guess_output = thermalqs::all_values
+          //  //                        - (thermalqs::pressure | thermalqs::temperature);
+          //  //Real mat_sie {frac_sie_v(i, midx) / frac_mass_v(i, midx)};
+          //  //Real mat_press {press_v(i)};
+          //  //Real mat_cv, mat_bmod, mat_dpde;
+          //  //temp_pte(tid, m) = temp_v(i);
+          //  //eos_v(mid).FillEos(rho_pte(tid, m), temp_pte(tid, m), mat_sie,
+          //  //                   mat_press, mat_cv, mat_bmod, mat_dpde);
+          //  //vfrac_pte(tid, m) = frac_mass_v(i, midx) / rho_pte(tid, m);
+          //  //press_pte(tid, m) = press_v(i);
+          //  //sie_pte(tid, m) = mat_sie;
+          //  //vfrac_pte(tid, m) = rho_pte(tid, m) / frac_mass_v(i, midx);
+          //  //vol_sum += vfrac_pte(tid, m);
+          //  //eng_sum += mu*sie_pte(tid, m);
+          //}
+        }
+        int niter;
+        const bool res_{pte_closure_josh_offset(
+            npte, eos_v.data(), vfrac_tot, sie_tot, &pte_mats(tid, 0), &rho_pte(tid, 0),
+            &vfrac_pte(tid, 0), &sie_pte(tid, 0), &temp_pte(tid, 0), &press_pte(tid, 0),
+            lambda_map)};
+        // assign local values to global
+        press_v(i) = p_is_inp ? press_v(i) : 0.0;
+        sie_v(i) = s_is_inp ? sie_v(i) : 0.0;
+        temp_v(i) = t_is_inp ? temp_v(i) : 0.0;
+        bmod_v(i) = 0.0;
+        cv_v(i) = 0.0;
+        dpde_v(i) = 0.0;
+        Real vol_sum = 0.0;
+        for (int m = 0; m < npte; ++m) {
+          int mid = pte_mats(tid, m);
+          int midx = pte_idxs(tid, m);
+          Real rho = mass_pte(tid, m) / vfrac_pte(tid, m);
+          Real spie = sie_pte(tid, m);
+          Real press_mat = press_v(i);
+          Real T = temp_v(i) * ev2k;
+          Real cv_mat = 0.0;
+          Real bmod_mat = 0.0;
+          eos_v(mid).FillEos(rho, T, spie, press_mat, cv_mat, bmod_mat, output, cache);
+          frac_sie_v(i, midx) = spie * frac_mass_v(i, midx);
+          frac_vol_v(i, midx) = frac_mass_v(i, midx) / rho;
+          vol_sum += frac_vol_v(i, midx);
+          temp_v(i) += t_is_inp ? 0.0 : frac_vol_v(i, midx) / ev2k * T;
+          press_v(i) += p_is_inp ? 0.0 : frac_vol_v(i, midx) * press_mat;
+          // optional cv and bmod
+          const Real dpde_mat =
+              rho * eos_v(mid).GruneisenParamFromDensityInternalEnergy(rho, spie, cache);
+          sie_v(i) += s_is_inp ? 0.0 : frac_sie_v(i, midx);
+          bmod_v(i) += frac_vol_v(i, midx) * bmod_mat;
+          cv_v(i) += frac_mass_v(i, midx) * cv_mat;
+          dpde_v(i) += frac_vol_v(i, midx) * dpde_mat;
+          if (do_frac_bmod) {
+            frac_bmod_v(i, midx) = bmod_mat;
+          }
+          if (do_frac_cv) {
+            frac_cv_v(i, midx) = cv_mat;
+          }
+          if (do_frac_dpde) {
+            frac_dpde_v(i, midx) = dpde_mat;
+          }
+        }
+        press_v(i) /= p_is_inp ? 1.0 : vol_sum;
+        sie_v(i) /= s_is_inp ? 1.0 : mass_sum;
+        temp_v(i) /= t_is_inp ? 1.0 : vol_sum;
+        bmod_v(i) /= vol_sum;
+        cv_v(i) *= ev2k / mass_sum;
+        dpde_v(i) /= vol_sum;
+        spvol_v(i) = r_is_inp ? spvol_v(i) : vol_sum / mass_sum;
+        pmax_v(i) = press_v(i) > pmax_v(i) ? press_v(i) : pmax_v(i);
+        // if failed, increment return value by 1
+        // use if rather than ternary to reduce contention
+        if (!res_) {
+          res() += 1;
+        }
+        // release token
+        tokens.release(token);
+      });
   Kokkos::fence();
   // copy results back into local values
   deep_copy(ret, res);
@@ -637,33 +606,29 @@ int get_sg_eos(// sizing information
   if (do_frac_cv) {
     deep_copy(frac_cv_hv, frac_cv_v);
   }
-  portableFor("freeing lambda ptrs", 0, nmat, PORTABLE_LAMBDA (const int& i)
-  {
-    free(lambda_map[i]);
-  });
+  portableFor(
+      "freeing lambda ptrs", 0, nmat,
+      PORTABLE_LAMBDA(const int &i) { free(lambda_map[i]); });
   PORTABLE_FREE(lambda_map);
   int tot_solves{0};
   deep_copy(tot_solves, n_solves);
-  if (ret > 0)
-    printf("%i/%i solves failed\n", ret, tot_solves);
+  if (ret > 0) printf("%i/%i solves failed\n", ret, tot_solves);
 #endif // PORTABILITY_STRATEGY_KOKKOS
   return ret;
 }
 
-int finalize_sg_eos(const int nmat, EOS* &eos, const int own_kokkos) {
+int finalize_sg_eos(const int nmat, EOS *&eos, const int own_kokkos) {
   {
     for (int i = 0; i < nmat; ++i)
       eos[i].Finalize();
-    #ifdef PORTABILITY_STRATEGY_KOKKOS
+#ifdef PORTABILITY_STRATEGY_KOKKOS
     Kokkos::fence();
-    #endif // PORTABILITY_STRATEGY_KOKKOS
+#endif // PORTABILITY_STRATEGY_KOKKOS
   }
   delete[] eos;
   eos = nullptr;
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  if (own_kokkos != 0)
-    Kokkos::finalize();
+  if (own_kokkos != 0) Kokkos::finalize();
 #endif
   return 0;
 }
-

--- a/singularity-eos/eos/singularity_eos.hpp
+++ b/singularity-eos/eos/singularity_eos.hpp
@@ -15,8 +15,8 @@
 #ifndef _SINGULARITY_EOS_EOS_SINGULARITY_EOS_HPP_
 #define _SINGULARITY_EOS_EOS_SINGULARITY_EOS_HPP_
 
-#include <singularity-eos/eos/eos.hpp>
 #include <singularity-eos/closure/mixed_cell_models.hpp>
+#include <singularity-eos/eos/eos.hpp>
 
 using singularity::EOS;
 
@@ -24,115 +24,106 @@ using singularity::EOS;
 extern "C" {
 #endif
 
-int init_sg_eos(const int nmat, EOS* &eos);
+int init_sg_eos(const int nmat, EOS *&eos);
 
-int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
-                     const double Cv,
-                     int const * const enabled, double const * const vals);
+int init_sg_IdealGas(const int matindex, EOS *eos, const double gm1, const double Cv,
+                     int const *const enabled, double const *const vals);
 
-int init_sg_JWL(const int matindex, EOS* eos, const double A,
-                const double B, const double R1, const double R2,
-                const double w, const double rho0, const double Cv,
-                int const * const enabled, double const * const vals);
+int init_sg_JWL(const int matindex, EOS *eos, const double A, const double B,
+                const double R1, const double R2, const double w, const double rho0,
+                const double Cv, int const *const enabled, double const *const vals);
 
-int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
-                      const double s1, const double s2, const double s3,
-                      const double G0, const double b, const double rho0,
-                      const double T0, const double P0, const double Cv,
-                      int const * const enabled, double const * const vals);
+int init_sg_Gruneisen(const int matindex, EOS *eos, const double C0, const double s1,
+                      const double s2, const double s3, const double G0, const double b,
+                      const double rho0, const double T0, const double P0,
+                      const double Cv, int const *const enabled,
+                      double const *const vals);
 
-int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
-                          const double b, const double k, const double n,
-                          const double vc, const double pc, const double Cv,
-                          const double E0,
-                          int const * const enabled, double const * const vals);
+int init_sg_DavisProducts(const int matindex, EOS *eos, const double a, const double b,
+                          const double k, const double n, const double vc,
+                          const double pc, const double Cv, const double E0,
+                          int const *const enabled, double const *const vals);
 
-int init_sg_DavisReactants(const int matindex, EOS* eos, const double rho0,
+int init_sg_DavisReactants(const int matindex, EOS *eos, const double rho0,
                            const double e0, const double P0, const double T0,
                            const double A, const double B, const double C,
                            const double G0, const double Z, const double alpha,
-                           const double Cv0,
-                           int const * const enabled,
-                           double const * const vals);
+                           const double Cv0, int const *const enabled,
+                           double const *const vals);
 
 #ifdef SPINER_USE_HDF
-int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
-                              const char* filename, const int id,
-                              int const * const enabled,
-                              double const * const vals);
+int init_sg_SpinerDependsRhoT(const int matindex, EOS *eos, const char *filename,
+                              const int id, int const *const enabled,
+                              double const *const vals);
 
-int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
-                                const char* filename, const int id,
-                                int const * const enabled,
-                                double const * const vals);
+int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filename,
+                                const int id, int const *const enabled,
+                                double const *const vals);
 #endif
 
 #ifdef SINGULARITY_USE_EOSPAC
 // capitalize? eospaceos Eospac Eospaceos EOSPAC EOSPACeos?
-int init_sg_eospac(const int matindex, EOS* eos, const int id,
-                   int const * const enabled, double const * const vals);
+int init_sg_eospac(const int matindex, EOS *eos, const int id, int const *const enabled,
+                   double const *const vals);
 #endif // SINGULARITY_USE_EOSPAC
 
-int get_sg_eos(// sizing information
-               int nmat, int ncell, int cell_dim,
-               // Input parameters
-               int input_int,
-               // eos index offsets
-               int* eos_offsets,
-               // equation of state array
-               EOS* eos,
-               // index offsets
-               int* offsets,
-               // per cell quantities
-               double* press, double* pmax, double* vol, double* spvol,
-               double* sie, double* temp, double* bmod, double* dpde,
-               double* cv,
-               // per material quantities
-               double* frac_mass, double* frac_vol, double* frac_sie,
-               // optional per material quantities
-               double* frac_bmod, double* frac_dpde, double* frac_cv);
+int get_sg_eos( // sizing information
+    int nmat, int ncell, int cell_dim,
+    // Input parameters
+    int input_int,
+    // eos index offsets
+    int *eos_offsets,
+    // equation of state array
+    EOS *eos,
+    // index offsets
+    int *offsets,
+    // per cell quantities
+    double *press, double *pmax, double *vol, double *spvol, double *sie, double *temp,
+    double *bmod, double *dpde, double *cv,
+    // per material quantities
+    double *frac_mass, double *frac_vol, double *frac_sie,
+    // optional per material quantities
+    double *frac_bmod, double *frac_dpde, double *frac_cv);
 
-int finalize_sg_eos(const int nmat, EOS* &eos, const int own_kokkos=0);
+int finalize_sg_eos(const int nmat, EOS *&eos, const int own_kokkos = 0);
 
 #if defined(__cplusplus)
 }
 #endif
 
 // outside of C scope, provide overloads
-int init_sg_IdealGas(const int matindex, EOS* eos, const double gm1,
-                     const double Cv);
+int init_sg_IdealGas(const int matindex, EOS *eos, const double gm1, const double Cv);
 
-int init_sg_JWL(const int matindex, EOS* eos, const double A,
-                const double B, const double R1, const double R2,
-                const double w, const double rho0, const double Cv);
+int init_sg_JWL(const int matindex, EOS *eos, const double A, const double B,
+                const double R1, const double R2, const double w, const double rho0,
+                const double Cv);
 
-int init_sg_Gruneisen(const int matindex, EOS* eos, const double C0,
-                      const double s1, const double s2, const double s3,
-                      const double G0, const double b, const double rho0,
-                      const double T0, const double P0, const double Cv);
+int init_sg_Gruneisen(const int matindex, EOS *eos, const double C0, const double s1,
+                      const double s2, const double s3, const double G0, const double b,
+                      const double rho0, const double T0, const double P0,
+                      const double Cv);
 
-int init_sg_DavisProducts(const int matindex, EOS* eos, const double a,
-                          const double b, const double k, const double n,
-                          const double vc, const double pc, const double Cv,
-                          const double E0);
+int init_sg_DavisProducts(const int matindex, EOS *eos, const double a, const double b,
+                          const double k, const double n, const double vc,
+                          const double pc, const double Cv, const double E0);
 
-int init_sg_DavisReactants(const int matindex, EOS* eos, const double rho0,
+int init_sg_DavisReactants(const int matindex, EOS *eos, const double rho0,
                            const double e0, const double P0, const double T0,
                            const double A, const double B, const double C,
                            const double G0, const double Z, const double alpha,
                            const double Cv0);
 
 #ifdef SPINER_USE_HDF
-int init_sg_SpinerDependsRhoT(const int matindex, EOS* eos,
-                              const char* filename, const int id);
+int init_sg_SpinerDependsRhoT(const int matindex, EOS *eos, const char *filename,
+                              const int id);
 
-int init_sg_SpinerDependsRhoSie(const int matindex, EOS* eos,
-                                const char* filename, const int id);
+int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filename,
+                                const int id);
 #endif
 
 #ifdef SINGULARITY_USE_EOSPAC
 // capitalize? eospaceos Eospac Eospaceos EOSPAC EOSPACeos?
-int init_sg_eospac(const int matindex, EOS* eos, const int id);
+int init_sg_eospac(const int matindex, EOS *eos, const int id);
 #endif // SINGULARITY_USE_EOSPAC
 
 #endif // EOS_SINGULARITY_EOS_HPP_

--- a/stellarcollapse2spiner/main.cpp
+++ b/stellarcollapse2spiner/main.cpp
@@ -22,13 +22,12 @@
 
 using singularity::StellarCollapse;
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
   if (argc < 3) {
     std::cout << "Converts a Stellar Collapse EOS file into an SP5 file.\n"
               << "Performs relevant data cleanup for use in fluid codes.\n"
               << "Usage:\n"
-              << argv[0] << " input_filename ouutput_filename"
-              << std::endl;
+              << argv[0] << " input_filename ouutput_filename" << std::endl;
     return 1;
   }
 

--- a/test/compare_on_data.cpp
+++ b/test/compare_on_data.cpp
@@ -18,7 +18,6 @@
   Author: Jonah Miller (jonahm@lanl.gov)
  */
 
-
 #ifdef SPINER_USE_HDF
 #ifdef SINGULARITY_USE_EOSPAC
 
@@ -53,11 +52,11 @@ using duration = std::chrono::duration<long double>;
 using dvec = std::vector<double>;
 using ivec = std::vector<int>;
 using Spiner::DataBox;
-using Spiner::RegularGrid1D;
 using Spiner::getOnDeviceDataBox;
+using Spiner::RegularGrid1D;
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-using RView = Kokkos::View<Real*>;
+using RView = Kokkos::View<Real *>;
 using RMirror = typename RView::HostMirror;
 #endif
 
@@ -73,76 +72,58 @@ struct Data {
     other.onDevice = true;
   }
   void Finalize() {
-    #ifdef PORTABILITY_STRATEGY_KOKKOS
+#ifdef PORTABILITY_STRATEGY_KOKKOS
     using HS = Kokkos::HostSpace;
     using DMS = Kokkos::DefaultExecutionSpace::memory_space;
-    constexpr const bool execution_is_host {std::is_same<DMS,HS>::value};
+    constexpr const bool execution_is_host{std::is_same<DMS, HS>::value};
     if (!execution_is_host && onDevice) {
       PORTABLE_FREE(rhos.data());
       PORTABLE_FREE(sies.data());
       PORTABLE_FREE(vfracs.data());
       PORTABLE_FREE(Ts.data());
     }
-    #endif
+#endif
   }
 };
 
-inline auto now() {
-  return std::chrono::high_resolution_clock::now();
-}
+inline auto now() { return std::chrono::high_resolution_clock::now(); }
 
-template<typename Function>
+template <typename Function>
 inline auto get_duration(Function function) {
   auto start = now();
   function();
   auto stop = now();
-  return std::chrono::duration_cast<duration>(stop-start).count();
+  return std::chrono::duration_cast<duration>(stop - start).count();
 }
 
-void load_data(const std::string& filename, Data& d);
-void filter_data_for_EOSPAC(const Data& d_in,
-                            std::vector<std::vector<EOS_REAL>>& rhos,
-                            std::vector<std::vector<EOS_REAL>>& sies,
-                            std::vector<std::vector<EOS_REAL>>& Ts);
-void load_eospac_tables(const std::vector<int>& matids,
-                        std::vector<EOS_INTEGER>& table_handles);
-void load_eos_spiner(const std::string& filename,
-                     const std::vector<int>& matids,
-                     std::vector<EOS>& eos_h,
-                     std::vector<EOS>& eos_d);
-void profile_eospac(int ncycles,
-                    const std::vector<int>& chunk_sizes,
-                    const Data& data,
-                    std::vector<EOS_INTEGER>& table_handles,
-                    std::vector<double>& timings,
-                    std::vector<double>& throughputs,
-                    std::vector<Real>& errors);
-void profile_spiner_host(int ncycles,
-                         const std::vector<int>& chunk_sizes,
-                         Data& data,
-                         std::vector<EOS>& eos,
-                         std::vector<double>& timings,
-                         std::vector<double>& throughputs,
-                         std::vector<Real>& errors);
-void compare_eospac_to_spiner(Data& data,
-                              int m, int nside,
-                              const std::string& outname,
-                              std::vector<EOS_INTEGER>& table_handle,
-                              std::vector<EOS>& eos);
-void make_table_sim_data(std::ostream& out,
-                              const std::string& dumpname,
-                              int ncycles,
-                              const std::vector<int>& chunk_sizes,
-                              const std::vector<Real>& errors_eospac,
-                              const std::vector<Real>& errors_spiner,
-                              const std::vector<double>& timings_eospac,
-                              const std::vector<double>& timings_spiner,
-                              const std::vector<double>& throughputs_eospac,
-                              const std::vector<double>& throughputs_spiner);
-void compare_on_sim_data(int ncycles, const std::vector<int>& chunk_sizes);
+void load_data(const std::string &filename, Data &d);
+void filter_data_for_EOSPAC(const Data &d_in, std::vector<std::vector<EOS_REAL>> &rhos,
+                            std::vector<std::vector<EOS_REAL>> &sies,
+                            std::vector<std::vector<EOS_REAL>> &Ts);
+void load_eospac_tables(const std::vector<int> &matids,
+                        std::vector<EOS_INTEGER> &table_handles);
+void load_eos_spiner(const std::string &filename, const std::vector<int> &matids,
+                     std::vector<EOS> &eos_h, std::vector<EOS> &eos_d);
+void profile_eospac(int ncycles, const std::vector<int> &chunk_sizes, const Data &data,
+                    std::vector<EOS_INTEGER> &table_handles, std::vector<double> &timings,
+                    std::vector<double> &throughputs, std::vector<Real> &errors);
+void profile_spiner_host(int ncycles, const std::vector<int> &chunk_sizes, Data &data,
+                         std::vector<EOS> &eos, std::vector<double> &timings,
+                         std::vector<double> &throughputs, std::vector<Real> &errors);
+void compare_eospac_to_spiner(Data &data, int m, int nside, const std::string &outname,
+                              std::vector<EOS_INTEGER> &table_handle,
+                              std::vector<EOS> &eos);
+void make_table_sim_data(std::ostream &out, const std::string &dumpname, int ncycles,
+                         const std::vector<int> &chunk_sizes,
+                         const std::vector<Real> &errors_eospac,
+                         const std::vector<Real> &errors_spiner,
+                         const std::vector<double> &timings_eospac,
+                         const std::vector<double> &timings_spiner,
+                         const std::vector<double> &throughputs_eospac,
+                         const std::vector<double> &throughputs_spiner);
+void compare_on_sim_data(int ncycles, const std::vector<int> &chunk_sizes);
 
-
-void load_data(const std::string& filename, Data& d) {
+void load_data(const std::string &filename, Data &d) {
 
   std::vector<std::vector<Real>> matrix;
 
@@ -151,8 +132,8 @@ void load_data(const std::string& filename, Data& d) {
 
   file.open(filename, std::ios::in);
   {
-    std::getline(file,line); // first line
-    while( std::getline(file, line) ) {
+    std::getline(file, line); // first line
+    while (std::getline(file, line)) {
       std::stringstream ss(line);
       std::vector<Real> row;
       Real val;
@@ -166,23 +147,23 @@ void load_data(const std::string& filename, Data& d) {
 
   d.Ts.resize(matrix.size());
   for (int i = 0; i < matrix.size(); i++) {
-    int j = matrix[i].size()-4;
+    int j = matrix[i].size() - 4;
     d.Ts(i) = matrix[i][j];
   }
 
   int stride = 3;
-  int nmats = (matrix[0].size() - 4)/stride;
-  d.rhos.resize(nmats,matrix.size());
-  d.sies.resize(nmats,matrix.size());
-  d.vfracs.resize(nmats,matrix.size());
+  int nmats = (matrix[0].size() - 4) / stride;
+  d.rhos.resize(nmats, matrix.size());
+  d.sies.resize(nmats, matrix.size());
+  d.vfracs.resize(nmats, matrix.size());
   for (int i = 0; i < matrix.size(); i++) {
     for (int mat = 0; mat < nmats; mat++) {
-      Real frac_mass = matrix[i][mat*stride];
-      Real frac_vol = matrix[i][mat*stride+1];
-      Real frac_eng = matrix[i][mat*stride+2];
-      d.rhos(mat,i) = frac_mass/frac_vol;
-      d.sies(mat,i) = frac_eng/frac_mass;
-      d.vfracs(mat,i) = frac_vol;
+      Real frac_mass = matrix[i][mat * stride];
+      Real frac_vol = matrix[i][mat * stride + 1];
+      Real frac_eng = matrix[i][mat * stride + 2];
+      d.rhos(mat, i) = frac_mass / frac_vol;
+      d.sies(mat, i) = frac_eng / frac_mass;
+      d.vfracs(mat, i) = frac_vol;
     }
   }
 
@@ -190,10 +171,9 @@ void load_data(const std::string& filename, Data& d) {
 }
 
 // this one must be ragged
-void filter_data_for_EOSPAC(const Data& d_in,
-                            std::vector<std::vector<EOS_REAL>>& rhos,
-                            std::vector<std::vector<EOS_REAL>>& sies,
-                            std::vector<std::vector<EOS_REAL>>& Ts) {
+void filter_data_for_EOSPAC(const Data &d_in, std::vector<std::vector<EOS_REAL>> &rhos,
+                            std::vector<std::vector<EOS_REAL>> &sies,
+                            std::vector<std::vector<EOS_REAL>> &Ts) {
   int nmats = d_in.rhos.dim(2);
   int ncells_tot = d_in.rhos.dim(1);
   rhos.resize(nmats);
@@ -202,16 +182,16 @@ void filter_data_for_EOSPAC(const Data& d_in,
   for (int mat = 0; mat < nmats; mat++) {
     int cell_count = 0;
     for (int i = 0; i < ncells_tot; i++) {
-      cell_count += (d_in.vfracs(mat,i) > 0) ? 1 : 0;
+      cell_count += (d_in.vfracs(mat, i) > 0) ? 1 : 0;
     }
     rhos[mat].resize(cell_count);
     sies[mat].resize(cell_count);
     Ts[mat].resize(cell_count);
     int c = 0;
     for (int i = 0; i < ncells_tot; i++) {
-      if (d_in.vfracs(mat,i) > 0) {
-        rhos[mat][c] = densityToSesame(d_in.rhos(mat,i));
-        sies[mat][c] = sieToSesame(d_in.sies(mat,i));
+      if (d_in.vfracs(mat, i) > 0) {
+        rhos[mat][c] = densityToSesame(d_in.rhos(mat, i));
+        sies[mat][c] = sieToSesame(d_in.sies(mat, i));
         Ts[mat][c] = temperatureToSesame(d_in.Ts(i));
         c++;
       }
@@ -219,8 +199,8 @@ void filter_data_for_EOSPAC(const Data& d_in,
   }
 }
 
-void load_eospac_tables(const std::vector<int>& matids,
-                        std::vector<EOS_INTEGER>& table_handles) {
+void load_eospac_tables(const std::vector<int> &matids,
+                        std::vector<EOS_INTEGER> &table_handles) {
   constexpr EOS_INTEGER NTABLES = 1;
   EOS_INTEGER tableType[] = {EOS_T_DUt};
 
@@ -230,10 +210,8 @@ void load_eospac_tables(const std::vector<int>& matids,
   }
 }
 
-void load_eos_spiner(const std::string& filename,
-                     const std::vector<int>& matids,
-                     std::vector<EOS>& eos_h,
-                     std::vector<EOS>& eos_d) {
+void load_eos_spiner(const std::string &filename, const std::vector<int> &matids,
+                     std::vector<EOS> &eos_h, std::vector<EOS> &eos_d) {
   eos_h.clear();
   eos_d.clear();
   EOSBuilder::EOSType type = EOSBuilder::EOSType::SpinerEOSDependsRhoT;
@@ -244,19 +222,15 @@ void load_eos_spiner(const std::string& filename,
   for (int matid : matids) {
     if (matid > 0) { // non-analytic
       params["matid"] = matid;
-      eos_h.push_back(EOSBuilder::buildEOS(type,params));
+      eos_h.push_back(EOSBuilder::buildEOS(type, params));
       eos_d.push_back(eos_h.back().GetOnDevice());
     }
   }
 }
 
-void profile_eospac(int ncycles,
-                    const std::vector<int>& chunk_sizes,
-                    const Data& data,
-                    std::vector<EOS_INTEGER>& table_handles,
-                    std::vector<double>& timings,
-                    std::vector<double>& throughputs,
-                    std::vector<Real>& errors) {
+void profile_eospac(int ncycles, const std::vector<int> &chunk_sizes, const Data &data,
+                    std::vector<EOS_INTEGER> &table_handles, std::vector<double> &timings,
+                    std::vector<double> &throughputs, std::vector<Real> &errors) {
 
   timings.clear();
   errors.clear();
@@ -267,134 +241,123 @@ void profile_eospac(int ncycles,
   std::vector<std::vector<Real>> Ts_out(nmats);
   std::vector<std::vector<EOS_REAL>> Ts_true;
 
-  for(int chunk_size : chunk_sizes) {
+  for (int chunk_size : chunk_sizes) {
     std::cout << "\t\t...chunk size = " << chunk_size << std::endl;
     auto time = get_duration([&]() {
-        for (int cycle = 0; cycle < ncycles; cycle++) {
+      for (int cycle = 0; cycle < ncycles; cycle++) {
 
-          std::vector<std::vector<EOS_REAL>> rhos;
-          std::vector<std::vector<EOS_REAL>> sies;
-          std::vector<std::vector<Real>> dx(nmats), dy(nmats);
-          filter_data_for_EOSPAC(data,rhos,sies,Ts_true);
-          npoints_tot = 0;
-          for (int m = 0; m < nmats; m++) {
-            int npoints_mat = rhos[m].size();
-            dx[m].resize(npoints_mat);
-            dy[m].resize(npoints_mat);
-            Ts_out[m].resize(npoints_mat);
-            npoints_tot += npoints_mat;
+        std::vector<std::vector<EOS_REAL>> rhos;
+        std::vector<std::vector<EOS_REAL>> sies;
+        std::vector<std::vector<Real>> dx(nmats), dy(nmats);
+        filter_data_for_EOSPAC(data, rhos, sies, Ts_true);
+        npoints_tot = 0;
+        for (int m = 0; m < nmats; m++) {
+          int npoints_mat = rhos[m].size();
+          dx[m].resize(npoints_mat);
+          dy[m].resize(npoints_mat);
+          Ts_out[m].resize(npoints_mat);
+          npoints_tot += npoints_mat;
+        }
+
+        for (int m = 0; m < nmats; m++) {
+          int size = rhos[m].size();
+          int stride = std::min(size, chunk_size);
+          int ncalls = rhos[m].size() / stride;
+          EOS_INTEGER nXYPairs = stride;
+          for (int c = 0; c < ncalls; c++) {
+            eosSafeInterpolate(&(table_handles[m]), nXYPairs, &(rhos[m][c * stride]),
+                               &(sies[m][c * stride]), &(Ts_out[m][c * stride]),
+                               &(dx[m][c * stride]), &(dy[m][c * stride]), "TofRE",
+                               false);
           }
-
-          for (int m = 0; m < nmats; m++) {
-            int size = rhos[m].size();
-            int stride = std::min(size,chunk_size);
-            int ncalls = rhos[m].size()/stride;
-            EOS_INTEGER nXYPairs = stride;
-            for (int c = 0; c < ncalls; c++) {
-              eosSafeInterpolate(&(table_handles[m]), nXYPairs,
-                                 &(rhos[m][c*stride]),
-                                 &(sies[m][c*stride]),
-                                 &(Ts_out[m][c*stride]),
-                                 &(dx[m][c*stride]),
-                                 &(dy[m][c*stride]),
-                                 "TofRE", false);
-            }
-            int n_leftover = rhos[m].size() - stride*ncalls;
-            if (n_leftover > 0) {
-              EOS_INTEGER nXYPairs = n_leftover;
-              int c = stride*ncalls;
-              eosSafeInterpolate(&(table_handles[m]), nXYPairs,
-                                 &(rhos[m][c]),
-                                 &(sies[m][c]),
-                                 &(Ts_out[m][c]),
-                                 &(dx[m][c]),
-                                 &(dy[m][c]),
-                                 "TofRE", false);
-            }
+          int n_leftover = rhos[m].size() - stride * ncalls;
+          if (n_leftover > 0) {
+            EOS_INTEGER nXYPairs = n_leftover;
+            int c = stride * ncalls;
+            eosSafeInterpolate(&(table_handles[m]), nXYPairs, &(rhos[m][c]),
+                               &(sies[m][c]), &(Ts_out[m][c]), &(dx[m][c]), &(dy[m][c]),
+                               "TofRE", false);
           }
         }
-      });
-    time /= (npoints_tot*ncycles);
+      }
+    });
+    time /= (npoints_tot * ncycles);
     timings.push_back(time);
 
-    auto throughput = 1./time;
+    auto throughput = 1. / time;
     throughputs.push_back(throughput);
-    
+
     Real L2_error = 0;
     int npoints = 0;
     for (int m = 0; m < nmats; m++) {
       for (int i = 0; i < Ts_true[m].size(); i++) {
         Real diff = Ts_out[m][i] - Ts_true[m][i];
-        Real denom = 0.5*(Ts_out[m][i] + Ts_true[m][i]);
-        L2_error += diff*diff/(denom*denom + 1e-20);
+        Real denom = 0.5 * (Ts_out[m][i] + Ts_true[m][i]);
+        L2_error += diff * diff / (denom * denom + 1e-20);
         npoints++;
       }
     }
-    L2_error = std::sqrt(L2_error/npoints);
+    L2_error = std::sqrt(L2_error / npoints);
     errors.push_back(L2_error);
   }
 }
 
-void profile_spiner_host(int ncycles,
-                         const std::vector<int>& chunk_sizes,
-                         Data& data,
-                         std::vector<EOS>& eos,
-                         std::vector<double>& timings,
-                         std::vector<double>& throughputs,
-                         std::vector<Real>& errors) {
+void profile_spiner_host(int ncycles, const std::vector<int> &chunk_sizes, Data &data,
+                         std::vector<EOS> &eos, std::vector<double> &timings,
+                         std::vector<double> &throughputs, std::vector<Real> &errors) {
   timings.clear();
   errors.clear();
   throughputs.clear();
 
-  int nmats = std::min((int)eos.size(),(int)data.rhos.dim(2));
+  int nmats = std::min((int)eos.size(), (int)data.rhos.dim(2));
   int ncells = data.rhos.dim(1);
 
   std::vector<Real> lambda_v(2);
-  Real* lambda = lambda_v.data();
+  Real *lambda = lambda_v.data();
 
-  DataBox Ts(nmats,ncells);
+  DataBox Ts(nmats, ncells);
 
-  for(int chunk_size : chunk_sizes) {
+  for (int chunk_size : chunk_sizes) {
     std::cout << "\t\t...chunk size = " << chunk_size << std::endl;
-    int stride = std::min(ncells,chunk_size);
-    int ncalls = ncells/stride;
-    auto time = get_duration([&](){
-        for (int cycle = 0; cycle < ncycles; cycle++) {
-          for (int m = 0; m < nmats; m++) {
-            for (int c = 0; c < ncalls; c++) {
-              int istart = c*stride;
-              #pragma omp simd
-              for (int i = 0; i < stride; i++) {
-                Real rho = data.rhos(m,istart+i);
-                Real sie = data.sies(m,istart+i);
-                if (data.vfracs(m,istart+i) > 0) {
-                  Ts(m,istart + i) = eos[m].TemperatureFromDensityInternalEnergy(rho,sie,
-                                                                                 lambda);
-                }
+    int stride = std::min(ncells, chunk_size);
+    int ncalls = ncells / stride;
+    auto time = get_duration([&]() {
+      for (int cycle = 0; cycle < ncycles; cycle++) {
+        for (int m = 0; m < nmats; m++) {
+          for (int c = 0; c < ncalls; c++) {
+            int istart = c * stride;
+#pragma omp simd
+            for (int i = 0; i < stride; i++) {
+              Real rho = data.rhos(m, istart + i);
+              Real sie = data.sies(m, istart + i);
+              if (data.vfracs(m, istart + i) > 0) {
+                Ts(m, istart + i) =
+                    eos[m].TemperatureFromDensityInternalEnergy(rho, sie, lambda);
               }
             }
-            int n_leftover = ncells - stride*ncalls;
-            if (n_leftover > 0) {
-              int istart = stride*ncalls;
-              #pragma omp simd
-              for (int i = 0; i < n_leftover; i++) {
-                Real rho = data.rhos(m,istart+i);
-                Real sie = data.sies(m,istart+i);
-                if (data.vfracs(m,istart+i) > 0) {
-                  Ts(m,istart + i) = eos[m].TemperatureFromDensityInternalEnergy(rho,sie,
-                                                                                 lambda);
-                }
+          }
+          int n_leftover = ncells - stride * ncalls;
+          if (n_leftover > 0) {
+            int istart = stride * ncalls;
+#pragma omp simd
+            for (int i = 0; i < n_leftover; i++) {
+              Real rho = data.rhos(m, istart + i);
+              Real sie = data.sies(m, istart + i);
+              if (data.vfracs(m, istart + i) > 0) {
+                Ts(m, istart + i) =
+                    eos[m].TemperatureFromDensityInternalEnergy(rho, sie, lambda);
               }
             }
           }
         }
-      });
-    time /= (ncells*ncycles);
+      }
+    });
+    time /= (ncells * ncycles);
     timings.push_back(time);
-    
-    auto throughput = 1./time;
+
+    auto throughput = 1. / time;
     throughputs.push_back(throughput);
-    
+
     // debug
     Real L2_error = 0;
     int npoints = 0;
@@ -402,29 +365,27 @@ void profile_spiner_host(int ncycles,
       for (int i = 0; i < ncells; i++) {
         // std::cout << "m,i = " << m << ", " << i << std::endl; // debug
         // std::cout << "vfrac = " << data.vfracs(m,i) << std::endl;
-        if (data.vfracs(m,i) > 0) {
-          Real diff = Ts(m,i) - data.Ts(i);
-          Real denom = 0.5*(Ts(m,i) + data.Ts(i));
-          L2_error += diff*diff/(denom*denom+1e-20);
+        if (data.vfracs(m, i) > 0) {
+          Real diff = Ts(m, i) - data.Ts(i);
+          Real denom = 0.5 * (Ts(m, i) + data.Ts(i));
+          L2_error += diff * diff / (denom * denom + 1e-20);
           npoints++;
         }
       }
     }
-    L2_error = std::sqrt(L2_error/npoints);
+    L2_error = std::sqrt(L2_error / npoints);
     errors.push_back(L2_error);
   }
 }
 
-void compare_eospac_to_spiner(Data& data,
-                              int m, int nside,
-                              const std::string& outname,
-                              std::vector<EOS_INTEGER>& table_handle,
-                              std::vector<EOS>& eos) {
+void compare_eospac_to_spiner(Data &data, int m, int nside, const std::string &outname,
+                              std::vector<EOS_INTEGER> &table_handle,
+                              std::vector<EOS> &eos) {
 
   std::cout << "\t\t...preparing data for EOSPAC" << std::endl;
   std::vector<std::vector<EOS_REAL>> rhos, sies, scratch;
 
-  filter_data_for_EOSPAC(data,rhos,sies,scratch);
+  filter_data_for_EOSPAC(data, rhos, sies, scratch);
 
   int ncells = rhos[m].size();
   Real rhoMin = densityFromSesame(*std::min_element(rhos[m].begin(), rhos[m].end()));
@@ -440,79 +401,72 @@ void compare_eospac_to_spiner(Data& data,
   std::vector<Real> Ts(ncells);
 
   std::cout << "\t\t...preparing histogram" << std::endl;
-  DataBox EOSPAC((nside+1),(nside-1));
-  DataBox Spiner((nside+1),(nside-1));
-  DataBox diffs((nside+1),(nside-1));
-  DataBox counts((nside+1),(nside-1));
-  EOSPAC.setRange(0,sieMin,sieMax,nside-1);
-  EOSPAC.setRange(1,rhoMin,rhoMax,nside+1);
+  DataBox EOSPAC((nside + 1), (nside - 1));
+  DataBox Spiner((nside + 1), (nside - 1));
+  DataBox diffs((nside + 1), (nside - 1));
+  DataBox counts((nside + 1), (nside - 1));
+  EOSPAC.setRange(0, sieMin, sieMax, nside - 1);
+  EOSPAC.setRange(1, rhoMin, rhoMax, nside + 1);
   Spiner.copyMetadata(EOSPAC);
   diffs.copyMetadata(EOSPAC);
   counts.copyMetadata(EOSPAC);
   for (int j = 0; j < EOSPAC.dim(2); j++) {
     for (int i = 0; i < EOSPAC.dim(1); i++) {
-      counts(j,i) = Spiner(j,i) = EOSPAC(j,i) = 0;
+      counts(j, i) = Spiner(j, i) = EOSPAC(j, i) = 0;
     }
   }
 
   std::cout << "\t\t...interpolating EOSPAC" << std::endl;
   EOS_INTEGER nXYPairs = ncells;
-  eosSafeInterpolate(&(table_handle[m]), nXYPairs,
-                     rhos[m].data(), sies[m].data(),
-                     Ts.data(), dx.data(), dy.data(),
-                     "TofRE", false);
+  eosSafeInterpolate(&(table_handle[m]), nXYPairs, rhos[m].data(), sies[m].data(),
+                     Ts.data(), dx.data(), dy.data(), "TofRE", false);
 
   std::cout << "\t\t...interpolating spiner" << std::endl;
   std::vector<Real> lambda_v(2);
-  Real* lambda = lambda_v.data();
+  Real *lambda = lambda_v.data();
   for (int i = 0; i < ncells; i++) {
     double rho = densityFromSesame(rhos[m][i]);
     double sie = sieFromSesame(sies[m][i]);
     int irho = EOSPAC.range(1).index(rho);
     int ie = EOSPAC.range(0).index(sie);
     Real TPAC = temperatureFromSesame(Ts[i]);
-    Real TSP  = eos[m].TemperatureFromDensityInternalEnergy(rho,sie,lambda);
+    Real TSP = eos[m].TemperatureFromDensityInternalEnergy(rho, sie, lambda);
     Real diff = TPAC - TSP;
-    EOSPAC(irho,ie) += TPAC;
-    Spiner(irho,ie) += TSP;
-    diffs(irho,ie) += diff*diff;
+    EOSPAC(irho, ie) += TPAC;
+    Spiner(irho, ie) += TSP;
+    diffs(irho, ie) += diff * diff;
     counts(irho, ie) += 1;
   }
 
   std::cout << "\t\t...finishing histogram" << std::endl;
   for (int j = 0; j < EOSPAC.dim(2); j++) {
     for (int i = 0; i < EOSPAC.dim(1); i++) {
-      EOSPAC(j,i) /= (counts(j,i) + 1e-20);
-      Spiner(j,i) /= (counts(j,i) + 1e-20);
-      if (diffs(j,i) > 0) {
-        diffs(j,i) = std::sqrt(diffs(j,i)/counts(j,i) + 1e-20);
+      EOSPAC(j, i) /= (counts(j, i) + 1e-20);
+      Spiner(j, i) /= (counts(j, i) + 1e-20);
+      if (diffs(j, i) > 0) {
+        diffs(j, i) = std::sqrt(diffs(j, i) / counts(j, i) + 1e-20);
       }
     }
   }
 
-  std::cout << "\t\t...saving to file "
-            << outname
-            << std::endl;
+  std::cout << "\t\t...saving to file " << outname << std::endl;
   herr_t status = H5_SUCCESS;
-  hid_t file = H5Fcreate(outname.c_str(), H5F_ACC_TRUNC,H5P_DEFAULT,H5P_DEFAULT);
-  status += EOSPAC.saveHDF(file,"EOSPAC");
-  status += Spiner.saveHDF(file,"Spiner");
-  status += diffs.saveHDF(file,"diffs");
+  hid_t file = H5Fcreate(outname.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  status += EOSPAC.saveHDF(file, "EOSPAC");
+  status += Spiner.saveHDF(file, "Spiner");
+  status += diffs.saveHDF(file, "diffs");
   status += H5Fclose(file);
   std::cout << "\t\t...Saved" << std::endl;
-
 }
 
-void make_table_sim_data(std::ostream& out,
-                              const std::string& dumpname,
-                              int ncycles,
-                              const std::vector<int>& chunk_sizes,
-                              const std::vector<Real>& errors_eospac,
-                              const std::vector<Real>& errors_spiner,
-                              const std::vector<double>& timings_eospac,
-                              const std::vector<double>& timings_spiner,
-                              const std::vector<double>& throughputs_eospac,
-                              const std::vector<double>& throughputs_spiner) { 
+void make_table_sim_data(std::ostream &out, const std::string &dumpname, int ncycles,
+                         const std::vector<int> &chunk_sizes,
+                         const std::vector<Real> &errors_eospac,
+                         const std::vector<Real> &errors_spiner,
+                         const std::vector<double> &timings_eospac,
+                         const std::vector<double> &timings_spiner,
+                         const std::vector<double> &throughputs_eospac,
+                         const std::vector<double> &throughputs_spiner) {
   out << "# input file = " << dumpname << "\n"
       << "# ncyles = " << ncycles << "\n"
       << "# Setup: 1 dump, 1 CPU. Compare EOSPAC to Spiner performance\n"
@@ -522,28 +476,17 @@ void make_table_sim_data(std::ostream& out,
       << "# [3]: time/point EOSPAC (microseconds/zone-cycle)\n"
       << "# [4]: time/point Spiner (microseconds/zone-cycle)\n"
       << "# [5]: throughput for EOSPAC (zone-cycles/cpu-second)\n"
-      << "# [6]: throughput for Spiner (zone-cycles/cpu-second)"
-      << std::endl;
+      << "# [6]: throughput for Spiner (zone-cycles/cpu-second)" << std::endl;
   for (int i = 0; i < chunk_sizes.size(); i++) {
-    out << std::setw(20)
-        << chunk_sizes[i] << "\t"
-        << std::setw(20)
-        << errors_eospac[i] << "\t"
-        << std::setw(20)
-        << errors_spiner[i] << "\t"
-        << std::setw(20)
-        << 1e6*timings_eospac[i] << "\t"
-        << std::setw(20)
-        << 1e6*timings_spiner[i] << "\t"
-        << std::setw(20)
-        << throughputs_eospac[i] << "\t"
-        << std::setw(20)
-        << throughputs_spiner[i]
-        << std::endl;
+    out << std::setw(20) << chunk_sizes[i] << "\t" << std::setw(20) << errors_eospac[i]
+        << "\t" << std::setw(20) << errors_spiner[i] << "\t" << std::setw(20)
+        << 1e6 * timings_eospac[i] << "\t" << std::setw(20) << 1e6 * timings_spiner[i]
+        << "\t" << std::setw(20) << throughputs_eospac[i] << "\t" << std::setw(20)
+        << throughputs_spiner[i] << std::endl;
   }
 }
 
-void compare_on_sim_data(int ncycles, const std::vector<int>& chunk_sizes) {
+void compare_on_sim_data(int ncycles, const std::vector<int> &chunk_sizes) {
   std::vector<int> matids = {5030, 3337, 4272, 90003, 95501};
   std::string dumpname = "/scratch/users/jonahm/eap/sim_data_dumps/SimData-dmp000605.txt";
   std::string spiner_fname = "../utils/sesame2spiner/sim-data-materials.sp5";
@@ -554,24 +497,22 @@ void compare_on_sim_data(int ncycles, const std::vector<int>& chunk_sizes) {
   std::cout << "Comparing on sim data.." << std::endl;
 
   std::cout << "\t...loading data" << std::endl;
-  load_data(dumpname,data_h);
+  load_data(dumpname, data_h);
 
   std::cout << "\t...loading tables" << std::endl;
   load_eospac_tables(matids, table_handles);
-  load_eos_spiner(spiner_fname,matids,eos_h,eos_d);
+  load_eos_spiner(spiner_fname, matids, eos_h, eos_d);
   Data data_d = data_h.GetOnDevice();
- 
+
   std::cout << "\t...We have " << data_h.rhos.dim(2) << " materials\n"
             << "\t\t...but we only operate on " << eos_h.size() << " of them.\n"
-            << "\t...We have " << data_h.rhos.dim(1) << " cells."
-            << std::endl;
+            << "\t...We have " << data_h.rhos.dim(1) << " cells." << std::endl;
 
   std::cout << "\t...root finding with EOSPAC" << std::endl;
   std::vector<double> timings_eospac, throughputs_eospac;
   std::vector<Real> errors_eospac;
-  profile_eospac(ncycles, chunk_sizes, data_h,
-                 table_handles,
-                 timings_eospac, throughputs_eospac,  errors_eospac);
+  profile_eospac(ncycles, chunk_sizes, data_h, table_handles, timings_eospac,
+                 throughputs_eospac, errors_eospac);
 
   /*
   std::cout << "#chunk\terrors\ttimings\tthroughputs" << std::endl;
@@ -588,9 +529,7 @@ void compare_on_sim_data(int ncycles, const std::vector<int>& chunk_sizes) {
   std::cout << "\t...root finding with spiner on 1 CPU" << std::endl;
   std::vector<double> timings_host, throughputs_host;
   std::vector<Real> errors_host;
-  profile_spiner_host(ncycles, chunk_sizes,
-                      data_h, eos_h,
-                      timings_host, throughputs_host,
+  profile_spiner_host(ncycles, chunk_sizes, data_h, eos_h, timings_host, throughputs_host,
                       errors_host);
 
   /*
@@ -604,16 +543,13 @@ void compare_on_sim_data(int ncycles, const std::vector<int>& chunk_sizes) {
               << std::endl;
   }
   */
-  make_table_sim_data(std::cout,dumpname,ncycles,chunk_sizes,
-                           errors_eospac,errors_host,
-                           timings_eospac,timings_host,
-                           throughputs_eospac,throughputs_host);
+  make_table_sim_data(std::cout, dumpname, ncycles, chunk_sizes, errors_eospac,
+                      errors_host, timings_eospac, timings_host, throughputs_eospac,
+                      throughputs_host);
   std::ofstream outfile;
   outfile.open("sim_data_timings.dat", std::ios::out | std::ios::trunc);
-  make_table_sim_data(outfile,dumpname,ncycles,chunk_sizes,
-                           errors_eospac,errors_host,
-                           timings_eospac,timings_host,
-                           throughputs_eospac,throughputs_host);
+  make_table_sim_data(outfile, dumpname, ncycles, chunk_sizes, errors_eospac, errors_host,
+                      timings_eospac, timings_host, throughputs_eospac, throughputs_host);
   outfile.close();
 
   data_d.Finalize();
@@ -621,10 +557,8 @@ void compare_on_sim_data(int ncycles, const std::vector<int>& chunk_sizes) {
     eos_d[m].Finalize();
   }
 
-  std::cout << "\t...comparing EOSPAC output to Spiner in histogram..."
-            << std::endl;
-  compare_eospac_to_spiner(data_h, 2, 256, "sim_data_diffs.sp5",
-                           table_handles, eos_h);
+  std::cout << "\t...comparing EOSPAC output to Spiner in histogram..." << std::endl;
+  compare_eospac_to_spiner(data_h, 2, 256, "sim_data_diffs.sp5", table_handles, eos_h);
 }
 
 int main() {
@@ -632,7 +566,7 @@ int main() {
   // compare_on_sim_data(100, {1, 8, 64, 512, 4096, 32768, 262144, 75449});
   compare_on_sim_data(20, {1, 8, 64, 512, 4096, 32768, 262144, 755449});
   // compare_on_sim_data(1, {4096});
-  
+
   return 0;
 }
 

--- a/test/compare_on_dataset.cpp
+++ b/test/compare_on_dataset.cpp
@@ -19,7 +19,6 @@
   Copyright: LANL
  */
 
-
 #ifdef SPINER_USE_HDF
 #ifdef SINGULARITY_USE_EOSPAC
 
@@ -53,24 +52,24 @@ using duration = std::chrono::duration<long double>;
 using dvec = std::vector<double>;
 using ivec = std::vector<int>;
 using Spiner::DataBox;
-using Spiner::RegularGrid1D;
 using Spiner::getOnDeviceDataBox;
+using Spiner::RegularGrid1D;
 
 using BEOS = SpinerEOSDependsRhoT;
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-using RView = Kokkos::View<Real*>;
+using RView = Kokkos::View<Real *>;
 using RMirror = typename RView::HostMirror;
 using KokkosAtomic = Kokkos::MemoryTraits<Kokkos::Atomic>;
 #endif
 
 const std::vector<int> matids = {
-  5762, // He4
-  3720, // Aluminum
-  7592, // CH cushion
-  2024, // Be Tamper
-  3070, // Cr inner shell
-  1018, // DT
+    5762, // He4
+    3720, // Aluminum
+    7592, // CH cushion
+    2024, // Be Tamper
+    3070, // Cr inner shell
+    1018, // DT
 };
 const int nmats = matids.size();
 const std::string spiner_fname = "../utils/sesame2spiner/dataset-materials.sp5";
@@ -90,67 +89,59 @@ struct Data {
     return other;
   }
   void Finalize() {
-    #ifdef PORTABILITY_STRATEGY_KOKKOS
+#ifdef PORTABILITY_STRATEGY_KOKKOS
     using HS = Kokkos::HostSpace;
     using DMS = Kokkos::DefaultExecutionSpace::memory_space;
-    constexpr const bool execution_is_host {std::is_same<DMS,HS>::value};
+    constexpr const bool execution_is_host{std::is_same<DMS, HS>::value};
     if (!execution_is_host && onDevice) {
       PORTABLE_FREE(rhos.data());
       PORTABLE_FREE(sies.data());
       PORTABLE_FREE(vfracs.data());
       PORTABLE_FREE(Ts.data());
     }
-    #endif
+#endif
   }
 };
 
-inline auto now() {
-  return std::chrono::high_resolution_clock::now();
-}
+inline auto now() { return std::chrono::high_resolution_clock::now(); }
 
-template<typename Function>
+template <typename Function>
 inline auto get_duration(Function function) {
   auto start = now();
   function();
   auto stop = now();
-  return std::chrono::duration_cast<duration>(stop-start).count();
+  return std::chrono::duration_cast<duration>(stop - start).count();
 }
 
-void load_data(const std::string& filename, Data& d);
-void filter_data_for_EOSPAC(const Data& d_in,
-                            std::vector<std::vector<EOS_REAL>>& rhos,
-                            std::vector<std::vector<EOS_REAL>>& sies,
-                            std::vector<std::vector<EOS_REAL>>& Ts);
-void load_eospac_tables(const std::vector<int>& matids,
-                        std::vector<EOS_INTEGER>& table_handles);
-void load_eos_spiner(const std::string& filename,
-                     const std::vector<int>& matids,
-                     std::vector<BEOS>& eos_h,
-                     std::vector<BEOS>& eos_d);
-void getDataSetBounds(const PortableMDArray<Data>& data,
-                      RegularGrid1D& rhoBounds,
-                      RegularGrid1D& sieBounds);
-double profile_eospac(const PortableMDArray<Data>& data,
-                      std::vector<EOS_INTEGER>& table_handles,
-                      DataBox& hist_EOSPAC);
-double profile_spiner_host(const PortableMDArray<Data>& data,
-                           PortableMDArray<BEOS>& eos,
-                           DataBox& hist);
-double profile_spiner_device(const PortableMDArray<Data>& data,
-                             PortableMDArray<BEOS>& eos,
-                             const int npoints,
-                             DataBox& hist);
-void save_histograms(DataBox& EOSPAC, DataBox& spiner_h, DataBox& spiner_hm);
+void load_data(const std::string &filename, Data &d);
+void filter_data_for_EOSPAC(const Data &d_in, std::vector<std::vector<EOS_REAL>> &rhos,
+                            std::vector<std::vector<EOS_REAL>> &sies,
+                            std::vector<std::vector<EOS_REAL>> &Ts);
+void load_eospac_tables(const std::vector<int> &matids,
+                        std::vector<EOS_INTEGER> &table_handles);
+void load_eos_spiner(const std::string &filename, const std::vector<int> &matids,
+                     std::vector<BEOS> &eos_h, std::vector<BEOS> &eos_d);
+void getDataSetBounds(const PortableMDArray<Data> &data, RegularGrid1D &rhoBounds,
+                      RegularGrid1D &sieBounds);
+double profile_eospac(const PortableMDArray<Data> &data,
+                      std::vector<EOS_INTEGER> &table_handles, DataBox &hist_EOSPAC);
+double profile_spiner_host(const PortableMDArray<Data> &data, PortableMDArray<BEOS> &eos,
+                           DataBox &hist);
+double profile_spiner_device(const PortableMDArray<Data> &data,
+                             PortableMDArray<BEOS> &eos, const int npoints,
+                             DataBox &hist);
+void save_histograms(DataBox &EOSPAC, DataBox &spiner_h, DataBox &spiner_hm);
 
-inline void set_zero(DataBox& d) {
-  for (int i = 0; i < d.size(); i++) d(i) = 0;
+inline void set_zero(DataBox &d) {
+  for (int i = 0; i < d.size(); i++)
+    d(i) = 0;
 }
-inline void normalize_hist(DataBox& hist, DataBox& counts) {
+inline void normalize_hist(DataBox &hist, DataBox &counts) {
   for (int m = 0; m < hist.dim(3); m++) {
     for (int j = 0; j < hist.dim(2); j++) {
       for (int i = 0; i < hist.dim(1); i++) {
-        if (counts(m,j,i) > 0) {
-          hist(m,j,i) /= (counts(m,j,i) + 1e-5);
+        if (counts(m, j, i) > 0) {
+          hist(m, j, i) /= (counts(m, j, i) + 1e-5);
         }
       }
     }
@@ -159,10 +150,10 @@ inline void normalize_hist(DataBox& hist, DataBox& counts) {
 
 // ======================================================================
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  Kokkos::initialize(argc,argv);
+  Kokkos::initialize(argc, argv);
 #endif
   {
     if (argc <= 1) {
@@ -174,9 +165,9 @@ int main(int argc, char* argv[]) {
 
     int nfiles = argc - 1;
     std::vector<Data> data_h_vec(nfiles);
-    PortableMDArray<Data> data_h(data_h_vec.data(),nfiles);
+    PortableMDArray<Data> data_h(data_h_vec.data(), nfiles);
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-    Kokkos::View<Data*> data_dv("data",nfiles);
+    Kokkos::View<Data *> data_dv("data", nfiles);
     auto data_hm = Kokkos::create_mirror_view(data_dv);
     PortableMDArray<Data> data_d(data_dv.data(), nfiles);
 #else
@@ -184,25 +175,23 @@ int main(int argc, char* argv[]) {
     data_d = data_h; // shallow copies of data_h
     data_hm = data_h;
 #endif
-    
+
     std::cout << "Loading files..." << std::endl;
     // must convert to std::string to sort since strings
     // are comparable and char[] are not.
     std::vector<std::string> infiles(nfiles);
-    for (int i = 1;  i < argc; i++) {
-      infiles[i-1] = argv[i];
+    for (int i = 1; i < argc; i++) {
+      infiles[i - 1] = argv[i];
     }
     std::sort(infiles.begin(), infiles.end());
     for (int i = 0; i < nfiles; i++) {
       std::cout << "\t..." << argv[i] << std::endl;
       load_data(infiles[i], data_h(i));
     }
-    
-    std::cout << "The data contains " << data_h(0).rhos.dim(2)
-              << " materials.\n"
-              << "\tWe are using " << matids.size() << " materials."
-              << std::endl;
-    
+
+    std::cout << "The data contains " << data_h(0).rhos.dim(2) << " materials.\n"
+              << "\tWe are using " << matids.size() << " materials." << std::endl;
+
     std::cout << "Moving data to device..." << std::endl;
     for (int i = 0; i < argc - 1; i++) {
       data_hm(i) = data_h(i).GetOnDevice();
@@ -210,20 +199,20 @@ int main(int argc, char* argv[]) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
     Kokkos::deep_copy(data_dv, data_hm);
 #endif
-    
+
     std::cout << "Loading tables.." << std::endl;
     std::vector<EOS_INTEGER> table_handles;
     std::vector<BEOS> eos_h_vec, eos_hm_vec;
     load_eospac_tables(matids, table_handles);
-    load_eos_spiner(spiner_fname,matids,eos_h_vec,eos_hm_vec);
-    PortableMDArray<BEOS> eos_h(eos_h_vec.data(),eos_h_vec.size());
+    load_eos_spiner(spiner_fname, matids, eos_h_vec, eos_hm_vec);
+    PortableMDArray<BEOS> eos_h(eos_h_vec.data(), eos_h_vec.size());
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-    Kokkos::View<BEOS*> eos_dv("eos",eos_h_vec.size());
+    Kokkos::View<BEOS *> eos_dv("eos", eos_h_vec.size());
     auto eos_hm = Kokkos::create_mirror_view(eos_dv);
     for (int m = 0; m < eos_hm_vec.size(); m++) {
       eos_hm(m) = eos_hm_vec[m];
     }
-    Kokkos::deep_copy(eos_dv,eos_hm);
+    Kokkos::deep_copy(eos_dv, eos_hm);
     PortableMDArray<BEOS> eos_d(eos_dv.data(), eos_h_vec.size());
 #else
     PortableMDArray<BEOS> eos_d(eos_h.data(), eos_h_vec.size());
@@ -233,24 +222,18 @@ int main(int argc, char* argv[]) {
     RegularGrid1D rhoBounds, sieBounds;
     getDataSetBounds(data_h, rhoBounds, sieBounds);
     std::cout << "Bounds are:\n"
-              << "\trho: ["
-              << rhoBounds.min() << ", " << rhoBounds.max()
-              << "]\n"
-              << "\tsie: ["
-              << sieBounds.min() << ", " << sieBounds.max()
-              << "]"
+              << "\trho: [" << rhoBounds.min() << ", " << rhoBounds.max() << "]\n"
+              << "\tsie: [" << sieBounds.min() << ", " << sieBounds.max() << "]"
               << std::endl;
 
-
-
     std::cout << "Profiling EOSPAC..." << std::endl;
-    DataBox hist_EOSPAC(nmats, HIST_NSIDE+1, HIST_NSIDE-1);
+    DataBox hist_EOSPAC(nmats, HIST_NSIDE + 1, HIST_NSIDE - 1);
     hist_EOSPAC.setRange(0, sieBounds);
     hist_EOSPAC.setRange(1, rhoBounds);
     double t_EOSPAC = profile_eospac(data_h, table_handles, hist_EOSPAC);
 
     std::cout << "Profiling spiner on host..." << std::endl;
-    DataBox hist_spiner_h(nmats, HIST_NSIDE+1, HIST_NSIDE-1);
+    DataBox hist_spiner_h(nmats, HIST_NSIDE + 1, HIST_NSIDE - 1);
     hist_spiner_h.setRange(0, sieBounds);
     hist_spiner_h.setRange(1, rhoBounds);
     double t_spiner_h = profile_spiner_host(data_h, eos_h, hist_spiner_h);
@@ -258,39 +241,38 @@ int main(int argc, char* argv[]) {
     // TODO: implement me
     std::cout << "Profiling spiner on device..." << std::endl;
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-    Kokkos::View<Real*,KokkosAtomic>
-      hist_spiner_dv("hist", nmats*(HIST_NSIDE+1)*(HIST_NSIDE-1));
+    Kokkos::View<Real *, KokkosAtomic> hist_spiner_dv("hist", nmats * (HIST_NSIDE + 1) *
+                                                                  (HIST_NSIDE - 1));
     auto hist_spiner_hmv = Kokkos::create_mirror_view(hist_spiner_dv);
-    DataBox hist_spiner_d(hist_spiner_dv.data(),nmats, HIST_NSIDE+1, HIST_NSIDE-1);
-    DataBox hist_spiner_hm(hist_spiner_hmv.data(),nmats, HIST_NSIDE+1, HIST_NSIDE-1);
+    DataBox hist_spiner_d(hist_spiner_dv.data(), nmats, HIST_NSIDE + 1, HIST_NSIDE - 1);
+    DataBox hist_spiner_hm(hist_spiner_hmv.data(), nmats, HIST_NSIDE + 1, HIST_NSIDE - 1);
 #else
-    DataBox hist_spiner_d(nmats, HIST_NSIDE+1, HIST_NSIDE-1);
-    DataBox hist_spiner_hm(hist_spiner_d.data(),nmats, HIST_NSIDE+1, HIST_NSIDE-1);
+    DataBox hist_spiner_d(nmats, HIST_NSIDE + 1, HIST_NSIDE - 1);
+    DataBox hist_spiner_hm(hist_spiner_d.data(), nmats, HIST_NSIDE + 1, HIST_NSIDE - 1);
 #endif
     hist_spiner_d.setRange(0, sieBounds);
     hist_spiner_d.setRange(1, rhoBounds);
     hist_spiner_hm.setRange(0, sieBounds);
     hist_spiner_hm.setRange(1, rhoBounds);
-    double t_spiner_d = profile_spiner_device(data_d, eos_d,
-                                              data_h(0).rhos.dim(1),
-                                              hist_spiner_d);
+    double t_spiner_d =
+        profile_spiner_device(data_d, eos_d, data_h(0).rhos.dim(1), hist_spiner_d);
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-    Kokkos::deep_copy(hist_spiner_hmv,hist_spiner_dv);
+    Kokkos::deep_copy(hist_spiner_hmv, hist_spiner_dv);
 #endif
-    
+
     std::cout << "Saving to file..." << std::endl;
     save_histograms(hist_EOSPAC, hist_spiner_h, hist_spiner_hm);
     std::cout << "Saved." << std::endl;
 
     std::cout << "\nTimings (microseconds/zone-cycle):\n"
-              << "\tEOSPAC        = " << 1e6*t_EOSPAC << "\n"
-              << "\tspiner host   = " << 1e6*t_spiner_h << "\n"
-              << "\tspiner device = " << 1e6*t_spiner_d << "\n"
+              << "\tEOSPAC        = " << 1e6 * t_EOSPAC << "\n"
+              << "\tspiner host   = " << 1e6 * t_spiner_h << "\n"
+              << "\tspiner device = " << 1e6 * t_spiner_d << "\n"
               << "\nThroughput (zone-cycles/second):\n"
-              << "\tEOSPAC        = " << 1./t_EOSPAC << "\n"
-              << "\tspiner host   = " << 1./t_spiner_h << "\n"
-              << "\tspiner device = " << 1./t_spiner_d << "\n"
+              << "\tEOSPAC        = " << 1. / t_EOSPAC << "\n"
+              << "\tspiner host   = " << 1. / t_spiner_h << "\n"
+              << "\tspiner device = " << 1. / t_spiner_d << "\n"
               << std::endl;
 
     for (int m = 0; m < nmats; m++) {
@@ -303,13 +285,13 @@ int main(int argc, char* argv[]) {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   Kokkos::finalize();
 #endif
-  
+
   return 0;
 }
 
 // ======================================================================
 
-void load_data(const std::string& filename, Data& d) {
+void load_data(const std::string &filename, Data &d) {
 
   std::vector<std::vector<Real>> matrix;
 
@@ -318,8 +300,8 @@ void load_data(const std::string& filename, Data& d) {
 
   file.open(filename, std::ios::in);
   {
-    std::getline(file,line); // first line
-    while( std::getline(file, line) ) {
+    std::getline(file, line); // first line
+    while (std::getline(file, line)) {
       std::stringstream ss(line);
       std::vector<Real> row;
       Real val;
@@ -333,24 +315,24 @@ void load_data(const std::string& filename, Data& d) {
 
   d.Ts.resize(matrix.size());
   for (int i = 0; i < matrix.size(); i++) {
-    int j = matrix[i].size()-4;
+    int j = matrix[i].size() - 4;
     d.Ts(i) = matrix[i][j];
   }
 
   int stride = 3;
-  int nmats = (matrix[0].size() - 4)/stride;
-  d.rhos.resize(nmats,matrix.size());
-  d.sies.resize(nmats,matrix.size());
-  d.vfracs.resize(nmats,matrix.size());
+  int nmats = (matrix[0].size() - 4) / stride;
+  d.rhos.resize(nmats, matrix.size());
+  d.sies.resize(nmats, matrix.size());
+  d.vfracs.resize(nmats, matrix.size());
   for (int i = 0; i < matrix.size(); i++) {
     for (int mat = 0; mat < nmats; mat++) {
-      Real frac_mass = matrix[i][mat*stride];
-      Real frac_vol = matrix[i][mat*stride+1];
-      Real frac_eng = matrix[i][mat*stride+2];
-      d.rhos(mat,i) = frac_vol > 0 ? frac_mass/(frac_vol+1e-5) : 0;
+      Real frac_mass = matrix[i][mat * stride];
+      Real frac_vol = matrix[i][mat * stride + 1];
+      Real frac_eng = matrix[i][mat * stride + 2];
+      d.rhos(mat, i) = frac_vol > 0 ? frac_mass / (frac_vol + 1e-5) : 0;
       // if (d.rhos(mat,i) < 1e-5) d.rhos(mat,i) = 1e-5;
-      d.sies(mat,i) = frac_mass > 0 ? frac_eng/(frac_mass+1e-5) : 0;
-      d.vfracs(mat,i) = frac_vol;
+      d.sies(mat, i) = frac_mass > 0 ? frac_eng / (frac_mass + 1e-5) : 0;
+      d.vfracs(mat, i) = frac_vol;
     }
   }
 
@@ -358,10 +340,9 @@ void load_data(const std::string& filename, Data& d) {
 }
 
 // this one must be ragged
-void filter_data_for_EOSPAC(const Data& d_in,
-                            std::vector<std::vector<EOS_REAL>>& rhos,
-                            std::vector<std::vector<EOS_REAL>>& sies,
-                            std::vector<std::vector<EOS_REAL>>& Ts) {
+void filter_data_for_EOSPAC(const Data &d_in, std::vector<std::vector<EOS_REAL>> &rhos,
+                            std::vector<std::vector<EOS_REAL>> &sies,
+                            std::vector<std::vector<EOS_REAL>> &Ts) {
   int nmats = d_in.rhos.dim(2);
   int ncells_tot = d_in.rhos.dim(1);
   rhos.resize(nmats);
@@ -370,16 +351,16 @@ void filter_data_for_EOSPAC(const Data& d_in,
   for (int mat = 0; mat < nmats; mat++) {
     int cell_count = 0;
     for (int i = 0; i < ncells_tot; i++) {
-      cell_count += (d_in.vfracs(mat,i) > 0) ? 1 : 0;
+      cell_count += (d_in.vfracs(mat, i) > 0) ? 1 : 0;
     }
     rhos[mat].resize(cell_count);
     sies[mat].resize(cell_count);
     Ts[mat].resize(cell_count);
     int c = 0;
     for (int i = 0; i < ncells_tot; i++) {
-      if (d_in.vfracs(mat,i) > 0) {
-        rhos[mat][c] = densityToSesame(d_in.rhos(mat,i));
-        sies[mat][c] = sieToSesame(d_in.sies(mat,i));
+      if (d_in.vfracs(mat, i) > 0) {
+        rhos[mat][c] = densityToSesame(d_in.rhos(mat, i));
+        sies[mat][c] = sieToSesame(d_in.sies(mat, i));
         Ts[mat][c] = temperatureToSesame(d_in.Ts(i));
         c++;
       }
@@ -387,8 +368,8 @@ void filter_data_for_EOSPAC(const Data& d_in,
   }
 }
 
-void load_eospac_tables(const std::vector<int>& matids,
-                        std::vector<EOS_INTEGER>& table_handles) {
+void load_eospac_tables(const std::vector<int> &matids,
+                        std::vector<EOS_INTEGER> &table_handles) {
   constexpr EOS_INTEGER NTABLES = 1;
   EOS_INTEGER tableType[] = {EOS_T_DUt};
 
@@ -398,22 +379,19 @@ void load_eospac_tables(const std::vector<int>& matids,
   }
 }
 
-void load_eos_spiner(const std::string& filename,
-                     const std::vector<int>& matids,
-                     std::vector<BEOS>& eos_h,
-                     std::vector<BEOS>& eos_d) {
+void load_eos_spiner(const std::string &filename, const std::vector<int> &matids,
+                     std::vector<BEOS> &eos_h, std::vector<BEOS> &eos_d) {
   eos_h.clear();
   eos_d.clear();
   for (int matid : matids) {
     if (matid <= 0) continue;
-    eos_h.push_back(SpinerEOSDependsRhoT(filename,matid,false));
+    eos_h.push_back(SpinerEOSDependsRhoT(filename, matid, false));
     eos_d.push_back(eos_h.back().GetOnDevice());
   }
 }
 
-void getDataSetBounds(const PortableMDArray<Data>& data,
-                      RegularGrid1D& rhoBounds,
-                      RegularGrid1D& sieBounds) {
+void getDataSetBounds(const PortableMDArray<Data> &data, RegularGrid1D &rhoBounds,
+                      RegularGrid1D &sieBounds) {
   const int nfiles = data.GetDim1();
   Real rhoMinAll = std::numeric_limits<Real>::infinity();
   Real rhoMaxAll = -std::numeric_limits<Real>::infinity();
@@ -424,8 +402,8 @@ void getDataSetBounds(const PortableMDArray<Data>& data,
     auto rhoLast = rhoFirst + data(n).rhos.size();
     Real rhoMin = *std::min_element(rhoFirst, rhoLast);
     Real rhoMax = *std::max_element(rhoFirst, rhoLast);
-    rhoMinAll = std::min(rhoMin,rhoMinAll);
-    rhoMaxAll = std::max(rhoMax,rhoMaxAll);
+    rhoMinAll = std::min(rhoMin, rhoMinAll);
+    rhoMaxAll = std::max(rhoMax, rhoMaxAll);
 
     auto sieFirst = data(n).sies.data();
     auto sieLast = sieFirst + data(n).sies.size();
@@ -434,13 +412,12 @@ void getDataSetBounds(const PortableMDArray<Data>& data,
     sieMinAll = std::min(sieMin, sieMinAll);
     sieMaxAll = std::max(sieMax, sieMaxAll);
   }
-  rhoBounds = RegularGrid1D(rhoMinAll, rhoMaxAll, HIST_NSIDE+1);
-  sieBounds = RegularGrid1D(sieMinAll, sieMaxAll, HIST_NSIDE-1);
+  rhoBounds = RegularGrid1D(rhoMinAll, rhoMaxAll, HIST_NSIDE + 1);
+  sieBounds = RegularGrid1D(sieMinAll, sieMaxAll, HIST_NSIDE - 1);
 }
 
-double profile_eospac(const PortableMDArray<Data>& data,
-                      std::vector<EOS_INTEGER>& table_handles,
-                      DataBox& hist_EOSPAC) {
+double profile_eospac(const PortableMDArray<Data> &data,
+                      std::vector<EOS_INTEGER> &table_handles, DataBox &hist_EOSPAC) {
 
   const int ndumps = data.GetDim1();
   const int nmats = table_handles.size();
@@ -457,39 +434,36 @@ double profile_eospac(const PortableMDArray<Data>& data,
   set_zero(counts);
 
   auto time = get_duration([&]() {
-      for (int d = 0; d < ndumps; d++) {
-        filter_data_for_EOSPAC(data(d),rhos,sies,Ts_true);
-        for (int m = 0; m < nmats; m++) {
-          int npoints_mat = rhos[m].size();
-          dx[m].resize(npoints_mat);
-          dy[m].resize(npoints_mat);
-          Ts_out[m].resize(npoints_mat);
+    for (int d = 0; d < ndumps; d++) {
+      filter_data_for_EOSPAC(data(d), rhos, sies, Ts_true);
+      for (int m = 0; m < nmats; m++) {
+        int npoints_mat = rhos[m].size();
+        dx[m].resize(npoints_mat);
+        dy[m].resize(npoints_mat);
+        Ts_out[m].resize(npoints_mat);
 
-          EOS_INTEGER nXYPairs = npoints_mat;
-          eosSafeInterpolate(&(table_handles[m]), nXYPairs,
-                             &(rhos[m][0]), &(sies[m][0]), &(Ts_out[m][0]),
-                             &(dx[m][0]), &(dy[m][0]),
-                             "TofRE", false);
+        EOS_INTEGER nXYPairs = npoints_mat;
+        eosSafeInterpolate(&(table_handles[m]), nXYPairs, &(rhos[m][0]), &(sies[m][0]),
+                           &(Ts_out[m][0]), &(dx[m][0]), &(dy[m][0]), "TofRE", false);
 
-          for (int i = 0; i < npoints_mat; i++) {
-            Real rho = densityFromSesame(rhos[m][i]);
-            Real sie = sieFromSesame(sies[m][i]);
-            Real T = temperatureFromSesame(Ts_out[m][i]);
-            int iRho = rhoBounds.index(rho);
-            int iSie = sieBounds.index(sie);
-            hist_EOSPAC(m,iRho,iSie) += T;
-            counts(m,iRho,iSie) += 1;
-          }
+        for (int i = 0; i < npoints_mat; i++) {
+          Real rho = densityFromSesame(rhos[m][i]);
+          Real sie = sieFromSesame(sies[m][i]);
+          Real T = temperatureFromSesame(Ts_out[m][i]);
+          int iRho = rhoBounds.index(rho);
+          int iSie = sieBounds.index(sie);
+          hist_EOSPAC(m, iRho, iSie) += T;
+          counts(m, iRho, iSie) += 1;
         }
       }
-      normalize_hist(hist_EOSPAC, counts);
-    });
-  return time / (nmats*ndumps*npoints);
+    }
+    normalize_hist(hist_EOSPAC, counts);
+  });
+  return time / (nmats * ndumps * npoints);
 }
 
-double profile_spiner_host(const PortableMDArray<Data>& data,
-                           PortableMDArray<BEOS>& eos,
-                           DataBox& hist) {
+double profile_spiner_host(const PortableMDArray<Data> &data, PortableMDArray<BEOS> &eos,
+                           DataBox &hist) {
 
   const int ndumps = data.GetDim1();
   const int nmats = eos.GetDim1();
@@ -499,95 +473,93 @@ double profile_spiner_host(const PortableMDArray<Data>& data,
   counts.copyMetadata(hist);
   RegularGrid1D rhoBounds = hist.range(1);
   RegularGrid1D sieBounds = hist.range(0);
-  set_zero(hist); set_zero(counts);
+  set_zero(hist);
+  set_zero(counts);
 
-  DataBox lambda_db(nmats,npoints,2);
+  DataBox lambda_db(nmats, npoints, 2);
 
   auto time = get_duration([&]() {
-      for (int d = 0; d < ndumps; d++) {
-        for (int m = 0; m < nmats; m++) {
-          #pragma omp simd
-          for (int i = 0; i < npoints; i++) {
-            Real rho = data(d).rhos(m,i);
-            Real sie = data(d).sies(m,i);
-            int iRho = rhoBounds.index(rho);
-            int iSie = sieBounds.index(sie);
-            Real* lambda = &(lambda_db(m,i,0));
-            if (data(d).vfracs(m,i) > 0) {
-              Real T = eos(m).TemperatureFromDensityInternalEnergy(rho,sie,
-                                                                   lambda);
-              hist(m,iRho,iSie) += T;
-              counts(m,iRho,iSie) += 1;
-            }
+    for (int d = 0; d < ndumps; d++) {
+      for (int m = 0; m < nmats; m++) {
+#pragma omp simd
+        for (int i = 0; i < npoints; i++) {
+          Real rho = data(d).rhos(m, i);
+          Real sie = data(d).sies(m, i);
+          int iRho = rhoBounds.index(rho);
+          int iSie = sieBounds.index(sie);
+          Real *lambda = &(lambda_db(m, i, 0));
+          if (data(d).vfracs(m, i) > 0) {
+            Real T = eos(m).TemperatureFromDensityInternalEnergy(rho, sie, lambda);
+            hist(m, iRho, iSie) += T;
+            counts(m, iRho, iSie) += 1;
           }
         }
       }
-      normalize_hist(hist, counts);
-    });
-  return time / (nmats*ndumps*npoints);
+    }
+    normalize_hist(hist, counts);
+  });
+  return time / (nmats * ndumps * npoints);
 }
 
-double profile_spiner_device(const PortableMDArray<Data>& data,
-                             PortableMDArray<BEOS>& eos,
-                             const int npoints,
-                             DataBox& hist) {
+double profile_spiner_device(const PortableMDArray<Data> &data,
+                             PortableMDArray<BEOS> &eos, const int npoints,
+                             DataBox &hist) {
   const int ndumps = data.GetDim1();
   const int nmats = eos.GetDim1();
 
   RegularGrid1D rhoBounds = hist.range(1);
   RegularGrid1D sieBounds = hist.range(0);
 
-  #ifdef PORTABILITY_STRATEGY_KOKKOS
-  Kokkos::View<Real*,KokkosAtomic>
-    counts_dv("counts",nmats*(HIST_NSIDE+1)*(HIST_NSIDE-1));
-  DataBox counts(counts_dv.data(), nmats, HIST_NSIDE+1, HIST_NSIDE-1);
-  #else
-  DataBox counts_h(HIST_NSIDE+1,HIST_NSIDE-1);
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  Kokkos::View<Real *, KokkosAtomic> counts_dv("counts", nmats * (HIST_NSIDE + 1) *
+                                                             (HIST_NSIDE - 1));
+  DataBox counts(counts_dv.data(), nmats, HIST_NSIDE + 1, HIST_NSIDE - 1);
+#else
+  DataBox counts_h(HIST_NSIDE + 1, HIST_NSIDE - 1);
   DataBox counts = getOnDeviceDataBox(counts_h);
-  #endif
+#endif
 
   DataBox lambda_db_h(nmats, npoints, 2);
   auto lambda_db = getOnDeviceDataBox(lambda_db_h);
 
-  portableFor("zeros",0,nmats,0,hist.dim(2),0,hist.dim(1),
-              PORTABLE_LAMBDA(const int k, const int j, const int i) {
-                hist(k,j,i) = 0;
-                counts(k,j,i) = 0;
-              });
+  portableFor(
+      "zeros", 0, nmats, 0, hist.dim(2), 0, hist.dim(1),
+      PORTABLE_LAMBDA(const int k, const int j, const int i) {
+        hist(k, j, i) = 0;
+        counts(k, j, i) = 0;
+      });
 
   auto time = get_duration([&]() {
-      portableFor("spiner",
-                  0, ndumps, 0, nmats, 0, npoints,
-                  PORTABLE_LAMBDA(const int d, const int m, const int i) {
-                    Real rho = data(d).rhos(m,i);
-                    Real sie = data(d).sies(m,i);
-                    Real vfrac = data(d).vfracs(m,i);
-                    Real* lambda = &(lambda_db(m,i,0));
-                    Real T = eos(m).TemperatureFromDensityInternalEnergy(rho,
-                                                                         sie,
-                                                                         lambda);
-                    int iRho = rhoBounds.index(rho);
-                    int iSie = sieBounds.index(sie);
-                    if (vfrac > 0) {
-                      hist(m,iRho,iSie) += T;
-                      counts(m,iRho,iSie) += 1;
-                    }
-                  });
-      portableFor("normalize", 0, nmats, 0, hist.dim(2), 0, hist.dim(1),
-                  PORTABLE_LAMBDA(const int& m, const int& j, const int& i) {
-                    if (counts(m,j,i) > 0) hist(m,j,i) /= (counts(m,j,i) + 1e-5);
-                  });
-    });
-  return time / (nmats*ndumps*npoints);
+    portableFor(
+        "spiner", 0, ndumps, 0, nmats, 0, npoints,
+        PORTABLE_LAMBDA(const int d, const int m, const int i) {
+          Real rho = data(d).rhos(m, i);
+          Real sie = data(d).sies(m, i);
+          Real vfrac = data(d).vfracs(m, i);
+          Real *lambda = &(lambda_db(m, i, 0));
+          Real T = eos(m).TemperatureFromDensityInternalEnergy(rho, sie, lambda);
+          int iRho = rhoBounds.index(rho);
+          int iSie = sieBounds.index(sie);
+          if (vfrac > 0) {
+            hist(m, iRho, iSie) += T;
+            counts(m, iRho, iSie) += 1;
+          }
+        });
+    portableFor(
+        "normalize", 0, nmats, 0, hist.dim(2), 0, hist.dim(1),
+        PORTABLE_LAMBDA(const int &m, const int &j, const int &i) {
+          if (counts(m, j, i) > 0) hist(m, j, i) /= (counts(m, j, i) + 1e-5);
+        });
+  });
+  return time / (nmats * ndumps * npoints);
 }
 
-void save_histograms(DataBox& EOSPAC, DataBox& spiner_h, DataBox& spiner_hm) {
+void save_histograms(DataBox &EOSPAC, DataBox &spiner_h, DataBox &spiner_hm) {
   herr_t status = H5_SUCCESS;
-  hid_t file = H5Fcreate(hist_name.c_str(), H5F_ACC_TRUNC,
-                         H5P_DEFAULT, H5P_DEFAULT);
-  status += EOSPAC.saveHDF(file,"EOSPAC");
+  hid_t file = H5Fcreate(hist_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  status += EOSPAC.saveHDF(file, "EOSPAC");
   status += spiner_h.saveHDF(file, "spiner_h");
-  status += spiner_hm.saveHDF(file,"spiner_d");
+  status += spiner_hm.saveHDF(file, "spiner_d");
   status += H5Fclose(file);
 }
 

--- a/test/compare_to_eospac.cpp
+++ b/test/compare_to_eospac.cpp
@@ -22,14 +22,14 @@
 #ifdef SPINER_USE_HDF
 #ifdef SINGULARITY_USE_EOSPAC
 
-#include <iostream>
-#include <string>
-#include <cstring>
-#include <vector>
-#include <cstdlib>
-#include <limits>
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
 
 #include <hdf5.h>
 #include <hdf5_hl.h>
@@ -38,10 +38,10 @@
 
 #include <ports-of-call/portability.hpp>
 #include <sp5/singularity_eos_sp5.hpp>
-#include <spiner/spiner_types.hpp>
-#include <spiner/sp5.hpp>
 #include <spiner/databox.hpp>
 #include <spiner/interpolation.hpp>
+#include <spiner/sp5.hpp>
+#include <spiner/spiner_types.hpp>
 
 #include <sesame2spiner/io_eospac.hpp>
 
@@ -55,610 +55,606 @@ using duration = std::chrono::microseconds;
 constexpr char diffFileName[] = "diffs.sp5";
 constexpr int NTIMES = 10;
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
 
   herr_t status = H5_SUCCESS;
 
   std::vector<int> matids;
 
-  #ifdef PORTABILITY_STRATEGY_KOKKOS
+#ifdef PORTABILITY_STRATEGY_KOKKOS
   Kokkos::initialize();
-  #endif
+#endif
   {
 
-  if (argc < 2) {
-    std::cerr << "Usage: " << argv[0] << " [-n nFine] [-f filename] matid1 matid2 ... matidN"
-              << std::endl;
-    std::exit(1);
-  }
+    if (argc < 2) {
+      std::cerr << "Usage: " << argv[0]
+                << " [-n nFine] [-f filename] matid1 matid2 ... matidN" << std::endl;
+      std::exit(1);
+    }
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using Kokkos::SpaceAccessibility;
-  using KDMS = Kokkos::DefaultExecutionSpace::memory_space;
-  using HS = Kokkos::HostSpace;
-  constexpr const bool is_host = SpaceAccessibility<HS, KDMS>::accessible;
-  constexpr const int def_fine = is_host ? 512 : 2048;
+    using Kokkos::SpaceAccessibility;
+    using KDMS = Kokkos::DefaultExecutionSpace::memory_space;
+    using HS = Kokkos::HostSpace;
+    constexpr const bool is_host = SpaceAccessibility<HS, KDMS>::accessible;
+    constexpr const int def_fine = is_host ? 512 : 2048;
 #else
-  constexpr const int def_fine = 512;
+    constexpr const int def_fine = 512;
 #endif // PORTABILITY_STRATEGY_KOKKOS
 
-  int nFine = def_fine;
-  std::string filename = "materials.sp5";
-  for (int i = 1; i < argc; ++i) {
-    if (std::strcmp(argv[i], "-f") == 0 && i < argc-1) {
-      filename = argv[i+1];
-      i++;
-    } else if (std::strcmp(argv[i], "-n") == 0 && i < argc-1) {
-      nFine = std::atoi(argv[i+1]);
-      i++;
-    } else {
-      matids.push_back(std::atoi(argv[i]));
-    }
-  }
-
-  int nFineRho = nFine + 1;
-  int nFineT = nFine - 1;
-  std::string sp5name = filename;
-
-  std::cout << "Comparison to EOSPAC" << std::endl;
-
-  if (status != H5_SUCCESS) {
-    std::cerr << "H5 error. Aborting" << std::endl;
-    std::exit(1);
-  }
-
-  hid_t file = H5Fcreate(diffFileName,H5F_ACC_TRUNC,H5P_DEFAULT,H5P_DEFAULT);
-
-  constexpr int NT = 3;
-  EOS_INTEGER nXYPairs = (nFineRho)*(nFineT);
-  DataBox xVals(nFineRho,nFineT);
-  DataBox yVals(nFineRho,nFineT);
-  DataBox vars(nFineRho,nFineT);
-  DataBox dx(nFineRho,nFineT);
-  DataBox dy(nFineRho,nFineT);
-  DataBox pressEOSPAC(nFineRho,nFineT);
-  DataBox pressDiff_h(nFineRho, nFineT);
-  DataBox pressDiff_d(nFineRho, nFineT);
-
-  #ifdef PORTABILITY_STRATEGY_KOKKOS
-  using RView = Kokkos::View<Real*>;
-  RView pressSpinerDView("pressSpinerDevice", nFineRho*nFineT);
-  typename RView::HostMirror pressSpinerHView
-    = Kokkos::create_mirror_view(pressSpinerDView);
-  DataBox pressSpiner_d(pressSpinerDView.data(),nFineRho,nFineT);
-  DataBox pressSpiner_hm(pressSpinerHView.data(),nFineRho,nFineT);
-  #else
-  DataBox pressSpiner_d(nFineRho,nFineT);
-  DataBox pressSpiner_hm = pressSpiner_d.slice(2,0,nFineRho);
-  #endif
-  
-  DataBox pressSpiner_h(nFineRho,nFineT);
-  DataBox tempSpiner_h(nFineRho,nFineT);
-  DataBox tempSpinerE_h(nFineRho,nFineT);
-  DataBox tempEOSPAC(nFineRho,nFineT);
-  DataBox tempDiff_h(nFineRho,nFineT);
-  DataBox tempDiff_d(nFineRho,nFineT);
-  DataBox tempDiffE_h(nFineRho,nFineT);
-  DataBox tempDiffE_d(nFineRho,nFineT);
-
-  #ifdef PORTABILITY_STRATEGY_KOKKOS
-  RView tempSpinerDView("tempSpinerDevice", nFineRho*nFineT);
-  RView tempSpinerDViewE("tempSpinerSieDevice", nFineRho*nFineT);
-  RView::HostMirror tempSpinerHView
-    = Kokkos::create_mirror_view(tempSpinerDView);
-  RView::HostMirror tempSpinerHViewE
-    = Kokkos::create_mirror_view(tempSpinerDViewE);
-  DataBox tempSpiner_d(tempSpinerDView.data(),nFineRho,nFineT);
-  DataBox tempSpiner_hm(tempSpinerHView.data(),nFineRho,nFineT);
-  DataBox tempSpinerE_d(tempSpinerDViewE.data(),nFineRho,nFineT);
-  DataBox tempSpinerE_hm(tempSpinerHViewE.data(),nFineRho,nFineT);
-  RView rhos_v("rhos",nFineRho);
-  RView Ts_v("Ts",nFineT);
-  RView sies_v("sies",nFineT);
-  DataBox rhos(rhos_v.data(),nFineRho);
-  DataBox Ts(Ts_v.data(),nFineT);
-  DataBox sies(sies_v.data(),nFineT);
-  #else
-  DataBox tempSpiner_d(nFineRho,nFineT);
-  DataBox tempSpiner_hm = tempSpiner_d.slice(2,0,nFineRho);
-  DataBox tempSpinerE_d(nFineRho,nFineT);
-  DataBox tempSpinerE_hm = tempSpiner_h.slice(2,0,nFineRho);
-  DataBox rhos(nFineRho);
-  DataBox Ts(nFineT);
-  DataBox sies(nFineT);
-  #endif
-  
-  std::cout << "Comparing to EOSPAC for materials..." << std::endl;
-  duration durationEospacTot    = duration::zero();
-  duration durationSpinerTot    = duration::zero();
-  duration durationSpinerDTot   = duration::zero();
-  duration durationSpinerSieTot = duration::zero();
-  duration durationEospac       = duration::zero();
-  duration durationSpiner       = duration::zero();
-  duration durationSpinerSie    = duration::zero();
-  duration durationSpinerDev    = duration::zero();
-  duration durationSpinerSieDev = duration::zero();
-  auto start = std::chrono::high_resolution_clock::now();
-  auto stop  = std::chrono::high_resolution_clock::now();
-  for (int i = 0; i < matids.size(); i++) {
-    durationEospac = duration::zero();
-    durationSpiner = duration::zero();
-
-    int matid = matids[i];
-    std::cout << "\t..." << matid << std::endl;
-    std::cout << "\t------------------------" << std::endl;
-
-    SesameMetadata metadata;
-    eosGetMetadata(matid,metadata,Verbosity::Debug);
-
-    hid_t idGroup = H5Gcreate(file, std::to_string(matid).c_str(),
-                              H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);   
-    
-    std::cout << "\t\tloading EOSs\n"
-              << "\t\t\tdepends rho T" << std::endl;
-    SpinerEOSDependsRhoT eos_host(sp5name, matid);
-    std::cout << "\t\t\tdepends rho sie" << std::endl;
-    SpinerEOSDependsRhoSie eosE_host(sp5name, matid);
-    std::cout << "\t\tmoving to device" << std::endl;
-    EOS eos_device = eos_host.GetOnDevice();
-    EOS eosE_device = eosE_host.GetOnDevice();
-
-    Real* lambda_dp =
-      (Real*)PORTABLE_MALLOC(sizeof(Real)*nFineRho*nFineT*eos_host.nlambda());
-    Real* lambda_hp =
-      (Real*)malloc(sizeof(Real)*nFineRho*nFineT*eos_host.nlambda());
-    DataBox lambda_h(lambda_hp,nFineRho,nFineT,eos_host.nlambda());
-    DataBox lambda_d(lambda_dp,nFineRho,nFineT,eos_host.nlambda());
-
-    Real rhoMin = eosE_host.rhoMin();
-    Real rhoMax = eosE_host.rhoMax();
-    Real TMin = eosE_host.TMin();
-    Real TMax = eosE_host.TMax();
-    Real sieMin = eosE_host.sieMin();
-    Real sieMax = eosE_host.sieMax();
-    Real shrinklRhoBounds = 0.0;
-    Real shrinklTBounds = 0.0;
-    Real shrinkleBounds = 0.0;
-
-    Bounds lRhoBounds(rhoMin,rhoMax,nFineRho,true,shrinklRhoBounds);
-    Bounds lTBounds(TMin,TMax,nFineT,true,shrinklTBounds);
-    Bounds leBounds(sieMin,sieMax,nFineT,true,shrinkleBounds);
-
-    std::cout << "\t\trho bounds = [" << rhoMin << ", " << rhoMax << "]" << std::endl;
-    std::cout << "\t\tT   bounds = [" << TMin << ", " << TMax << "]" << std::endl;
-    std::cout << "\t\tsie bounds = [" << sieMin << ", " << sieMax << "]" << std::endl;
-    
-    EOS_INTEGER tableHandle[NT];
-    EOS_INTEGER eospacPofRT, eospacTofRE, eospacEofRT;
-    EOS_INTEGER tableType[NT] = {EOS_Pt_DT, EOS_T_DUt, EOS_Ut_DT};
-    eosSafeLoad(NT, matid, tableType, tableHandle, Verbosity::Debug);
-    eospacPofRT = tableHandle[0];
-    eospacTofRE = tableHandle[1];
-    eospacEofRT = tableHandle[2];
-
-    std::cout << "\t\tGenerating interpolation points for rho-T tables"
-              << std::endl;
-    start = std::chrono::high_resolution_clock::now();
-    for (int j = 0; j < nFineRho; j++) {
-      Real rho = lRhoBounds.i2lin(j);
-      for (int i = 0; i < nFineT; i++) {
-        Real T = lTBounds.i2lin(i);
-        xVals(j,i) = rho;
-        yVals(j,i) = T;
+    int nFine = def_fine;
+    std::string filename = "materials.sp5";
+    for (int i = 1; i < argc; ++i) {
+      if (std::strcmp(argv[i], "-f") == 0 && i < argc - 1) {
+        filename = argv[i + 1];
+        i++;
+      } else if (std::strcmp(argv[i], "-n") == 0 && i < argc - 1) {
+        nFine = std::atoi(argv[i + 1]);
+        i++;
+      } else {
+        matids.push_back(std::atoi(argv[i]));
       }
     }
-    stop = std::chrono::high_resolution_clock::now();
-    durationEospac += std::chrono::duration_cast<duration>(stop-start);
 
-    portableFor("densities",0,nFineRho,PORTABLE_LAMBDA(const int& j) {
-        rhos(j) = lRhoBounds.i2lin(j);
-      });
-    portableFor("temperatures",0,nFineT,PORTABLE_LAMBDA(const int& i) {
-        Ts(i) = lTBounds.i2lin(i);
-        sies(i) = leBounds.i2lin(i);
-      });
+    int nFineRho = nFine + 1;
+    int nFineT = nFine - 1;
+    std::string sp5name = filename;
 
-    std::cout << "\t\tInterpolate pressure of rho T" << std::endl;
-    {
-      pressSpiner_h.setRange(0,lTBounds.grid);
-      pressSpiner_h.setRange(1,lRhoBounds.grid);
-      pressSpiner_d.setRange(0,lTBounds.grid);
-      pressSpiner_d.setRange(1,lRhoBounds.grid);
-      pressSpiner_hm.setRange(0,lTBounds.grid);
-      pressSpiner_hm.setRange(1,lRhoBounds.grid);
-      pressEOSPAC.copyMetadata(pressSpiner_h);
-      pressDiff_h.copyMetadata(pressSpiner_h);
-      pressDiff_d.copyMetadata(pressSpiner_h);
+    std::cout << "Comparison to EOSPAC" << std::endl;
 
-      std::cout << "\t\t...eospac..." << std::endl;
-      start = std::chrono::high_resolution_clock::now();
-      for (int n = 0; n < NTIMES; n++) {
-        for (int i = 0; i < nXYPairs; i++) vars(i) = dx(i) = dy(i) = 0;
-        eosSafeInterpolate(&eospacPofRT, nXYPairs,
-                           xVals.data(), yVals.data(), vars.data(),
-                           dx.data(), dy.data(),
-                           "PofRT", Verbosity::Quiet);
-      }
-      stop = std::chrono::high_resolution_clock::now();
-      durationEospac += std::chrono::duration_cast<duration>(stop-start);
-      
-      std::cout << "\t\t...spiner on host..." << std::endl;
-      start = std::chrono::high_resolution_clock::now();
-      for (int n = 0; n < NTIMES; n++) {
-        #pragma omp simd
-        for (int j = 0; j < nFineRho; j++) {
-          const Real rho = xVals(j,0);
-          for (int i = 0; i < nFineT; i++) {
-            const Real T = yVals(0,i);
-            pressSpiner_h(j,i)
-              = eos_host.PressureFromDensityTemperature(rho,T);
-          }
-        }
-      }
-      stop = std::chrono::high_resolution_clock::now();
-      durationSpiner += std::chrono::duration_cast<duration>(stop-start);
-      
-      std::cout << "\t\t...spiner on device..." << std::endl;
-      #ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::fence();
-      #endif
-      start = std::chrono::high_resolution_clock::now();
-      for(int n = 0; n < NTIMES; ++n) {
-	portableFor("pressure from density and temperature",
-		    0,nFineRho,0,nFineT,
-		    PORTABLE_LAMBDA(const int& j, const int& i) {
-		      Real rho = rhos(j);
-		      Real T = Ts(i);
-		      pressSpiner_d(j,i)
-			= eos_device.PressureFromDensityTemperature(rho,T);
-		    });
-      }
-      #ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::fence();
-      #endif
-      stop = std::chrono::high_resolution_clock::now();
-      durationSpinerDev += std::chrono::duration_cast<duration>(stop-start);
-
-      Real diffL2 {0.0}, L2 {0.0};
-      std::cout << "\t\t...comparing on host..." << std::endl;
-      for (int j = 0; j < nFineRho; j++) {
-        for (int i = 0; i < nFineT; i++) {
-	  const Real p_true = pressureFromSesame(vars(j,i));
-          pressEOSPAC(j,i) = p_true;
-	  const Real diff = pressSpiner_h(j,i) - p_true;
-          pressDiff_h(j,i) = diff;
-          diffL2 += diff*diff;
-	  const Real mean_p = 0.5*diff + p_true;
-	  L2 += mean_p*mean_p;
-        }
-      }
-      diffL2 /= L2;
-      diffL2 = std::sqrt(diffL2);
-      std::cout << "\t\t...L2 difference = " << diffL2 << std::endl;
-
-      hid_t pressGroup = H5Gcreate(idGroup, "pressuresRhoT",
-                                   H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
-      status += pressSpiner_h.saveHDF(pressGroup,"spiner_h");
-      status += pressEOSPAC.saveHDF(pressGroup,"EOSPAC");
-      status += pressDiff_h.saveHDF(pressGroup,"diff_h");
-      
-      #ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::deep_copy(pressSpinerHView,pressSpinerDView);
-      #endif
-      std::cout << "\t\t...comparing device results..." << std::endl;
-      diffL2 = 0; L2 = 0;
-      for (int j = 0; j < nFineRho; j++) {
-        for (int i = 0; i < nFineT; i++) {
-          // pressSpiner_d has been copied into pressSpiner_h
-	  const Real p_true = pressEOSPAC(j,i);
-	  const Real diff = pressSpiner_hm(j,i) - p_true;
-          pressDiff_d(j,i) = diff;
-	  const Real mean_p = 0.5*diff + p_true;
-          diffL2 += diff*diff;
-	  L2 += mean_p*mean_p;
-        }
-      }
-      diffL2 /= L2;
-      diffL2 = std::sqrt(diffL2);
-      std::cout << "\t\t...L2 difference = " << diffL2 << std::endl;
-
-      status += pressSpiner_hm.saveHDF(pressGroup,"spiner_d");
-      status += pressDiff_d.saveHDF(pressGroup,"diff_d");
-      status += H5Gclose(pressGroup);      
-      
-      std::cout << "\t\t...EOSPAC time/point (microseconds) = "
-                << durationEospac.count() / static_cast<Real>((nFineRho)*(nFineT)*NTIMES)
-                << std::endl;
-      std::cout << "\t\t...spiner host time/point (microseconds) = "
-                << durationSpiner.count() / static_cast<Real>((nFineRho)*(nFineT)*NTIMES)
-                << std::endl;
-      std::cout << "\t\t...spiner device time/point (microseconds) = "
-                << durationSpinerDev.count() / static_cast<Real>((nFineRho)*(nFineT)*NTIMES)
-                << std::endl;
-      std::cout << "\t\t...saving to file..." << std::endl;
+    if (status != H5_SUCCESS) {
+      std::cerr << "H5 error. Aborting" << std::endl;
+      std::exit(1);
     }
-    durationEospacTot += durationEospac;
-    durationSpinerTot += durationSpiner;
-    durationSpinerDTot += durationSpinerDev;
-    durationEospac = duration::zero();
-    durationSpiner = duration::zero();
-    durationSpinerDev = duration::zero();
 
-    std::cout << "\t\tGenerating interpolation points for rho-sie tables"
-              << std::endl;
-    start = std::chrono::high_resolution_clock::now();
-    for (int j = 0; j < nFineRho; j++) {
-      Real rho = lRhoBounds.i2lin(j);
-      for (int i = 0; i < nFineT; i++) {
-        Real sie = leBounds.i2lin(i);
-        xVals(j,i) = rho;
-        yVals(j,i) = sieToSesame(sie);
-      }
-    }
-    stop = std::chrono::high_resolution_clock::now();
-    durationEospac += std::chrono::duration_cast<duration>(stop-start);
-    std::cout << "\t\tRoot find temperature of rho sie" << std::endl;
-    {      
-      tempSpiner_h.setRange(0,leBounds.grid);
-      tempSpiner_h.setRange(1,lRhoBounds.grid);
-      tempSpiner_d.setRange(0,leBounds.grid);
-      tempSpiner_d.setRange(1,lRhoBounds.grid);
-      tempSpiner_hm.setRange(0,leBounds.grid);
-      tempSpiner_hm.setRange(1,lRhoBounds.grid);
-      tempSpinerE_h.setRange(0,leBounds.grid);
-      tempSpinerE_h.setRange(1,lRhoBounds.grid);
-      tempSpinerE_d.setRange(0,leBounds.grid);
-      tempSpinerE_d.setRange(1,lRhoBounds.grid);
-      tempSpinerE_hm.setRange(0,leBounds.grid);
-      tempSpinerE_hm.setRange(1,lRhoBounds.grid);
-      tempEOSPAC.copyMetadata(tempSpiner_h);
-      tempDiff_h.copyMetadata(tempSpiner_h);
-      tempDiff_d.copyMetadata(tempSpiner_h);
-      tempDiffE_h.copyMetadata(tempSpiner_h);
-      tempDiffE_d.copyMetadata(tempSpiner_d);
+    hid_t file = H5Fcreate(diffFileName, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
-      std::cout << "\t\t...eospac..." << std::endl;
-      start = std::chrono::high_resolution_clock::now();
-      for (int n = 0; n < NTIMES; n++) {
-        eosSafeInterpolate(&eospacTofRE, nXYPairs,
-                           xVals.data(), yVals.data(), vars.data(),
-                           dx.data(), dy.data(),
-                           "TofRE", Verbosity::Quiet);
-      }
-      stop = std::chrono::high_resolution_clock::now();
-      durationEospac += std::chrono::duration_cast<duration>(stop-start);
+    constexpr int NT = 3;
+    EOS_INTEGER nXYPairs = (nFineRho) * (nFineT);
+    DataBox xVals(nFineRho, nFineT);
+    DataBox yVals(nFineRho, nFineT);
+    DataBox vars(nFineRho, nFineT);
+    DataBox dx(nFineRho, nFineT);
+    DataBox dy(nFineRho, nFineT);
+    DataBox pressEOSPAC(nFineRho, nFineT);
+    DataBox pressDiff_h(nFineRho, nFineT);
+    DataBox pressDiff_d(nFineRho, nFineT);
 
-      std::cout << "\t\t...spiner(rho,T) on host..." << std::endl;
-      start = std::chrono::high_resolution_clock::now();
-      for (int n = 0; n < NTIMES; n++) {
-        for (int j = 0; j < nFineRho; j++) {
-          Real rho = lRhoBounds.i2lin(j);
-          DataBox lambda_hj = lambda_h.slice(j);
-          for (int i = 0; i < nFineT; i++) {
-            Real sie = leBounds.i2lin(i);
-            DataBox lambda = lambda_hj.slice(i);
-            tempSpiner_h(j,i)
-              = eos_host.TemperatureFromDensityInternalEnergy(rho,sie,
-                                                              lambda.data());
-          }
-        }
-      }
-      stop = std::chrono::high_resolution_clock::now();
-      durationSpiner += std::chrono::duration_cast<duration>(stop-start);
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+    using RView = Kokkos::View<Real *>;
+    RView pressSpinerDView("pressSpinerDevice", nFineRho * nFineT);
+    typename RView::HostMirror pressSpinerHView =
+        Kokkos::create_mirror_view(pressSpinerDView);
+    DataBox pressSpiner_d(pressSpinerDView.data(), nFineRho, nFineT);
+    DataBox pressSpiner_hm(pressSpinerHView.data(), nFineRho, nFineT);
+#else
+    DataBox pressSpiner_d(nFineRho, nFineT);
+    DataBox pressSpiner_hm = pressSpiner_d.slice(2, 0, nFineRho);
+#endif
 
-      std::cout << "\t\t...spiner(rho,T) on device..." << std::endl;
-      #ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::fence();
-      #endif
-      start = std::chrono::high_resolution_clock::now();
-      for (int n = 0; n < NTIMES; ++n) {
-	portableFor("T(rho,e)",
-		    0,nFineRho,0,nFineT,
-		    PORTABLE_LAMBDA(const int& j, const int& i) {
-		      Real rho = rhos(j);
-		      Real sie = sies(i);
-		      DataBox lambda = lambda_d.slice(j).slice(i);
-		      tempSpiner_d(j,i)
-			= eos_device.\
-                          TemperatureFromDensityInternalEnergy(rho,sie,
-                                                               lambda.data());
-		    });
-      }
-      #ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::fence();
-      #endif
-      stop = std::chrono::high_resolution_clock::now();
-      durationSpinerDev += std::chrono::duration_cast<duration>(stop-start);
+    DataBox pressSpiner_h(nFineRho, nFineT);
+    DataBox tempSpiner_h(nFineRho, nFineT);
+    DataBox tempSpinerE_h(nFineRho, nFineT);
+    DataBox tempEOSPAC(nFineRho, nFineT);
+    DataBox tempDiff_h(nFineRho, nFineT);
+    DataBox tempDiff_d(nFineRho, nFineT);
+    DataBox tempDiffE_h(nFineRho, nFineT);
+    DataBox tempDiffE_d(nFineRho, nFineT);
 
-      std::cout << "\t\t...spiner(rho,sie) on host..." << std::endl;
-      start = std::chrono::high_resolution_clock::now();
-      for (int n = 0; n < NTIMES; n++) {
-        for (int j = 0; j < nFineRho; j++) {
-          Real rho = lRhoBounds.i2lin(j);
-          for (int i = 0; i < nFineT; i++) {
-            Real sie = leBounds.i2lin(i);
-            tempSpinerE_h(j,i)
-              = eosE_host.TemperatureFromDensityInternalEnergy(rho,sie);
-          }
-        }
-      }
-      stop = std::chrono::high_resolution_clock::now();
-      durationSpinerSie += std::chrono::duration_cast<duration>(stop-start);
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+    RView tempSpinerDView("tempSpinerDevice", nFineRho * nFineT);
+    RView tempSpinerDViewE("tempSpinerSieDevice", nFineRho * nFineT);
+    RView::HostMirror tempSpinerHView = Kokkos::create_mirror_view(tempSpinerDView);
+    RView::HostMirror tempSpinerHViewE = Kokkos::create_mirror_view(tempSpinerDViewE);
+    DataBox tempSpiner_d(tempSpinerDView.data(), nFineRho, nFineT);
+    DataBox tempSpiner_hm(tempSpinerHView.data(), nFineRho, nFineT);
+    DataBox tempSpinerE_d(tempSpinerDViewE.data(), nFineRho, nFineT);
+    DataBox tempSpinerE_hm(tempSpinerHViewE.data(), nFineRho, nFineT);
+    RView rhos_v("rhos", nFineRho);
+    RView Ts_v("Ts", nFineT);
+    RView sies_v("sies", nFineT);
+    DataBox rhos(rhos_v.data(), nFineRho);
+    DataBox Ts(Ts_v.data(), nFineT);
+    DataBox sies(sies_v.data(), nFineT);
+#else
+    DataBox tempSpiner_d(nFineRho, nFineT);
+    DataBox tempSpiner_hm = tempSpiner_d.slice(2, 0, nFineRho);
+    DataBox tempSpinerE_d(nFineRho, nFineT);
+    DataBox tempSpinerE_hm = tempSpiner_h.slice(2, 0, nFineRho);
+    DataBox rhos(nFineRho);
+    DataBox Ts(nFineT);
+    DataBox sies(nFineT);
+#endif
 
-      std::cout << "\t\t...spiner(rho,sie) on device..." << std::endl;
-      #ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::fence();
-      #endif
-      start = std::chrono::high_resolution_clock::now();
-      for (int n = 0; n < NTIMES; ++n) {
-        portableFor("T(rho,e)",
-                    0,nFineRho,0,nFineT,
-                    PORTABLE_LAMBDA(const int& j, const int& i) {
-                      Real rho = rhos(j);
-                      Real sie = sies(i);
-                      tempSpinerE_d(j,i)
-                        = eosE_device.\
-                          TemperatureFromDensityInternalEnergy(rho, sie);
-                    });
-      }
-      #ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::fence();
-      #endif
-      stop = std::chrono::high_resolution_clock::now();
-      durationSpinerSieDev += std::chrono::duration_cast<duration>(stop-start);
+    std::cout << "Comparing to EOSPAC for materials..." << std::endl;
+    duration durationEospacTot = duration::zero();
+    duration durationSpinerTot = duration::zero();
+    duration durationSpinerDTot = duration::zero();
+    duration durationSpinerSieTot = duration::zero();
+    duration durationEospac = duration::zero();
+    duration durationSpiner = duration::zero();
+    duration durationSpinerSie = duration::zero();
+    duration durationSpinerDev = duration::zero();
+    duration durationSpinerSieDev = duration::zero();
+    auto start = std::chrono::high_resolution_clock::now();
+    auto stop = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < matids.size(); i++) {
+      durationEospac = duration::zero();
+      durationSpiner = duration::zero();
 
-      std::cout << "\t\t...comparing host data..." << std::endl;
-      Real diffL1, diffL1E, diffL1_d, diffL1E_d;
-      Real diffL2, diffL2E, diffL2_d, diffL2E_d;
-      Real L2 {0.0};
-      diffL2 = 0;
-      for (int j = 0; j < nFineRho; j++) {
-        for (int i = 0; i < nFineT; i++) {
-	  const Real t_true = temperatureFromSesame(vars(j,i));
-          tempEOSPAC(j,i) = t_true;
-	  Real diff = tempSpiner_h(j,i) - t_true;
-          tempDiff_h(j,i) = diff;
-	  const Real mean_t = 0.5*diff + t_true;
-          if (isnan(diff)) {
-            std:: cout << "NAN! " << j << ", " << i << ", "
-                       << tempSpiner_h(j,i) << ", "
-                       << tempEOSPAC(j,i) << ", "
-                       << mean_t << ", "
-                       << diff
-                       << std::endl;
-            exit(1);
-          }
-          #ifdef singularity_normalize_cold_point
-          if (tempSpiner_h(j,i) <= 2.*TMin && tempEOSPAC(j,i) < TMin) {
-            tempSpiner_h(j,i) = 0;
-            tempEOSPAC(j,i) = 0;
-            diff = 0;
-          }
-          #endif
-          diffL2 += diff*diff;
-	  L2 += mean_t*mean_t;
-        }
-      }
-      diffL2 /= L2;
-      diffL2 = std::sqrt(diffL2);
-      diffL2E = 0; L2 = 0;
-      for (int j = 0; j < nFineRho; j++) {
-        for (int i = 0; i < nFineT; i++) {
-          const Real t_true = tempEOSPAC(j,i);
-	  const Real diff = tempSpinerE_h(j,i) - t_true;
-	  tempDiffE_h(j,i) = diff;
-	  const Real mean_t = 0.5*diff + t_true;
-          diffL2E += diff*diff;
-	  L2 += mean_t*mean_t;
-        }
-      }
-      diffL2E /= L2;
-      diffL2E = std::sqrt(diffL2E);
-      std::cout << "\t\tRoot finding:\n"
-                << "\t\tits: counts\n";
-      for (int i = 0; i < eos_host.counts.nBins(); i++) {
-        std::cout << "\t\t\t"
-                  << i << ": "
-                  << 100.*eos_host.counts[i]/eos_host.counts.total()
-                  << "\n";
-      }
-      hid_t pressGroup = H5Gcreate(idGroup, "temperaturesRhoSie",
-                                   H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
-      status += tempSpiner_h.saveHDF(pressGroup,"spiner_h");
-      status += tempEOSPAC.saveHDF(pressGroup,"EOSPAC");
-      status += tempDiff_h.saveHDF(pressGroup,"diff_h");
-      status += tempSpinerE_h.saveHDF(pressGroup,"spinerE_h");
-      status += tempDiffE_h.saveHDF(pressGroup,"diffE_h");
-
-      #ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::deep_copy(tempSpinerHView,tempSpinerDView);
-      Kokkos::deep_copy(tempSpinerHViewE,tempSpinerDViewE);
-      #endif
-      // tempSpiner_hm now contains copy of device data
-      diffL2_d = 0; L2 = 0;
-      for (int j = 0; j < nFineRho; j++) {
-        for (int i = 0; i < nFineT; i++) {
-	  const Real t_true = tempEOSPAC(j,i);
-	  Real diff = tempSpiner_hm(j,i) - t_true;
-          tempDiff_d(j,i) = diff;
-	  const Real mean_t = 0.5*diff + t_true;
-          #ifdef singularity_normalize_cold_point
-          if (tempSpiner_hm(j,i) < 2*TMin && tempEOSPAC(j,i) < TMin) {
-            tempSpiner_hm(j,i) = 0;
-            tempEOSPAC(j,i) = 0;
-            diff = 0;
-          }
-          #endif
-          diffL2_d += diff*diff;
-	  L2 += mean_t*mean_t;
-        }
-      }
-      diffL2_d /= L2;
-      diffL2_d = std::sqrt(diffL2_d);
-      diffL2E_d = 0; L2 = 0;
-      for (int j = 0; j < nFineRho; j++) {
-        for (int i = 0; i < nFineT; i++) {
-	  const Real t_true = tempEOSPAC(j,i);
-	  const Real diff = tempSpinerE_hm(j,i) - t_true;
-          tempDiffE_d(j,i) = diff;
-	  const Real mean_t = 0.5*diff + t_true;
-          diffL2E_d += diff*diff;
-	  L2 += mean_t*mean_t;
-        }
-      }
-      diffL2E_d /= L2;
-      diffL2E_d = std::sqrt(diffL2E_d);
-      status += tempSpiner_hm.saveHDF(pressGroup,"spiner_d");
-      status += tempDiff_d.saveHDF(pressGroup,"diff_d");
-      status += tempSpinerE_hm.saveHDF(pressGroup,"spinerE_d");
-      status += tempDiffE_d.saveHDF(pressGroup,"diffE_d");
-      status += H5Gclose(pressGroup);
-
+      int matid = matids[i];
+      std::cout << "\t..." << matid << std::endl;
       std::cout << "\t------------------------" << std::endl;
-      std::cout << "\t\t...L2 difference for spiner(rho,T) host = "
-                << diffL2 << std::endl;
-      std::cout << "\t\t...L2 difference for spiner(rho,sie) host = "
-                << diffL2E << std::endl;
-      std::cout << "\t\t...L2 difference for spiner(rho,T) device = "
-                << diffL2_d << std::endl;
-      std::cout << "\t\t...L2 difference for spiner(rho,sie) device = "
-                << diffL2E_d << std::endl;
-      std::cout << "\t\t...EOSPAC time/point (microseconds) = "
-        << durationEospac.count() / static_cast<Real>((nFineRho)*(nFineT)*NTIMES)
-                << std::endl;
-      std::cout << "\t\t...spiner(rho,T) time/point (microseconds) host = "
-        << durationSpiner.count() / static_cast<Real>((nFineRho)*(nFineT)*NTIMES)
-                << std::endl;
-      std::cout << "\t\t...spiner(rho,sie) time/point (microseconds) host = "
-        << durationSpinerSie.count() / static_cast<Real>((nFineRho)*(nFineT)*NTIMES)
-                << std::endl;
-      std::cout << "\t\t...spiner(rho,T) time/point (microseconds) device = "
-        << durationSpinerDev.count() / static_cast<Real>((nFineRho)*(nFineT)*NTIMES)
-                << std::endl;
-      std::cout << "\t\t...spiner(rho,sie) time/point (microseconds) device = "
-        << durationSpinerSieDev.count() / static_cast<Real>((nFineRho)*(nFineT)*NTIMES)
-                << std::endl;
+
+      SesameMetadata metadata;
+      eosGetMetadata(matid, metadata, Verbosity::Debug);
+
+      hid_t idGroup = H5Gcreate(file, std::to_string(matid).c_str(), H5P_DEFAULT,
+                                H5P_DEFAULT, H5P_DEFAULT);
+
+      std::cout << "\t\tloading EOSs\n"
+                << "\t\t\tdepends rho T" << std::endl;
+      SpinerEOSDependsRhoT eos_host(sp5name, matid);
+      std::cout << "\t\t\tdepends rho sie" << std::endl;
+      SpinerEOSDependsRhoSie eosE_host(sp5name, matid);
+      std::cout << "\t\tmoving to device" << std::endl;
+      EOS eos_device = eos_host.GetOnDevice();
+      EOS eosE_device = eosE_host.GetOnDevice();
+
+      Real *lambda_dp =
+          (Real *)PORTABLE_MALLOC(sizeof(Real) * nFineRho * nFineT * eos_host.nlambda());
+      Real *lambda_hp =
+          (Real *)malloc(sizeof(Real) * nFineRho * nFineT * eos_host.nlambda());
+      DataBox lambda_h(lambda_hp, nFineRho, nFineT, eos_host.nlambda());
+      DataBox lambda_d(lambda_dp, nFineRho, nFineT, eos_host.nlambda());
+
+      Real rhoMin = eosE_host.rhoMin();
+      Real rhoMax = eosE_host.rhoMax();
+      Real TMin = eosE_host.TMin();
+      Real TMax = eosE_host.TMax();
+      Real sieMin = eosE_host.sieMin();
+      Real sieMax = eosE_host.sieMax();
+      Real shrinklRhoBounds = 0.0;
+      Real shrinklTBounds = 0.0;
+      Real shrinkleBounds = 0.0;
+
+      Bounds lRhoBounds(rhoMin, rhoMax, nFineRho, true, shrinklRhoBounds);
+      Bounds lTBounds(TMin, TMax, nFineT, true, shrinklTBounds);
+      Bounds leBounds(sieMin, sieMax, nFineT, true, shrinkleBounds);
+
+      std::cout << "\t\trho bounds = [" << rhoMin << ", " << rhoMax << "]" << std::endl;
+      std::cout << "\t\tT   bounds = [" << TMin << ", " << TMax << "]" << std::endl;
+      std::cout << "\t\tsie bounds = [" << sieMin << ", " << sieMax << "]" << std::endl;
+
+      EOS_INTEGER tableHandle[NT];
+      EOS_INTEGER eospacPofRT, eospacTofRE, eospacEofRT;
+      EOS_INTEGER tableType[NT] = {EOS_Pt_DT, EOS_T_DUt, EOS_Ut_DT};
+      eosSafeLoad(NT, matid, tableType, tableHandle, Verbosity::Debug);
+      eospacPofRT = tableHandle[0];
+      eospacTofRE = tableHandle[1];
+      eospacEofRT = tableHandle[2];
+
+      std::cout << "\t\tGenerating interpolation points for rho-T tables" << std::endl;
+      start = std::chrono::high_resolution_clock::now();
+      for (int j = 0; j < nFineRho; j++) {
+        Real rho = lRhoBounds.i2lin(j);
+        for (int i = 0; i < nFineT; i++) {
+          Real T = lTBounds.i2lin(i);
+          xVals(j, i) = rho;
+          yVals(j, i) = T;
+        }
+      }
+      stop = std::chrono::high_resolution_clock::now();
+      durationEospac += std::chrono::duration_cast<duration>(stop - start);
+
+      portableFor(
+          "densities", 0, nFineRho,
+          PORTABLE_LAMBDA(const int &j) { rhos(j) = lRhoBounds.i2lin(j); });
+      portableFor(
+          "temperatures", 0, nFineT, PORTABLE_LAMBDA(const int &i) {
+            Ts(i) = lTBounds.i2lin(i);
+            sies(i) = leBounds.i2lin(i);
+          });
+
+      std::cout << "\t\tInterpolate pressure of rho T" << std::endl;
+      {
+        pressSpiner_h.setRange(0, lTBounds.grid);
+        pressSpiner_h.setRange(1, lRhoBounds.grid);
+        pressSpiner_d.setRange(0, lTBounds.grid);
+        pressSpiner_d.setRange(1, lRhoBounds.grid);
+        pressSpiner_hm.setRange(0, lTBounds.grid);
+        pressSpiner_hm.setRange(1, lRhoBounds.grid);
+        pressEOSPAC.copyMetadata(pressSpiner_h);
+        pressDiff_h.copyMetadata(pressSpiner_h);
+        pressDiff_d.copyMetadata(pressSpiner_h);
+
+        std::cout << "\t\t...eospac..." << std::endl;
+        start = std::chrono::high_resolution_clock::now();
+        for (int n = 0; n < NTIMES; n++) {
+          for (int i = 0; i < nXYPairs; i++)
+            vars(i) = dx(i) = dy(i) = 0;
+          eosSafeInterpolate(&eospacPofRT, nXYPairs, xVals.data(), yVals.data(),
+                             vars.data(), dx.data(), dy.data(), "PofRT",
+                             Verbosity::Quiet);
+        }
+        stop = std::chrono::high_resolution_clock::now();
+        durationEospac += std::chrono::duration_cast<duration>(stop - start);
+
+        std::cout << "\t\t...spiner on host..." << std::endl;
+        start = std::chrono::high_resolution_clock::now();
+        for (int n = 0; n < NTIMES; n++) {
+#pragma omp simd
+          for (int j = 0; j < nFineRho; j++) {
+            const Real rho = xVals(j, 0);
+            for (int i = 0; i < nFineT; i++) {
+              const Real T = yVals(0, i);
+              pressSpiner_h(j, i) = eos_host.PressureFromDensityTemperature(rho, T);
+            }
+          }
+        }
+        stop = std::chrono::high_resolution_clock::now();
+        durationSpiner += std::chrono::duration_cast<duration>(stop - start);
+
+        std::cout << "\t\t...spiner on device..." << std::endl;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::fence();
+#endif
+        start = std::chrono::high_resolution_clock::now();
+        for (int n = 0; n < NTIMES; ++n) {
+          portableFor(
+              "pressure from density and temperature", 0, nFineRho, 0, nFineT,
+              PORTABLE_LAMBDA(const int &j, const int &i) {
+                Real rho = rhos(j);
+                Real T = Ts(i);
+                pressSpiner_d(j, i) = eos_device.PressureFromDensityTemperature(rho, T);
+              });
+        }
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::fence();
+#endif
+        stop = std::chrono::high_resolution_clock::now();
+        durationSpinerDev += std::chrono::duration_cast<duration>(stop - start);
+
+        Real diffL2{0.0}, L2{0.0};
+        std::cout << "\t\t...comparing on host..." << std::endl;
+        for (int j = 0; j < nFineRho; j++) {
+          for (int i = 0; i < nFineT; i++) {
+            const Real p_true = pressureFromSesame(vars(j, i));
+            pressEOSPAC(j, i) = p_true;
+            const Real diff = pressSpiner_h(j, i) - p_true;
+            pressDiff_h(j, i) = diff;
+            diffL2 += diff * diff;
+            const Real mean_p = 0.5 * diff + p_true;
+            L2 += mean_p * mean_p;
+          }
+        }
+        diffL2 /= L2;
+        diffL2 = std::sqrt(diffL2);
+        std::cout << "\t\t...L2 difference = " << diffL2 << std::endl;
+
+        hid_t pressGroup =
+            H5Gcreate(idGroup, "pressuresRhoT", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        status += pressSpiner_h.saveHDF(pressGroup, "spiner_h");
+        status += pressEOSPAC.saveHDF(pressGroup, "EOSPAC");
+        status += pressDiff_h.saveHDF(pressGroup, "diff_h");
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::deep_copy(pressSpinerHView, pressSpinerDView);
+#endif
+        std::cout << "\t\t...comparing device results..." << std::endl;
+        diffL2 = 0;
+        L2 = 0;
+        for (int j = 0; j < nFineRho; j++) {
+          for (int i = 0; i < nFineT; i++) {
+            // pressSpiner_d has been copied into pressSpiner_h
+            const Real p_true = pressEOSPAC(j, i);
+            const Real diff = pressSpiner_hm(j, i) - p_true;
+            pressDiff_d(j, i) = diff;
+            const Real mean_p = 0.5 * diff + p_true;
+            diffL2 += diff * diff;
+            L2 += mean_p * mean_p;
+          }
+        }
+        diffL2 /= L2;
+        diffL2 = std::sqrt(diffL2);
+        std::cout << "\t\t...L2 difference = " << diffL2 << std::endl;
+
+        status += pressSpiner_hm.saveHDF(pressGroup, "spiner_d");
+        status += pressDiff_d.saveHDF(pressGroup, "diff_d");
+        status += H5Gclose(pressGroup);
+
+        std::cout << "\t\t...EOSPAC time/point (microseconds) = "
+                  << durationEospac.count() /
+                         static_cast<Real>((nFineRho) * (nFineT)*NTIMES)
+                  << std::endl;
+        std::cout << "\t\t...spiner host time/point (microseconds) = "
+                  << durationSpiner.count() /
+                         static_cast<Real>((nFineRho) * (nFineT)*NTIMES)
+                  << std::endl;
+        std::cout << "\t\t...spiner device time/point (microseconds) = "
+                  << durationSpinerDev.count() /
+                         static_cast<Real>((nFineRho) * (nFineT)*NTIMES)
+                  << std::endl;
+        std::cout << "\t\t...saving to file..." << std::endl;
+      }
+      durationEospacTot += durationEospac;
+      durationSpinerTot += durationSpiner;
+      durationSpinerDTot += durationSpinerDev;
+      durationEospac = duration::zero();
+      durationSpiner = duration::zero();
+      durationSpinerDev = duration::zero();
+
+      std::cout << "\t\tGenerating interpolation points for rho-sie tables" << std::endl;
+      start = std::chrono::high_resolution_clock::now();
+      for (int j = 0; j < nFineRho; j++) {
+        Real rho = lRhoBounds.i2lin(j);
+        for (int i = 0; i < nFineT; i++) {
+          Real sie = leBounds.i2lin(i);
+          xVals(j, i) = rho;
+          yVals(j, i) = sieToSesame(sie);
+        }
+      }
+      stop = std::chrono::high_resolution_clock::now();
+      durationEospac += std::chrono::duration_cast<duration>(stop - start);
+      std::cout << "\t\tRoot find temperature of rho sie" << std::endl;
+      {
+        tempSpiner_h.setRange(0, leBounds.grid);
+        tempSpiner_h.setRange(1, lRhoBounds.grid);
+        tempSpiner_d.setRange(0, leBounds.grid);
+        tempSpiner_d.setRange(1, lRhoBounds.grid);
+        tempSpiner_hm.setRange(0, leBounds.grid);
+        tempSpiner_hm.setRange(1, lRhoBounds.grid);
+        tempSpinerE_h.setRange(0, leBounds.grid);
+        tempSpinerE_h.setRange(1, lRhoBounds.grid);
+        tempSpinerE_d.setRange(0, leBounds.grid);
+        tempSpinerE_d.setRange(1, lRhoBounds.grid);
+        tempSpinerE_hm.setRange(0, leBounds.grid);
+        tempSpinerE_hm.setRange(1, lRhoBounds.grid);
+        tempEOSPAC.copyMetadata(tempSpiner_h);
+        tempDiff_h.copyMetadata(tempSpiner_h);
+        tempDiff_d.copyMetadata(tempSpiner_h);
+        tempDiffE_h.copyMetadata(tempSpiner_h);
+        tempDiffE_d.copyMetadata(tempSpiner_d);
+
+        std::cout << "\t\t...eospac..." << std::endl;
+        start = std::chrono::high_resolution_clock::now();
+        for (int n = 0; n < NTIMES; n++) {
+          eosSafeInterpolate(&eospacTofRE, nXYPairs, xVals.data(), yVals.data(),
+                             vars.data(), dx.data(), dy.data(), "TofRE",
+                             Verbosity::Quiet);
+        }
+        stop = std::chrono::high_resolution_clock::now();
+        durationEospac += std::chrono::duration_cast<duration>(stop - start);
+
+        std::cout << "\t\t...spiner(rho,T) on host..." << std::endl;
+        start = std::chrono::high_resolution_clock::now();
+        for (int n = 0; n < NTIMES; n++) {
+          for (int j = 0; j < nFineRho; j++) {
+            Real rho = lRhoBounds.i2lin(j);
+            DataBox lambda_hj = lambda_h.slice(j);
+            for (int i = 0; i < nFineT; i++) {
+              Real sie = leBounds.i2lin(i);
+              DataBox lambda = lambda_hj.slice(i);
+              tempSpiner_h(j, i) =
+                  eos_host.TemperatureFromDensityInternalEnergy(rho, sie, lambda.data());
+            }
+          }
+        }
+        stop = std::chrono::high_resolution_clock::now();
+        durationSpiner += std::chrono::duration_cast<duration>(stop - start);
+
+        std::cout << "\t\t...spiner(rho,T) on device..." << std::endl;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::fence();
+#endif
+        start = std::chrono::high_resolution_clock::now();
+        for (int n = 0; n < NTIMES; ++n) {
+          portableFor(
+              "T(rho,e)", 0, nFineRho, 0, nFineT,
+              PORTABLE_LAMBDA(const int &j, const int &i) {
+                Real rho = rhos(j);
+                Real sie = sies(i);
+                DataBox lambda = lambda_d.slice(j).slice(i);
+                tempSpiner_d(j, i) = eos_device.TemperatureFromDensityInternalEnergy(
+                    rho, sie, lambda.data());
+              });
+        }
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::fence();
+#endif
+        stop = std::chrono::high_resolution_clock::now();
+        durationSpinerDev += std::chrono::duration_cast<duration>(stop - start);
+
+        std::cout << "\t\t...spiner(rho,sie) on host..." << std::endl;
+        start = std::chrono::high_resolution_clock::now();
+        for (int n = 0; n < NTIMES; n++) {
+          for (int j = 0; j < nFineRho; j++) {
+            Real rho = lRhoBounds.i2lin(j);
+            for (int i = 0; i < nFineT; i++) {
+              Real sie = leBounds.i2lin(i);
+              tempSpinerE_h(j, i) =
+                  eosE_host.TemperatureFromDensityInternalEnergy(rho, sie);
+            }
+          }
+        }
+        stop = std::chrono::high_resolution_clock::now();
+        durationSpinerSie += std::chrono::duration_cast<duration>(stop - start);
+
+        std::cout << "\t\t...spiner(rho,sie) on device..." << std::endl;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::fence();
+#endif
+        start = std::chrono::high_resolution_clock::now();
+        for (int n = 0; n < NTIMES; ++n) {
+          portableFor(
+              "T(rho,e)", 0, nFineRho, 0, nFineT,
+              PORTABLE_LAMBDA(const int &j, const int &i) {
+                Real rho = rhos(j);
+                Real sie = sies(i);
+                tempSpinerE_d(j, i) =
+                    eosE_device.TemperatureFromDensityInternalEnergy(rho, sie);
+              });
+        }
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::fence();
+#endif
+        stop = std::chrono::high_resolution_clock::now();
+        durationSpinerSieDev += std::chrono::duration_cast<duration>(stop - start);
+
+        std::cout << "\t\t...comparing host data..." << std::endl;
+        Real diffL1, diffL1E, diffL1_d, diffL1E_d;
+        Real diffL2, diffL2E, diffL2_d, diffL2E_d;
+        Real L2{0.0};
+        diffL2 = 0;
+        for (int j = 0; j < nFineRho; j++) {
+          for (int i = 0; i < nFineT; i++) {
+            const Real t_true = temperatureFromSesame(vars(j, i));
+            tempEOSPAC(j, i) = t_true;
+            Real diff = tempSpiner_h(j, i) - t_true;
+            tempDiff_h(j, i) = diff;
+            const Real mean_t = 0.5 * diff + t_true;
+            if (isnan(diff)) {
+              std::cout << "NAN! " << j << ", " << i << ", " << tempSpiner_h(j, i) << ", "
+                        << tempEOSPAC(j, i) << ", " << mean_t << ", " << diff
+                        << std::endl;
+              exit(1);
+            }
+#ifdef singularity_normalize_cold_point
+            if (tempSpiner_h(j, i) <= 2. * TMin && tempEOSPAC(j, i) < TMin) {
+              tempSpiner_h(j, i) = 0;
+              tempEOSPAC(j, i) = 0;
+              diff = 0;
+            }
+#endif
+            diffL2 += diff * diff;
+            L2 += mean_t * mean_t;
+          }
+        }
+        diffL2 /= L2;
+        diffL2 = std::sqrt(diffL2);
+        diffL2E = 0;
+        L2 = 0;
+        for (int j = 0; j < nFineRho; j++) {
+          for (int i = 0; i < nFineT; i++) {
+            const Real t_true = tempEOSPAC(j, i);
+            const Real diff = tempSpinerE_h(j, i) - t_true;
+            tempDiffE_h(j, i) = diff;
+            const Real mean_t = 0.5 * diff + t_true;
+            diffL2E += diff * diff;
+            L2 += mean_t * mean_t;
+          }
+        }
+        diffL2E /= L2;
+        diffL2E = std::sqrt(diffL2E);
+        std::cout << "\t\tRoot finding:\n"
+                  << "\t\tits: counts\n";
+        for (int i = 0; i < eos_host.counts.nBins(); i++) {
+          std::cout << "\t\t\t" << i << ": "
+                    << 100. * eos_host.counts[i] / eos_host.counts.total() << "\n";
+        }
+        hid_t pressGroup = H5Gcreate(idGroup, "temperaturesRhoSie", H5P_DEFAULT,
+                                     H5P_DEFAULT, H5P_DEFAULT);
+        status += tempSpiner_h.saveHDF(pressGroup, "spiner_h");
+        status += tempEOSPAC.saveHDF(pressGroup, "EOSPAC");
+        status += tempDiff_h.saveHDF(pressGroup, "diff_h");
+        status += tempSpinerE_h.saveHDF(pressGroup, "spinerE_h");
+        status += tempDiffE_h.saveHDF(pressGroup, "diffE_h");
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::deep_copy(tempSpinerHView, tempSpinerDView);
+        Kokkos::deep_copy(tempSpinerHViewE, tempSpinerDViewE);
+#endif
+        // tempSpiner_hm now contains copy of device data
+        diffL2_d = 0;
+        L2 = 0;
+        for (int j = 0; j < nFineRho; j++) {
+          for (int i = 0; i < nFineT; i++) {
+            const Real t_true = tempEOSPAC(j, i);
+            Real diff = tempSpiner_hm(j, i) - t_true;
+            tempDiff_d(j, i) = diff;
+            const Real mean_t = 0.5 * diff + t_true;
+#ifdef singularity_normalize_cold_point
+            if (tempSpiner_hm(j, i) < 2 * TMin && tempEOSPAC(j, i) < TMin) {
+              tempSpiner_hm(j, i) = 0;
+              tempEOSPAC(j, i) = 0;
+              diff = 0;
+            }
+#endif
+            diffL2_d += diff * diff;
+            L2 += mean_t * mean_t;
+          }
+        }
+        diffL2_d /= L2;
+        diffL2_d = std::sqrt(diffL2_d);
+        diffL2E_d = 0;
+        L2 = 0;
+        for (int j = 0; j < nFineRho; j++) {
+          for (int i = 0; i < nFineT; i++) {
+            const Real t_true = tempEOSPAC(j, i);
+            const Real diff = tempSpinerE_hm(j, i) - t_true;
+            tempDiffE_d(j, i) = diff;
+            const Real mean_t = 0.5 * diff + t_true;
+            diffL2E_d += diff * diff;
+            L2 += mean_t * mean_t;
+          }
+        }
+        diffL2E_d /= L2;
+        diffL2E_d = std::sqrt(diffL2E_d);
+        status += tempSpiner_hm.saveHDF(pressGroup, "spiner_d");
+        status += tempDiff_d.saveHDF(pressGroup, "diff_d");
+        status += tempSpinerE_hm.saveHDF(pressGroup, "spinerE_d");
+        status += tempDiffE_d.saveHDF(pressGroup, "diffE_d");
+        status += H5Gclose(pressGroup);
+
+        std::cout << "\t------------------------" << std::endl;
+        std::cout << "\t\t...L2 difference for spiner(rho,T) host = " << diffL2
+                  << std::endl;
+        std::cout << "\t\t...L2 difference for spiner(rho,sie) host = " << diffL2E
+                  << std::endl;
+        std::cout << "\t\t...L2 difference for spiner(rho,T) device = " << diffL2_d
+                  << std::endl;
+        std::cout << "\t\t...L2 difference for spiner(rho,sie) device = " << diffL2E_d
+                  << std::endl;
+        std::cout << "\t\t...EOSPAC time/point (microseconds) = "
+                  << durationEospac.count() /
+                         static_cast<Real>((nFineRho) * (nFineT)*NTIMES)
+                  << std::endl;
+        std::cout << "\t\t...spiner(rho,T) time/point (microseconds) host = "
+                  << durationSpiner.count() /
+                         static_cast<Real>((nFineRho) * (nFineT)*NTIMES)
+                  << std::endl;
+        std::cout << "\t\t...spiner(rho,sie) time/point (microseconds) host = "
+                  << durationSpinerSie.count() /
+                         static_cast<Real>((nFineRho) * (nFineT)*NTIMES)
+                  << std::endl;
+        std::cout << "\t\t...spiner(rho,T) time/point (microseconds) device = "
+                  << durationSpinerDev.count() /
+                         static_cast<Real>((nFineRho) * (nFineT)*NTIMES)
+                  << std::endl;
+        std::cout << "\t\t...spiner(rho,sie) time/point (microseconds) device = "
+                  << durationSpinerSieDev.count() /
+                         static_cast<Real>((nFineRho) * (nFineT)*NTIMES)
+                  << std::endl;
+      }
+      std::cout << "\t------------------------" << std::endl;
+
+      status += H5Gclose(idGroup);
+
+      PORTABLE_FREE(lambda_dp);
+      free(lambda_hp);
+      eos_device.Finalize();
+      eosE_device.Finalize();
     }
-    std::cout << "\t------------------------" << std::endl;
 
-    status += H5Gclose(idGroup);
-
-    PORTABLE_FREE(lambda_dp);
-    free(lambda_hp);
-    eos_device.Finalize();
-    eosE_device.Finalize();
+    status += H5Fclose(file);
+    if (status != H5_SUCCESS) {
+      std::cerr << "WARNING: problem with HDf5" << std::endl;
+    }
   }
-
-  status += H5Fclose(file);
-  if (status != H5_SUCCESS) {
-    std::cerr << "WARNING: problem with HDf5" << std::endl;
-  }
-
-  }
-  #ifdef PORTABILITY_STRATEGY_KOKKOS
+#ifdef PORTABILITY_STRATEGY_KOKKOS
   Kokkos::finalize();
-  #endif
-  
+#endif
+
   return 0;
 }
 

--- a/test/eos_unit_tests.cpp
+++ b/test/eos_unit_tests.cpp
@@ -12,14 +12,14 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
-#include <iostream> // debug
 #include <cmath>
-#include <cstdlib>
 #include <cstdio>
+#include <cstdlib>
+#include <iostream> // debug
 
-#include <root-finding-1d/root_finding.hpp>
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
+#include <root-finding-1d/root_finding.hpp>
 #include <singularity-eos/eos/eos.hpp>
 #include <singularity-eos/eos/eos_builder.hpp>
 
@@ -32,8 +32,8 @@ using singularity::ScaledEOS;
 using singularity::ShiftedEOS;
 
 #ifdef SPINER_USE_HDF
-using singularity::SpinerEOSDependsRhoT;
 using singularity::SpinerEOSDependsRhoSie;
+using singularity::SpinerEOSDependsRhoT;
 #endif
 
 #ifdef SINGULARITY_USE_EOSPAC
@@ -59,20 +59,20 @@ constexpr Real ev2k = 1.160451812e4;
 
 constexpr Real EPS = 1e-2; // within a percent
 PORTABLE_INLINE_FUNCTION bool isClose(Real a, Real b) {
-  return fabs(b - a)/(fabs(a+b)+1e-20) <= EPS;
+  return fabs(b - a) / (fabs(a + b) + 1e-20) <= EPS;
 }
 
 PORTABLE_INLINE_FUNCTION Real myAtan(Real x, Real shift, Real scale, Real offset) {
-  return scale*atan(x - shift) + offset;
+  return scale * atan(x - shift) + offset;
 }
 
-SCENARIO( "Rudimentary test of the root finder", "[RootFinding1D]" ) {
+SCENARIO("Rudimentary test of the root finder", "[RootFinding1D]") {
 
-  GIVEN( "A root counts object" ) {
+  GIVEN("A root counts object") {
     using namespace RootFinding1D;
     RootCounts counts;
 
-    THEN( "A root can be found for shift = 1, scale = 2, offset = 0.5" ) {
+    THEN("A root can be found for shift = 1, scale = 2, offset = 0.5") {
       int ntimes = 100;
       Real guess = 0;
       Real root;
@@ -81,50 +81,45 @@ SCENARIO( "Rudimentary test of the root finder", "[RootFinding1D]" ) {
       Real scale = 2;
       Real offset = 0.5;
 
-      auto f = PORTABLE_LAMBDA(const Real x) {
-        return myAtan(x,shift,scale,offset);
-      };
-      Status* statusesp = (Status*)PORTABLE_MALLOC(ntimes*sizeof(Status));
-      Real* rootsp = (Real*)PORTABLE_MALLOC(ntimes*sizeof(Real));
+      auto f = PORTABLE_LAMBDA(const Real x) { return myAtan(x, shift, scale, offset); };
+      Status *statusesp = (Status *)PORTABLE_MALLOC(ntimes * sizeof(Status));
+      Real *rootsp = (Real *)PORTABLE_MALLOC(ntimes * sizeof(Real));
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::View<Status*,Kokkos::MemoryTraits<Kokkos::Unmanaged>>
-        statuses(statusesp, ntimes);
-      Kokkos::View<Real*,Kokkos::MemoryTraits<Kokkos::Unmanaged>>
-        roots(rootsp, ntimes);
+      Kokkos::View<Status *, Kokkos::MemoryTraits<Kokkos::Unmanaged>> statuses(statusesp,
+                                                                               ntimes);
+      Kokkos::View<Real *, Kokkos::MemoryTraits<Kokkos::Unmanaged>> roots(rootsp, ntimes);
 #else
       PortableMDArray<Status> statuses;
       PortableMDArray<Real> roots;
-      statuses.NewPortableMDArray(statusesp,ntimes);
-      roots.NewPortableMDArray(rootsp,ntimes);
+      statuses.NewPortableMDArray(statusesp, ntimes);
+      roots.NewPortableMDArray(rootsp, ntimes);
 #endif
-      portableFor("find roots", 0, ntimes,
-                  PORTABLE_LAMBDA(const int i) {
-                    RootCounts per_thread_counts;
-                    statuses(i) = findRoot(f, 0, guess,
-                                           -1, 3,
-                                           1e-10, 1e-10, roots(i), 
-                                           per_thread_counts);
-                  });
+      portableFor(
+          "find roots", 0, ntimes, PORTABLE_LAMBDA(const int i) {
+            RootCounts per_thread_counts;
+            statuses(i) =
+                findRoot(f, 0, guess, -1, 3, 1e-10, 1e-10, roots(i), per_thread_counts);
+          });
 #ifdef PORTABILITY_STRATEGY_KOKKOS
       Kokkos::View<Status> s_copy(statuses, 0);
       Kokkos::View<Real> r_copy(roots, 0);
       Kokkos::deep_copy(root, r_copy);
       Kokkos::deep_copy(status, s_copy);
 #else
-      status = statuses(ntimes-1);
-      root = roots(ntimes-1);
+      status = statuses(ntimes - 1);
+      root = roots(ntimes - 1);
 #endif
 
       PORTABLE_FREE(statusesp);
       PORTABLE_FREE(rootsp);
-      REQUIRE( status == Status::SUCCESS );
-      REQUIRE( isClose(root, 0.744658) );
-      REQUIRE( 100.*counts[counts.more()] / counts.total() <= 10 );
+      REQUIRE(status == Status::SUCCESS);
+      REQUIRE(isClose(root, 0.744658));
+      REQUIRE(100. * counts[counts.more()] / counts.total() <= 10);
     }
   }
 }
 
-SCENARIO("EOS Builder and Modifiers","[EOSBuilder],[Modifiers]") {
+SCENARIO("EOS Builder and Modifiers", "[EOSBuilder],[Modifiers]") {
 
   GIVEN("Parameters for a shifted and scaled ideal gas") {
     constexpr Real Cv = 2.0;
@@ -134,13 +129,12 @@ SCENARIO("EOS Builder and Modifiers","[EOSBuilder],[Modifiers]") {
     constexpr Real rho = 2.0;
     constexpr Real sie = 0.5;
     WHEN("We construct a shifted, scaled IdealGas by hand") {
-      IdealGas a = IdealGas(gm1,Cv);
-      ScaledEOS<IdealGas> b = ScaledEOS<IdealGas>(std::move(a),scale);
-      EOS eos = ShiftedEOS<ScaledEOS<IdealGas>>(std::move(b),
-								  shift);
+      IdealGas a = IdealGas(gm1, Cv);
+      ScaledEOS<IdealGas> b = ScaledEOS<IdealGas>(std::move(a), scale);
+      EOS eos = ShiftedEOS<ScaledEOS<IdealGas>>(std::move(b), shift);
       THEN("The shift and scale parameters pass through correctly") {
 
-        REQUIRE( eos.PressureFromDensityInternalEnergy(rho,sie) == 0.4 );
+        REQUIRE(eos.PressureFromDensityInternalEnergy(rho, sie) == 0.4);
       }
     }
     WHEN("We use the EOSBuilder") {
@@ -153,11 +147,9 @@ SCENARIO("EOS Builder and Modifiers","[EOSBuilder],[Modifiers]") {
       scaled_params["scale"].emplace<Real>(scale);
       modifiers[EOSBuilder::EOSModifier::Shifted] = shifted_params;
       modifiers[EOSBuilder::EOSModifier::Scaled] = scaled_params;
-      EOS eos = EOSBuilder::buildEOS(type,
-						       base_params,
-						       modifiers);
+      EOS eos = EOSBuilder::buildEOS(type, base_params, modifiers);
       THEN("The shift and scale parameters pass through correctly") {
-        REQUIRE( eos.PressureFromDensityInternalEnergy(rho,sie) == 0.4 );
+        REQUIRE(eos.PressureFromDensityInternalEnergy(rho, sie) == 0.4);
       }
     }
   }
@@ -175,13 +167,13 @@ SCENARIO("Relativistic EOS", "[EOSBuilder][RelativisticEOS]") {
       base_params["gm1"].emplace<Real>(gm1);
       relativity_params["cl"].emplace<Real>(1.0);
       modifiers[EOSBuilder::EOSModifier::Relativistic] = relativity_params;
-      EOS eos = EOSBuilder::buildEOS(type,base_params,modifiers);
+      EOS eos = EOSBuilder::buildEOS(type, base_params, modifiers);
       THEN("The EOS has finite sound speeds") {
         constexpr Real rho = 1e3;
         constexpr Real sie = 1e3;
         Real bmod = eos.BulkModulusFromDensityInternalEnergy(rho, sie);
         Real cs2 = bmod / rho;
-        REQUIRE( cs2 < 1 );
+        REQUIRE(cs2 < 1);
       }
     }
   }
@@ -189,75 +181,69 @@ SCENARIO("Relativistic EOS", "[EOSBuilder][RelativisticEOS]") {
 
 #ifdef SPINER_USE_HDF
 #ifdef SINGULARITY_TEST_SESAME
-SCENARIO( "SpinerEOS depends on Rho and T", "[SpinerEOS],[DependsRhoT]" ) {
+SCENARIO("SpinerEOS depends on Rho and T", "[SpinerEOS],[DependsRhoT]") {
 
-  GIVEN( "SpinerEOS for steel can be initialized with matid" ) {
-    EOS steelEOS_host_polymorphic
-      = SpinerEOSDependsRhoT(eosName, steelID);
+  GIVEN("SpinerEOS for steel can be initialized with matid") {
+    EOS steelEOS_host_polymorphic = SpinerEOSDependsRhoT(eosName, steelID);
     EOS steelEOS = steelEOS_host_polymorphic.GetOnDevice();
-    auto steelEOS_host
-      = steelEOS_host_polymorphic.get<SpinerEOSDependsRhoT>();
-    THEN( "The correct metadata is read in" ) {
-      REQUIRE( steelEOS_host.matid() == steelID );
-      REQUIRE( steelEOS_host.filename() == eosName );
+    auto steelEOS_host = steelEOS_host_polymorphic.get<SpinerEOSDependsRhoT>();
+    THEN("The correct metadata is read in") {
+      REQUIRE(steelEOS_host.matid() == steelID);
+      REQUIRE(steelEOS_host.filename() == eosName);
 
-      AND_THEN( "We can get a reference density and temperature" ) {
-        Real rho,T,sie,P,cv,bmod,dpde,dvdt;
-        steelEOS_host.ValuesAtReferenceState(rho,T,sie,P,cv,bmod,dpde,dvdt);
-        REQUIRE( isClose(rho,7.91) );
-        REQUIRE( isClose(T,293) );
+      AND_THEN("We can get a reference density and temperature") {
+        Real rho, T, sie, P, cv, bmod, dpde, dvdt;
+        steelEOS_host.ValuesAtReferenceState(rho, T, sie, P, cv, bmod, dpde, dvdt);
+        REQUIRE(isClose(rho, 7.91));
+        REQUIRE(isClose(T, 293));
       }
-      
+
       // TODO: this needs to be a much more rigorous test
-      AND_THEN( "Quantities can be read from density and temperature" ) {
+      AND_THEN("Quantities can be read from density and temperature") {
         int nw_ie{0}, nw_bm{0};
 #ifdef PORTABILITY_STRATEGY_KOKKOS
         using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
-        Kokkos::View<int, atomic_view > n_wrong_ie("wrong_ie");
-        Kokkos::View<int, atomic_view > n_wrong_bm("wrong_bm");
+        Kokkos::View<int, atomic_view> n_wrong_ie("wrong_ie");
+        Kokkos::View<int, atomic_view> n_wrong_bm("wrong_bm");
 #else
-        PortableMDArray<int> n_wrong_ie(&nw_ie,1);
-        PortableMDArray<int> n_wrong_bm(&nw_bm,1);
+        PortableMDArray<int> n_wrong_ie(&nw_ie, 1);
+        PortableMDArray<int> n_wrong_bm(&nw_bm, 1);
 #endif
-        portableFor("calc ie's", 0, 100, PORTABLE_LAMBDA(const int& i)
-        {
-          const double ie = steelEOS.InternalEnergyFromDensityTemperature(1e0,1e6);
-          const double bm = steelEOS.BulkModulusFromDensityTemperature(1e0, 1e6);
-          if ( !isClose(ie, 4.96416e13) )
-            n_wrong_ie() += 1;
-          if ( !isClose(bm, 2.55268e13) )
-            n_wrong_bm() += 1;
-        });
+        portableFor(
+            "calc ie's", 0, 100, PORTABLE_LAMBDA(const int &i) {
+              const double ie = steelEOS.InternalEnergyFromDensityTemperature(1e0, 1e6);
+              const double bm = steelEOS.BulkModulusFromDensityTemperature(1e0, 1e6);
+              if (!isClose(ie, 4.96416e13)) n_wrong_ie() += 1;
+              if (!isClose(bm, 2.55268e13)) n_wrong_bm() += 1;
+            });
 #ifdef PORTABILITY_STRATEGY_KOKKOS
         Kokkos::deep_copy(nw_ie, n_wrong_ie);
         Kokkos::deep_copy(nw_bm, n_wrong_bm);
 #endif
-        REQUIRE( nw_ie == 0 );
-        REQUIRE( nw_bm == 0 );
+        REQUIRE(nw_ie == 0);
+        REQUIRE(nw_bm == 0);
       }
 
-      AND_THEN( "rho(P,T) correct for P=1atm, T=room temp" ) {
-        Real T = 273; // Kelvin
-        Real P = 1e6; // barye
+      AND_THEN("rho(P,T) correct for P=1atm, T=room temp") {
+        Real T = 273;  // Kelvin
+        Real P = 1e6;  // barye
         Real rho, sie; // output
         std::vector<Real> lambda(steelEOS_host_polymorphic.nlambda());
-        steelEOS_host_polymorphic.DensityEnergyFromPressureTemperature(P,T,
-                                                                       lambda.data(),
-                                                                       rho,sie);
-        REQUIRE( isClose( sie, -6.28625e+07 ) );
-        REQUIRE( isClose( rho, 7.90679) );
+        steelEOS_host_polymorphic.DensityEnergyFromPressureTemperature(
+            P, T, lambda.data(), rho, sie);
+        REQUIRE(isClose(sie, -6.28625e+07));
+        REQUIRE(isClose(rho, 7.90679));
       }
 
-      AND_THEN( "rho(P,T) correct for P = 0, T = room temp" ) {
+      AND_THEN("rho(P,T) correct for P = 0, T = room temp") {
         Real T = 273; // Kelvin
-        Real P = 0; // barye
+        Real P = 0;   // barye
         Real rho, sie;
         std::vector<Real> lambda(steelEOS_host_polymorphic.nlambda());
-        steelEOS_host_polymorphic.DensityEnergyFromPressureTemperature(P,T,
-                                                                       lambda.data(),
-                                                                       rho,sie);
-        REQUIRE( isClose( rho, 7.90679 ) );
-        REQUIRE( isClose( sie, -6.28601e+07 ) );
+        steelEOS_host_polymorphic.DensityEnergyFromPressureTemperature(
+            P, T, lambda.data(), rho, sie);
+        REQUIRE(isClose(rho, 7.90679));
+        REQUIRE(isClose(sie, -6.28601e+07));
       }
     }
     // Failing to call finalize leads to a memory leak,
@@ -267,138 +253,130 @@ SCENARIO( "SpinerEOS depends on Rho and T", "[SpinerEOS],[DependsRhoT]" ) {
     // we can re-examine.
     steelEOS_host_polymorphic.Finalize(); // host and device must be
                                           // finalized separately.
-    steelEOS.Finalize(); // cleans up memory on device.
+    steelEOS.Finalize();                  // cleans up memory on device.
   }
 
-  GIVEN( "SpinerEOS for air can be initialized with matid" ) {
+  GIVEN("SpinerEOS for air can be initialized with matid") {
     SpinerEOSDependsRhoT airEOS_host = SpinerEOSDependsRhoT(eosName, airID);
     EOS airEOS = airEOS_host.GetOnDevice();
     constexpr Real rho = 1e0;
     constexpr Real sie = 2.5e-4;
-    THEN( "We can get a reference state" ) {
-      Real rho,T,sie,P,cv,bmod,dpde,dvdt;
-      airEOS_host.ValuesAtReferenceState(rho,T,sie,P,cv,bmod,dpde,dvdt);
-      REQUIRE( isClose(rho, 0.001293) );
-      REQUIRE( isClose(T, 293) );
+    THEN("We can get a reference state") {
+      Real rho, T, sie, P, cv, bmod, dpde, dvdt;
+      airEOS_host.ValuesAtReferenceState(rho, T, sie, P, cv, bmod, dpde, dvdt);
+      REQUIRE(isClose(rho, 0.001293));
+      REQUIRE(isClose(T, 293));
     }
-    THEN( "Quantities of rho and sie look sane on the cold curve on host" ) {
-      Real Gamma = airEOS_host.GruneisenParamFromDensityInternalEnergy(rho,
-                                                                       sie);
-      REQUIRE( isClose(Gamma, 1.7873096807718434e+00) );
-      Real bMod = airEOS_host.BulkModulusFromDensityInternalEnergy(rho,sie);
-      REQUIRE( isClose(std::sqrt(bMod/rho), 1.7110234124731066e+05) );
-      Real T = airEOS_host.TemperatureFromDensityInternalEnergy(rho,sie);
-      REQUIRE( isClose(T, 175.236) );
-      Real cv = airEOS_host.SpecificHeatFromDensityInternalEnergy(rho,sie);
-      REQUIRE( isClose(ev2k*cv, 9.3694474640148560e+10) );
+    THEN("Quantities of rho and sie look sane on the cold curve on host") {
+      Real Gamma = airEOS_host.GruneisenParamFromDensityInternalEnergy(rho, sie);
+      REQUIRE(isClose(Gamma, 1.7873096807718434e+00));
+      Real bMod = airEOS_host.BulkModulusFromDensityInternalEnergy(rho, sie);
+      REQUIRE(isClose(std::sqrt(bMod / rho), 1.7110234124731066e+05));
+      Real T = airEOS_host.TemperatureFromDensityInternalEnergy(rho, sie);
+      REQUIRE(isClose(T, 175.236));
+      Real cv = airEOS_host.SpecificHeatFromDensityInternalEnergy(rho, sie);
+      REQUIRE(isClose(ev2k * cv, 9.3694474640148560e+10));
     }
-    THEN( "Quantities of rho and sie look sane on the cold curve on device" ) {
+    THEN("Quantities of rho and sie look sane on the cold curve on device") {
       int nw_gm1{0}, nw_cv{0};
 #ifdef PORTABILITY_STRATEGY_KOKKOS
       using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
-      Kokkos::View<int, atomic_view > n_wrong_gm1("wrong_gm1");
-      Kokkos::View<int, atomic_view > n_wrong_cv("wrong_cv");
+      Kokkos::View<int, atomic_view> n_wrong_gm1("wrong_gm1");
+      Kokkos::View<int, atomic_view> n_wrong_cv("wrong_cv");
 #else
-      PortableMDArray<int> n_wrong_gm1(&nw_gm1,1);
-      PortableMDArray<int> n_wrong_cv(&nw_cv,1);
+      PortableMDArray<int> n_wrong_gm1(&nw_gm1, 1);
+      PortableMDArray<int> n_wrong_cv(&nw_cv, 1);
 #endif
-      portableFor("calc gm1 and cv", 0, 100, PORTABLE_LAMBDA(const int& i)
-        {
-          const double gm1 = airEOS.GruneisenParamFromDensityInternalEnergy(rho,sie);
-          const double cv  = airEOS.SpecificHeatFromDensityInternalEnergy(rho, sie);
-          if ( !isClose(gm1, 1.7873096807718434e+00) )
-            n_wrong_gm1() += 1;
-          if ( !isClose(cv*ev2k, 9.3694474640148560e+10) )
-            n_wrong_cv() += 1;
-        });
+      portableFor(
+          "calc gm1 and cv", 0, 100, PORTABLE_LAMBDA(const int &i) {
+            const double gm1 = airEOS.GruneisenParamFromDensityInternalEnergy(rho, sie);
+            const double cv = airEOS.SpecificHeatFromDensityInternalEnergy(rho, sie);
+            if (!isClose(gm1, 1.7873096807718434e+00)) n_wrong_gm1() += 1;
+            if (!isClose(cv * ev2k, 9.3694474640148560e+10)) n_wrong_cv() += 1;
+          });
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-        Kokkos::deep_copy(nw_gm1, n_wrong_gm1);
-        Kokkos::deep_copy(nw_cv, n_wrong_cv);
+      Kokkos::deep_copy(nw_gm1, n_wrong_gm1);
+      Kokkos::deep_copy(nw_cv, n_wrong_cv);
 #endif
-        REQUIRE( nw_gm1 == 0 );
-        REQUIRE( nw_cv == 0 );
+      REQUIRE(nw_gm1 == 0);
+      REQUIRE(nw_cv == 0);
     }
     airEOS_host.Finalize();
     airEOS.Finalize();
   }
 
-  GIVEN( "SpinerEOS for Deuterium can be initialized with matid" ) {
+  GIVEN("SpinerEOS for Deuterium can be initialized with matid") {
     SpinerEOSDependsRhoT dtEOS_host = SpinerEOSDependsRhoT(eosName, DTID);
-    Real P   = 1e8;
+    Real P = 1e8;
     Real rho = 1.28e-3;
-    THEN( "Inversion for T(rho,P) works on host" ) {
+    THEN("Inversion for T(rho,P) works on host") {
       Real T, sie, cv, bmod;
-      unsigned long output = (thermalqs::temperature |
-                              thermalqs::specific_internal_energy |
-                              thermalqs::specific_heat |
-                              thermalqs::bulk_modulus);
-      dtEOS_host.FillEos(rho,T,sie,P,cv,bmod,output);
-      REQUIRE( isClose( T, 3.126436e-1*ev2k ) );
-      REQUIRE( isClose( sie, 2.82e11 ) );
-      REQUIRE( isClose( cv*ev2k, 1.862e12 ) );
-      REQUIRE( isClose( std::sqrt(bmod/rho), 311563 ) );
+      unsigned long output =
+          (thermalqs::temperature | thermalqs::specific_internal_energy |
+           thermalqs::specific_heat | thermalqs::bulk_modulus);
+      dtEOS_host.FillEos(rho, T, sie, P, cv, bmod, output);
+      REQUIRE(isClose(T, 3.126436e-1 * ev2k));
+      REQUIRE(isClose(sie, 2.82e11));
+      REQUIRE(isClose(cv * ev2k, 1.862e12));
+      REQUIRE(isClose(std::sqrt(bmod / rho), 311563));
     }
     dtEOS_host.Finalize();
   }
 
-  GIVEN( "SpinerEOS for Gold can be initialized with matid" ) {
+  GIVEN("SpinerEOS for Gold can be initialized with matid") {
     SpinerEOSDependsRhoT goldEOS_host = SpinerEOSDependsRhoT(eosName, goldID);
-    THEN( "PT lookup works on the host" ) {
-      Real P = 1e6; // cgs
-      Real T = 0.025/ev2k; // K
+    THEN("PT lookup works on the host") {
+      Real P = 1e6;          // cgs
+      Real T = 0.025 / ev2k; // K
       Real rho, sie;
       std::vector<Real> lambda(goldEOS_host.nlambda());
-      goldEOS_host.DensityEnergyFromPressureTemperature(P,T,lambda.data(),rho,sie);
-      REQUIRE( isClose(rho, 19.2756) );
-      REQUIRE( isClose(sie, 1.93876e+07) );
+      goldEOS_host.DensityEnergyFromPressureTemperature(P, T, lambda.data(), rho, sie);
+      REQUIRE(isClose(rho, 19.2756));
+      REQUIRE(isClose(sie, 1.93876e+07));
     }
     goldEOS_host.Finalize();
   }
 }
 
 // Disabling these tests for now as the DependsRhoSie code is not well-maintained
-SCENARIO( "SpinerEOS depends on rho and sie", "[SpinerEOS],[DependsRhoSie]" ) {
+SCENARIO("SpinerEOS depends on rho and sie", "[SpinerEOS],[DependsRhoSie]") {
 
-  GIVEN( "SpinerEOSes for steel can be initialised with matid" ) {
+  GIVEN("SpinerEOSes for steel can be initialised with matid") {
     SpinerEOSDependsRhoSie steelEOS_host(eosName, steelID);
     EOS steelEOS = steelEOS_host.GetOnDevice();
-    THEN( "The correct metadata is read in" ) {
-      REQUIRE( steelEOS_host.matid() == steelID );
-      REQUIRE( steelEOS_host.filename() == eosName );
+    THEN("The correct metadata is read in") {
+      REQUIRE(steelEOS_host.matid() == steelID);
+      REQUIRE(steelEOS_host.filename() == eosName);
       // REQUIRE( steelEOS_host.lRhoOffset() == 0 );
       // REQUIRE( steelEOS_host.lTOffset() == 0 );
       // REQUIRE( isClose(steelEOS_host.lEOffset(), 0) );
 
-      int nw_ie2{0}, nw_te2{0};      
+      int nw_ie2{0}, nw_te2{0};
 #ifdef PORTABILITY_STRATEGY_KOKKOS
       using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
-      Kokkos::View<int, atomic_view > n_wrong_ie("wrong_ie");
-      Kokkos::View<int, atomic_view > n_wrong_te("wrong_te");
+      Kokkos::View<int, atomic_view> n_wrong_ie("wrong_ie");
+      Kokkos::View<int, atomic_view> n_wrong_te("wrong_te");
 #else
-      PortableMDArray<int> n_wrong_ie(&nw_ie2,1);
-      PortableMDArray<int> n_wrong_te(&nw_te2,1);
+      PortableMDArray<int> n_wrong_ie(&nw_ie2, 1);
+      PortableMDArray<int> n_wrong_te(&nw_te2, 1);
 #endif
-      portableFor("calc ie's", 0, 100, PORTABLE_LAMBDA(const int& i)
-      {
-        const Real
-          ie {steelEOS.InternalEnergyFromDensityTemperature(1e0,1e6)};
-        const Real
-          te {steelEOS.TemperatureFromDensityInternalEnergy(1e0,1e12)};
-        if ( !isClose(ie, 4.96415e13) )
-          n_wrong_ie() += 1;
-        if ( !isClose(te, 75594.6) )
-          n_wrong_te() += 1;
-      });
+      portableFor(
+          "calc ie's", 0, 100, PORTABLE_LAMBDA(const int &i) {
+            const Real ie{steelEOS.InternalEnergyFromDensityTemperature(1e0, 1e6)};
+            const Real te{steelEOS.TemperatureFromDensityInternalEnergy(1e0, 1e12)};
+            if (!isClose(ie, 4.96415e13)) n_wrong_ie() += 1;
+            if (!isClose(te, 75594.6)) n_wrong_te() += 1;
+          });
 #ifdef PORTABILITY_STRATEGY_KOKKOS
       Kokkos::deep_copy(nw_ie2, n_wrong_ie);
       Kokkos::deep_copy(nw_te2, n_wrong_te);
 #endif
-      REQUIRE( nw_ie2 == 0 );
-      REQUIRE( nw_te2 == 0 );
+      REQUIRE(nw_ie2 == 0);
+      REQUIRE(nw_te2 == 0);
     }
     // this can be removed with with reference counting or other tricks
     steelEOS_host.Finalize(); // cleans up host memory
-    steelEOS.Finalize(); // cleans up device memory
+    steelEOS.Finalize();      // cleans up device memory
   }
 }
 
@@ -417,13 +395,10 @@ SCENARIO("EOS Builder and SpinerEOS",
       scaled_params["scale"].emplace<Real>(scale);
       modifiers[EOSBuilder::EOSModifier::Shifted] = shifted_params;
       modifiers[EOSBuilder::EOSModifier::Scaled] = scaled_params;
-      EOS eosHost = EOSBuilder::buildEOS(type,
-                                         base_params,
-                                         modifiers);
+      EOS eosHost = EOSBuilder::buildEOS(type, base_params, modifiers);
       THEN("The EOS is consistent.") {
-        REQUIRE( isClose(4.96416e13,
-                         eosHost.InternalEnergyFromDensityTemperature(1e0,1e6)
-                         ));
+        REQUIRE(
+            isClose(4.96416e13, eosHost.InternalEnergyFromDensityTemperature(1e0, 1e6)));
       }
       WHEN("We get an EOS on device") {
         EOS eosDevice = eosHost.GetOnDevice();
@@ -431,21 +406,19 @@ SCENARIO("EOS Builder and SpinerEOS",
           int nw_bm{0};
 #ifdef PORTABILITY_STRATEGY_KOKKOS
           using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
-          Kokkos::View<int, atomic_view > n_wrong_bm("wrong_bm");
+          Kokkos::View<int, atomic_view> n_wrong_bm("wrong_bm");
 #else
-          PortableMDArray<int> n_wrong_bm(&nw_bm,1);
+          PortableMDArray<int> n_wrong_bm(&nw_bm, 1);
 #endif
-          portableFor("calc ie's", 0, 100, PORTABLE_LAMBDA(const int& i)
-                      {
-                        const Real
-                          bm {eosDevice.BulkModulusFromDensityTemperature(1e0, 1e6)};
-                        if ( !isClose(bm, 2.55268e13) )
-                          n_wrong_bm() += 1;
-                      });
+          portableFor(
+              "calc ie's", 0, 100, PORTABLE_LAMBDA(const int &i) {
+                const Real bm{eosDevice.BulkModulusFromDensityTemperature(1e0, 1e6)};
+                if (!isClose(bm, 2.55268e13)) n_wrong_bm() += 1;
+              });
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-          Kokkos::deep_copy(nw_bm, n_wrong_bm);        
+          Kokkos::deep_copy(nw_bm, n_wrong_bm);
 #endif
-          REQUIRE( nw_bm == 0 );
+          REQUIRE(nw_bm == 0);
         }
         eosDevice.Finalize();
       }
@@ -456,10 +429,9 @@ SCENARIO("EOS Builder and SpinerEOS",
 #endif // SINGULARITY_TEST_SESAME
 
 #ifdef SINGULARITY_TEST_STELLAR_COLLAPSE
-SCENARIO("Stellar Collapse EOS",
-         "[StellarCollapse][EOSBuilder]") {
-  using singularity::StellarCollapse;
+SCENARIO("Stellar Collapse EOS", "[StellarCollapse][EOSBuilder]") {
   using singularity::IdealGas;
+  using singularity::StellarCollapse;
   const std::string savename = "stellar_collapse_ideal.sp5";
   GIVEN("A stellar collapse EOS") {
     const std::string filename = "../stellar_collapse_ideal.h5";
@@ -468,29 +440,29 @@ SCENARIO("Stellar Collapse EOS",
       AND_THEN("Some properties we expect for ideal gas hold") {
         Real lambda[2];
         Real rho, t, sie, p, cv, b, dpde, dvdt;
-        sc.ValuesAtReferenceState(rho,t,sie,p,cv,b,dpde,dvdt,lambda);
+        sc.ValuesAtReferenceState(rho, t, sie, p, cv, b, dpde, dvdt, lambda);
         Real yemin = sc.YeMin();
         Real yemax = sc.YeMax();
         int N = 123;
-        Real dY = (yemax - yemin)/(N+1);
+        Real dY = (yemax - yemin) / (N + 1);
         for (int i = 0; i < N; ++i) {
-          Real Ye = yemin + i*dY;
+          Real Ye = yemin + i * dY;
           lambda[0] = Ye;
-          REQUIRE(isClose(sie, sc.InternalEnergyFromDensityTemperature(rho,t,lambda)));
+          REQUIRE(isClose(sie, sc.InternalEnergyFromDensityTemperature(rho, t, lambda)));
         }
         Real rhomin = sc.rhoMin();
         Real rhomax = sc.rhoMax();
-        Real drho = (rhomax - rhomin)/(N+1);
+        Real drho = (rhomax - rhomin) / (N + 1);
         for (int i = 0; i < N; ++i) {
-          Real rho = rhomin + i*drho;
-          REQUIRE(isClose(sie, sc.InternalEnergyFromDensityTemperature(rho,t,lambda)));
+          Real rho = rhomin + i * drho;
+          REQUIRE(isClose(sie, sc.InternalEnergyFromDensityTemperature(rho, t, lambda)));
         }
       }
       GIVEN("An Ideal Gas equation of state") {
         constexpr Real gamma = 1.4;
         constexpr Real mp = 1.67262171e-24;
-        constexpr Real Cv = 1./(mp*(gamma-1)); // assumes cgs
-        IdealGas ig(gamma-1, Cv);
+        constexpr Real Cv = 1. / (mp * (gamma - 1)); // assumes cgs
+        IdealGas ig(gamma - 1, Cv);
         auto ig_d = ig.GetOnDevice();
         THEN("The tabulated gamma Stellar Collapse and the gamma agree roughly") {
           Real yemin = sc.YeMin();
@@ -502,53 +474,54 @@ SCENARIO("Stellar Collapse EOS",
           Real lrhomin = sc.lRhoMin();
           Real lrhomax = sc.lRhoMax();
           auto sc_d = sc.GetOnDevice();
-          
+
           int nwrong_h = 0;
 #ifdef PORTABILITY_STRATEGY_KOKKOS
           using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
-          Kokkos::View<int, atomic_view>nwrong_d("wrong");
+          Kokkos::View<int, atomic_view> nwrong_d("wrong");
 #else
           PortableMDArray<int> nwrong_d(&nwrong_h, 1);
 #endif
-          
+
           const int N = 123;
-          const Real dY = (yemax - yemin)/(N+1);
-          const Real dlT = (ltmax - ltmin)/(N+1);
-          const Real dlR = (lrhomax - lrhomin)/(N+1);
-          portableFor("fill eos", 0, N, 0, N, 0, N,
-                      PORTABLE_LAMBDA(const int &k, const int &j, const int &i) {
-                        Real lambda[2];
-                        Real Ye = yemin + k*dY;
-                        Real lT = ltmin + j*dlT;
-                        Real lR = lrhomin + i*dlR;
-                        Real T = std::pow(10.,lT);
-                        Real R = std::pow(10.,lR);
-                        Real e1, e2, p1, p2, cv1, cv2, b1, b2;
-                        unsigned long output = (singularity::thermalqs::pressure
-                                                |singularity::thermalqs::specific_internal_energy
-                                                |singularity::thermalqs::specific_heat
-                                                |singularity::thermalqs::bulk_modulus);
-                        lambda[0] = Ye;
-                        
-                        sc_d.FillEos(R, T, e1, p1, cv1, b1, output, lambda);
-                        ig_d.FillEos(R, T, e2, p2, cv2, b2, output, lambda);
-                        if (!isClose(e1,e2)) {
-                          nwrong_d() += 1;
-                        }
-                        if (!isClose(p1,p2)) {
-                          nwrong_d() += 1;
-                        }
-                        if (!isClose(cv1,cv2)) {
-                           nwrong_d() += 1;
-                        }
-                        if (!isClose(b1,b2)) {
-                          nwrong_d() += 1;
-                        }
-                      });
+          const Real dY = (yemax - yemin) / (N + 1);
+          const Real dlT = (ltmax - ltmin) / (N + 1);
+          const Real dlR = (lrhomax - lrhomin) / (N + 1);
+          portableFor(
+              "fill eos", 0, N, 0, N, 0, N,
+              PORTABLE_LAMBDA(const int &k, const int &j, const int &i) {
+                Real lambda[2];
+                Real Ye = yemin + k * dY;
+                Real lT = ltmin + j * dlT;
+                Real lR = lrhomin + i * dlR;
+                Real T = std::pow(10., lT);
+                Real R = std::pow(10., lR);
+                Real e1, e2, p1, p2, cv1, cv2, b1, b2;
+                unsigned long output = (singularity::thermalqs::pressure |
+                                        singularity::thermalqs::specific_internal_energy |
+                                        singularity::thermalqs::specific_heat |
+                                        singularity::thermalqs::bulk_modulus);
+                lambda[0] = Ye;
+
+                sc_d.FillEos(R, T, e1, p1, cv1, b1, output, lambda);
+                ig_d.FillEos(R, T, e2, p2, cv2, b2, output, lambda);
+                if (!isClose(e1, e2)) {
+                  nwrong_d() += 1;
+                }
+                if (!isClose(p1, p2)) {
+                  nwrong_d() += 1;
+                }
+                if (!isClose(cv1, cv2)) {
+                  nwrong_d() += 1;
+                }
+                if (!isClose(b1, b2)) {
+                  nwrong_d() += 1;
+                }
+              });
 #ifdef PORTABILITY_STRATEGY_KOKKOS
           Kokkos::deep_copy(nwrong_h, nwrong_d);
 #endif
-          REQUIRE( nwrong_h == 0);
+          REQUIRE(nwrong_h == 0);
           sc_d.Finalize();
         }
         ig_d.Finalize();
@@ -587,35 +560,37 @@ SCENARIO("Stellar Collapse EOS",
 #endif
 
             const int N = 123;
-            const Real dY = (yemax - yemin)/(N+1);
-            const Real dlT = (ltmax - ltmin)/(N+1);
-            const Real dlR = (lrhomax - lrhomin)/(N+1);
-            portableFor("fill eos", 0, N, 0, N, 0, N,
-                        PORTABLE_LAMBDA(const int &k, const int &j, const int &i) {
-                          Real lambda[2];
-                          Real Ye = yemin + k*dY;
-                          Real lT = ltmin + j*dlT;
-                          Real lR = lrhomin + i*dlR;
-                          Real T = std::pow(10.,lT);
-                          Real R = std::pow(10.,lR);
-                          Real e1, e2, p1, p2, cv1, cv2, b1, b2;
-                          unsigned long output = (singularity::thermalqs::pressure
-                                                  |singularity::thermalqs::specific_internal_energy
-                                                  |singularity::thermalqs::specific_heat
-                                                  |singularity::thermalqs::bulk_modulus);
-                          lambda[0] = Ye;
+            const Real dY = (yemax - yemin) / (N + 1);
+            const Real dlT = (ltmax - ltmin) / (N + 1);
+            const Real dlR = (lrhomax - lrhomin) / (N + 1);
+            portableFor(
+                "fill eos", 0, N, 0, N, 0, N,
+                PORTABLE_LAMBDA(const int &k, const int &j, const int &i) {
+                  Real lambda[2];
+                  Real Ye = yemin + k * dY;
+                  Real lT = ltmin + j * dlT;
+                  Real lR = lrhomin + i * dlR;
+                  Real T = std::pow(10., lT);
+                  Real R = std::pow(10., lR);
+                  Real e1, e2, p1, p2, cv1, cv2, b1, b2;
+                  unsigned long output =
+                      (singularity::thermalqs::pressure |
+                       singularity::thermalqs::specific_internal_energy |
+                       singularity::thermalqs::specific_heat |
+                       singularity::thermalqs::bulk_modulus);
+                  lambda[0] = Ye;
 
-                          sc1_d.FillEos(R, T, e1, p1, cv1, b1, output, lambda);
-                          sc2_d.FillEos(R, T, e2, p2, cv2, b2, output, lambda);
-                          if (!isClose(e1,e2)) nwrong_d() += 1;
-                          if (!isClose(p1,p2)) nwrong_d() += 1;
-                          if (!isClose(cv1,cv2)) nwrong_d() += 1;
-                          if (!isClose(b1,b2)) nwrong_d() += 1;
-                        });
+                  sc1_d.FillEos(R, T, e1, p1, cv1, b1, output, lambda);
+                  sc2_d.FillEos(R, T, e2, p2, cv2, b2, output, lambda);
+                  if (!isClose(e1, e2)) nwrong_d() += 1;
+                  if (!isClose(p1, p2)) nwrong_d() += 1;
+                  if (!isClose(cv1, cv2)) nwrong_d() += 1;
+                  if (!isClose(b1, b2)) nwrong_d() += 1;
+                });
 #ifdef PORTABILITY_STRATEGY_KOKKOS
             Kokkos::deep_copy(nwrong_h, nwrong_d);
 #endif
-            REQUIRE( nwrong_h == 0);
+            REQUIRE(nwrong_h == 0);
 
             sc1_d.Finalize();
             sc2_d.Finalize();
@@ -632,36 +607,34 @@ SCENARIO("Stellar Collapse EOS",
 
 #ifdef SINGULARITY_USE_EOSPAC
 #ifdef SINGULARITY_TEST_SESAME
-SCENARIO( "EOSPAC API", "[EOSPAC]") {
-  GIVEN( "An EOSPAC EOS initialized with steel" ) {
+SCENARIO("EOSPAC API", "[EOSPAC]") {
+  GIVEN("An EOSPAC EOS initialized with steel") {
     EOS eos = EOSPAC(steelID);
     THEN("We can get a reference density and temperature") {
       Real rho, T, sie, P, cv, bmod, dpde, dvdt;
       eos.ValuesAtReferenceState(rho, T, sie, P, cv, bmod, dpde, dvdt);
-      REQUIRE( isClose(rho, 7.91) );
-      REQUIRE( isClose(T, 293) );
+      REQUIRE(isClose(rho, 7.91));
+      REQUIRE(isClose(T, 293));
     }
     THEN("Quantities can be read from density and temperature") {
-      Real ie = eos.InternalEnergyFromDensityTemperature(1e0,1e6);
-      REQUIRE( isClose(ie, 4.96416e13) );
+      Real ie = eos.InternalEnergyFromDensityTemperature(1e0, 1e6);
+      REQUIRE(isClose(ie, 4.96416e13));
       Real bm = eos.BulkModulusFromDensityTemperature(1e0, 1e6);
-      REQUIRE( isClose(bm, 2.27214e+13) );
+      REQUIRE(isClose(bm, 2.27214e+13));
     }
   }
 }
 #endif // SINGULARITY_TEST_SESAME
 #endif // SINGULARITY_USE_EOSPAC
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
 
-#ifdef PORTABILITY_STRATEGY_KOKKOS  
+#ifdef PORTABILITY_STRATEGY_KOKKOS
   Kokkos::initialize();
 #endif
   int result;
-  {
-    result = Catch::Session().run( argc, argv );
-  }
-#ifdef PORTABILITY_STRATEGY_KOKKOS  
+  { result = Catch::Session().run(argc, argv); }
+#ifdef PORTABILITY_STRATEGY_KOKKOS
   Kokkos::finalize();
 #endif
   return result;

--- a/test/profile_eos.cpp
+++ b/test/profile_eos.cpp
@@ -44,45 +44,40 @@ using Spiner::DataBox;
 using Spiner::RegularGrid1D;
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-using RView = Kokkos::View<Real*>;
+using RView = Kokkos::View<Real *>;
 using RMirror = typename RView::HostMirror;
 #endif
 
 constexpr Real RHO_MIN = 1e-2; // g/cm^3
 constexpr Real RHO_MAX = 1e2;
-constexpr Real T_MIN   = 1e2;  // Kelvin
-constexpr Real T_MAX   = 1e4;
+constexpr Real T_MIN = 1e2; // Kelvin
+constexpr Real T_MAX = 1e4;
 
-inline auto now() {
-  return std::chrono::high_resolution_clock::now();
-}
+inline auto now() { return std::chrono::high_resolution_clock::now(); }
 
-template<typename Function>
+template <typename Function>
 inline double get_duration(Function function) {
   auto start = now();
   function();
   auto stop = now();
-  return std::chrono::duration_cast<duration>(stop-start).count();
+  return std::chrono::duration_cast<duration>(stop - start).count();
 }
 
 /*
   TODO(JMM): Only profiles Pressure call
   and does not accept lambdas.
 */
-inline void get_timing(int ncycles,
-                       const ivec& ncells_1d,
-                       const double rho_min, const double rho_max,
-                       const double T_min, const double T_max,
-                       const std::string& name,
-                       EOS& eos_h) {
+inline void get_timing(int ncycles, const ivec &ncells_1d, const double rho_min,
+                       const double rho_max, const double T_min, const double T_max,
+                       const std::string &name, EOS &eos_h) {
 
   std::cout << "\t...Profiling EOS: " << name << "..." << std::endl;
 
   std::ofstream prof_file;
   std::random_device rd; // seed
   std::mt19937 e2(rd()); // generator
-  std::uniform_real_distribution<> dist_rho(rho_min,rho_max);
-  std::uniform_real_distribution<> dist_T(T_min,T_max);
+  std::uniform_real_distribution<> dist_rho(rho_min, rho_max);
+  std::uniform_real_distribution<> dist_T(T_min, T_max);
 
   ivec ncells(ncells_1d.size());
   dvec zonecycles(ncells_1d.size());
@@ -92,165 +87,151 @@ inline void get_timing(int ncycles,
   dvec throughputs_device(ncells_1d.size());
 
   for (int i = 0; i < ncells_1d.size(); i++) {
-    ncells[i] = ncells_1d[i]*ncells_1d[i]*ncells_1d[i];
-    zonecycles[i] = static_cast<double>(ncycles*ncells[i]);
+    ncells[i] = ncells_1d[i] * ncells_1d[i] * ncells_1d[i];
+    zonecycles[i] = static_cast<double>(ncycles * ncells[i]);
   }
-  
 
   EOS eos_d = eos_h.GetOnDevice();
 
   for (int n = 0; n < ncells_1d.size(); n++) {
-    
+
     std::cout << "\t\t...ncells 1d = " << ncells_1d[n] << std::endl;
 
     const int nc1d = ncells_1d[n];
     const int nc = ncells[n];
-    DataBox P_h(nc1d,nc1d,nc1d);
-    #ifdef PORTABILITY_STRATEGY_KOKKOS
-    RView rho_v("rho",nc); // first views
-    RView T_v("T",nc);
-    RView P_v("P",nc);
+    DataBox P_h(nc1d, nc1d, nc1d);
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+    RView rho_v("rho", nc); // first views
+    RView T_v("T", nc);
+    RView P_v("P", nc);
     RMirror rho_v_hm = Kokkos::create_mirror_view(rho_v);
     RMirror T_v_hm = Kokkos::create_mirror_view(T_v);
     RMirror P_v_hm = Kokkos::create_mirror_view(P_v);
-    DataBox rho_d(rho_v.data(),nc1d,nc1d,nc1d); // wrap viws in databoxes
-    DataBox T_d(T_v.data(),nc1d,nc1d,nc1d);
-    DataBox P_d(P_v.data(),nc1d,nc1d,nc1d);
-    DataBox rho_h(rho_v_hm.data(),nc1d,nc1d,nc1d);
-    DataBox T_h(T_v_hm.data(),nc1d,nc1d,nc1d);
-    DataBox P_hm(P_v_hm.data(),nc1d,nc1d,nc1d);
-    #else
-    DataBox rho_h(nc1d,nc1d,nc1d);
-    DataBox T_h(nc1d,nc1d,nc1d);
-    DataBox rho_d = rho_h.slice(3,0,nc1d);
-    DataBox T_d = T_h.slice(3,0,nc1d);
-    DataBox P_d(nc1d,nc1d,nc1d);
-    DataBox P_hm = P_d.slice(3,0,nc1d);
-    #endif
+    DataBox rho_d(rho_v.data(), nc1d, nc1d, nc1d); // wrap viws in databoxes
+    DataBox T_d(T_v.data(), nc1d, nc1d, nc1d);
+    DataBox P_d(P_v.data(), nc1d, nc1d, nc1d);
+    DataBox rho_h(rho_v_hm.data(), nc1d, nc1d, nc1d);
+    DataBox T_h(T_v_hm.data(), nc1d, nc1d, nc1d);
+    DataBox P_hm(P_v_hm.data(), nc1d, nc1d, nc1d);
+#else
+    DataBox rho_h(nc1d, nc1d, nc1d);
+    DataBox T_h(nc1d, nc1d, nc1d);
+    DataBox rho_d = rho_h.slice(3, 0, nc1d);
+    DataBox T_d = T_h.slice(3, 0, nc1d);
+    DataBox P_d(nc1d, nc1d, nc1d);
+    DataBox P_hm = P_d.slice(3, 0, nc1d);
+#endif
 
     for (int k = 0; k < nc1d; k++) {
       for (int j = 0; j < nc1d; j++) {
         for (int i = 0; i < nc1d; i++) {
-          rho_h(k,j,i) = dist_rho(e2);
-          T_h(k,j,i) = dist_T(e2);
+          rho_h(k, j, i) = dist_rho(e2);
+          T_h(k, j, i) = dist_T(e2);
         }
       }
     }
-    #ifdef PORTABILITY_STRATEGY_KOKKOS
-    Kokkos::deep_copy(rho_v,rho_v_hm);
-    Kokkos::deep_copy(T_v,T_v_hm);
-    #endif
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+    Kokkos::deep_copy(rho_v, rho_v_hm);
+    Kokkos::deep_copy(T_v, T_v_hm);
+#endif
 
     durations_host[n] = get_duration([&]() {
-        for (int cycle = 0; cycle < ncycles; cycle++) {
-          #pragma omp parallel
-          for (int k = 0; k < nc1d; k++) {
-            for (int j = 0; j< nc1d; j++) {
-              for (int i = 0; i < nc1d; i++) {
-                P_h(k,j,i) = eos_h.PressureFromDensityTemperature(rho_h(k,j,i),
-                                                                  T_h(k,j,i));
-              }
+      for (int cycle = 0; cycle < ncycles; cycle++) {
+#pragma omp parallel
+        for (int k = 0; k < nc1d; k++) {
+          for (int j = 0; j < nc1d; j++) {
+            for (int i = 0; i < nc1d; i++) {
+              P_h(k, j, i) =
+                  eos_h.PressureFromDensityTemperature(rho_h(k, j, i), T_h(k, j, i));
             }
           }
         }
-      });
-    durations_host[n] /= static_cast<Real>(nc*ncycles);
+      }
+    });
+    durations_host[n] /= static_cast<Real>(nc * ncycles);
 
     durations_device[n] = get_duration([&]() {
-        portableFor("pressure from density and temperature",
-                    0,ncycles,0,nc1d,0,nc1d,0,nc1d,
-                    PORTABLE_LAMBDA(const int& n, const int& k,
-                                    const int& j, const int& i) {
-                      P_d(k,j,i) = eos_d.PressureFromDensityTemperature(rho_d(k,j,i),
-                                                                        T_d(k,j,i));
-                    });
-      });
-    durations_device[n] /= static_cast<Real>(nc*ncycles);
+      portableFor(
+          "pressure from density and temperature", 0, ncycles, 0, nc1d, 0, nc1d, 0, nc1d,
+          PORTABLE_LAMBDA(const int &n, const int &k, const int &j, const int &i) {
+            P_d(k, j, i) =
+                eos_d.PressureFromDensityTemperature(rho_d(k, j, i), T_d(k, j, i));
+          });
+    });
+    durations_device[n] /= static_cast<Real>(nc * ncycles);
 
-    throughputs_host[n] = 1e6/durations_host[n];
-    throughputs_device[n] = 1e6/durations_device[n];
+    throughputs_host[n] = 1e6 / durations_host[n];
+    throughputs_device[n] = 1e6 / durations_device[n];
 
-    #ifdef PORTABILITY_STRATEGY_KOKKOS
+#ifdef PORTABILITY_STRATEGY_KOKKOS
     Kokkos::deep_copy(P_v_hm, P_v);
-    #endif
+#endif
     Real max_diff = 0;
     for (int k = 0; k < nc1d; k++) {
       for (int j = 0; j < nc1d; j++) {
         for (int i = 0; i < nc1d; i++) {
-          Real diff = (100.*std::abs(P_h(k,j,i) - P_hm(k,j,i))
-                       /(std::abs(P_h(k,j,i)) + 1e-20));
+          Real diff = (100. * std::abs(P_h(k, j, i) - P_hm(k, j, i)) /
+                       (std::abs(P_h(k, j, i)) + 1e-20));
           if (diff > max_diff) max_diff = diff;
         }
       }
     }
-    std::cout << "\t\t\t...max difference = "
-              << max_diff << "%"
-              << std::endl;
+    std::cout << "\t\t\t...max difference = " << max_diff << "%" << std::endl;
   }
 
-  prof_file.open(name + "_timing.dat",
-                 std::ios::out | std::ios::trunc);
+  prof_file.open(name + "_timing.dat", std::ios::out | std::ios::trunc);
   prof_file << "# EOS name = " << name << "\n"
             << "# Columns:\n"
             << "# [0]: ncells/axis\n"
             << "# [1]: time/point on host   (microseconds)\n"
             << "# [2]: throughput on host   (zone-cycles/node-second)\n"
             << "# [3]: time/point on device (microseconds)\n"
-            << "# [4]: throughput on device (zone-cycles/GPU-second)"
-            << std::endl;
+            << "# [4]: throughput on device (zone-cycles/GPU-second)" << std::endl;
   for (int n = 0; n < ncells_1d.size(); n++) {
-    prof_file << std::setw(10)
-              << ncells_1d[n] << "\t"
-              << durations_host[n] << "\t"
-              << throughputs_host[n] << "\t"
-              << durations_device[n] << "\t"
-              << throughputs_device[n]
-              << std::endl;
+    prof_file << std::setw(10) << ncells_1d[n] << "\t" << durations_host[n] << "\t"
+              << throughputs_host[n] << "\t" << durations_device[n] << "\t"
+              << throughputs_device[n] << std::endl;
   }
   prof_file.close();
 
   eos_d.Finalize();
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
 
-  #ifdef PORTABILITY_STRATEGY_KOKKOS
-  Kokkos::initialize(argc,argv);
-  #endif
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  Kokkos::initialize(argc, argv);
+#endif
   {
     ivec ncells_1d;
     if (argc < 3) {
-      std::cerr << argv[0]
-                << ": ncycles ncells1, ncells2, ncells3, ..."
-                << std::endl;
+      std::cerr << argv[0] << ": ncycles ncells1, ncells2, ncells3, ..." << std::endl;
       return 1;
     }
-    
+
     int ncycles = std::atoi(argv[1]);
-    
-    ncells_1d.resize(argc-2);
+
+    ncells_1d.resize(argc - 2);
     for (int i = 2; i < argc; i++) {
-      ncells_1d[i-2] = std::atoi(argv[i]);
+      ncells_1d[i - 2] = std::atoi(argv[i]);
     }
-    
+
     std::cout << "Welcome to the profiler.\n"
               << "Please note that timings are for 1 node and 1 GPU respectively.\n"
               << "Beginning profiling..." << std::endl;
-    
+
     EOSBuilder::EOSType type = EOSBuilder::EOSType::IdealGas;
     EOSBuilder::params_t params;
-    params["Cv"] = 1e7*0.716; // specific heat in ergs/(g K)
-    params["gm1"] = 0.4; // gamma - 1
-    EOS eos = EOSBuilder::buildEOS(type,params);
-    get_timing(ncycles, ncells_1d,
-               RHO_MIN, RHO_MAX, T_MIN, T_MAX,
-               "IdealGas", eos);
-    
+    params["Cv"] = 1e7 * 0.716; // specific heat in ergs/(g K)
+    params["gm1"] = 0.4;        // gamma - 1
+    EOS eos = EOSBuilder::buildEOS(type, params);
+    get_timing(ncycles, ncells_1d, RHO_MIN, RHO_MAX, T_MIN, T_MAX, "IdealGas", eos);
+
     std::cout << "Done." << std::endl;
   }
-  #ifdef PORTABILITY_STRATEGY_KOKKOS
+#ifdef PORTABILITY_STRATEGY_KOKKOS
   Kokkos::finalize();
-  #endif
+#endif
 
   return 0;
 }

--- a/test/test_pte.cpp
+++ b/test/test_pte.cpp
@@ -19,10 +19,10 @@
 #include <time.h>
 #include <vector>
 
-#include <singularity-eos/eos/eos.hpp>
-#include <singularity-eos/closure/mixed_cell_models.hpp>
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
+#include <singularity-eos/closure/mixed_cell_models.hpp>
+#include <singularity-eos/eos/eos.hpp>
 #include <spiner/databox.hpp>
 
 constexpr int NMAT = 3;
@@ -33,37 +33,39 @@ constexpr int HIST_SIZE = 10;
 using namespace singularity;
 using Spiner::DataBox;
 
-template <typename T> class LinearIndexer {
-public:
+template <typename T>
+class LinearIndexer {
+ public:
   PORTABLE_FUNCTION LinearIndexer() = default;
   LinearIndexer(const T &t) : data_(t) {}
   PORTABLE_INLINE_FUNCTION
   auto &operator[](const int i) const { return data_(i); }
 
-private:
+ private:
   T data_;
 };
 
-template <typename T> class Indexer2D {
-public:
+template <typename T>
+class Indexer2D {
+ public:
   PORTABLE_FUNCTION Indexer2D() = default;
   PORTABLE_FUNCTION Indexer2D(const int j, const T &t) : j_(j), data_(t) {}
   Indexer2D(const int j, const T &&t) = delete; // prevents r-value binding
   PORTABLE_INLINE_FUNCTION
   auto &operator[](const int i) const { return data_(j_, i); }
 
-private:
+ private:
   const int j_;
   const T &data_;
 };
 
-template <typename EOSIndexer> void set_eos(EOSIndexer &&eos) {
-  eos[0] = Gruneisen(394000.0, 1.489, 0.0, 0.0, 2.02, 0.47, 8.93, 297.0, 1.0e6,
-                     0.383e7);
-  eos[1] = DavisReactants(1.890, 4.115e10, 1.0e6, 297.0, 1.8, 4.6, 0.34, 0.56,
-                          0.0, 0.4265, 0.001074e10);
-  eos[2] = DavisProducts(0.798311, 0.58, 1.35, 2.66182, 0.75419, 3.2e10,
-                         0.001072e10, 0.0);
+template <typename EOSIndexer>
+void set_eos(EOSIndexer &&eos) {
+  eos[0] = Gruneisen(394000.0, 1.489, 0.0, 0.0, 2.02, 0.47, 8.93, 297.0, 1.0e6, 0.383e7);
+  eos[1] = DavisReactants(1.890, 4.115e10, 1.0e6, 297.0, 1.8, 4.6, 0.34, 0.56, 0.0,
+                          0.4265, 0.001074e10);
+  eos[2] =
+      DavisProducts(0.798311, 0.58, 1.35, 2.66182, 0.75419, 3.2e10, 0.001072e10, 0.0);
 }
 
 template <typename RealIndexer, typename EOSIndexer>
@@ -121,7 +123,7 @@ int main(int argc, char *argv[]) {
     RView sie_v("sie", NPTS);
     RView temp_v("temp", NPTS);
     RView press_v("press", NPTS);
-    Kokkos::View<int*,atomic_view> hist_d("histogram", HIST_SIZE);
+    Kokkos::View<int *, atomic_view> hist_d("histogram", HIST_SIZE);
     auto rho_vh = Kokkos::create_mirror_view(rho_v);
     auto vfrac_vh = Kokkos::create_mirror_view(vfrac_v);
     auto sie_vh = Kokkos::create_mirror_view(sie_v);
@@ -206,8 +208,8 @@ int main(int argc, char *argv[]) {
           sie_tot /= rho_tot;
 
           int niter = 0;
-          bool success = pte_closure_josh(NMAT, eos, 1.0, sie_tot, rho, vfrac,
-                                          sie, temp, press, lambda, niter);
+          bool success = pte_closure_josh(NMAT, eos, 1.0, sie_tot, rho, vfrac, sie, temp,
+                                          press, lambda, niter);
           if (success) {
             nsuccess_d() += 1;
           }
@@ -217,8 +219,7 @@ int main(int argc, char *argv[]) {
     Kokkos::fence();
 #endif
     auto stop = std::chrono::high_resolution_clock::now();
-    auto sum_time =
-        std::chrono::duration_cast<std::chrono::microseconds>(stop - start);
+    auto sum_time = std::chrono::duration_cast<std::chrono::microseconds>(stop - start);
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
     Kokkos::deep_copy(nsuccess, nsuccess_d);
@@ -227,8 +228,8 @@ int main(int argc, char *argv[]) {
 
     Real milliseconds = sum_time.count() / 1e3;
 
-    std::cout << "Finished " << NTRIAL << " solves in " << milliseconds
-              << " milliseconds" << std::endl;
+    std::cout << "Finished " << NTRIAL << " solves in " << milliseconds << " milliseconds"
+              << std::endl;
     std::cout << "Solves/ms = " << NTRIAL / milliseconds << std::endl;
     std::cout << "Success: " << nsuccess << "   Failure: " << NTRIAL - nsuccess
               << std::endl;
@@ -237,7 +238,7 @@ int main(int argc, char *argv[]) {
               << "----------------------\n";
     for (int i = 0; i < HIST_SIZE; ++i) {
       std::cout << i << "\t" << hist_vh[i] << "\n";
-        }
+    }
     std::cout << std::endl;
   }
 #ifdef PORTABILITY_STRATEGY_KOKKOS

--- a/test/test_pte_flag.cpp
+++ b/test/test_pte_flag.cpp
@@ -14,27 +14,27 @@
 
 #include <iostream>
 //#include <vector>
+#include <chrono>
 #include <memory>
 #include <stdlib.h>
 #include <time.h>
-#include <chrono>
 
 #include <ports-of-call/portability.hpp>
-#include <singularity-eos/eos/eos.hpp>
-#include <singularity-eos/eos/bedroom_door.hpp>
 #include <singularity-eos/closure/mixed_cell_models.hpp>
+#include <singularity-eos/eos/bedroom_door.hpp>
+#include <singularity-eos/eos/eos.hpp>
 
-static constexpr const int NMAT {3};
-static constexpr const int NTRIAL {3};
+static constexpr const int NMAT{3};
+static constexpr const int NTRIAL{3};
 
-template <typename T> using TempArray = std::unique_ptr<T[]>;
+template <typename T>
+using TempArray = std::unique_ptr<T[]>;
 using RealArray = TempArray<Real>;
 using IntArray = TempArray<int>;
 
 using namespace singularity;
 
-void set_state(RealArray& rho, RealArray& vfrac, RealArray& sie,
-               BetterEOS* eos) {
+void set_state(RealArray &rho, RealArray &vfrac, RealArray &sie, BetterEOS *eos) {
 
   rho[0] = 8.93;
   rho[1] = 1.89;
@@ -43,26 +43,25 @@ void set_state(RealArray& rho, RealArray& vfrac, RealArray& sie,
   Real vsum = 0.;
   for (int i = 0; i < NMAT; i++) {
     sie[i] = eos[i].InternalEnergyFromDensityTemperature(rho[i], 600.0);
-    vfrac[i] = rand()/(1.0*RAND_MAX);
+    vfrac[i] = rand() / (1.0 * RAND_MAX);
     vsum += vfrac[i];
   }
 
-  for (int i = 0; i < NMAT; i++) vfrac[i] *= 1.0/vsum;
-
+  for (int i = 0; i < NMAT; i++)
+    vfrac[i] *= 1.0 / vsum;
 }
 
-void compare_values(const int n, const RealArray& a, const RealArray& b,
-                    const char* s) {
-  for (int i {0}; i < n; ++i) {
+void compare_values(const int n, const RealArray &a, const RealArray &b, const char *s) {
+  for (int i{0}; i < n; ++i) {
     Real diff = fabs(b[i] - a[i]);
     const Real divide = a[i] == 0.0 ? 1.0 : fabs(a[i]);
-    printf("%s[%i]: %e %e %e\n", s, i, a[i], b[i], diff/divide);
+    printf("%s[%i]: %e %e %e\n", s, i, a[i], b[i], diff / divide);
   }
   return;
 }
 
-void print_values(const int n, const RealArray& a, const char* s) {
-  for (int i {0}; i < n; ++i) {
+void print_values(const int n, const RealArray &a, const char *s) {
+  for (int i{0}; i < n; ++i) {
     printf("%s[%i]: %e\n", s, i, a[i]);
   }
   return;
@@ -70,30 +69,30 @@ void print_values(const int n, const RealArray& a, const char* s) {
 
 int main(int argc, char *argv[]) {
 
-  Real* lambda[NMAT];
-  BetterEOS* eos;
+  Real *lambda[NMAT];
+  BetterEOS *eos;
 
   init_bd_eos(NMAT, eos);
-  eos[0] = Gruneisen(394000.0, 1.489, 0.0, 0.0, 2.02, 0.47, 8.93, 297.0, 1.0e6,
-                     0.383e7);
-  eos[1] = DavisReactants(1.890, 4.115e10, 1.0e6, 297.0, 1.8, 4.6, 0.34, 0.56,
-                          0.0, 0.4265, 0.001074e10);
-  eos[2] = DavisProducts(0.798311, 0.58, 1.35, 2.66182, 0.75419, 3.2e10,
-                         0.001072e10, 0.0);
+  eos[0] = Gruneisen(394000.0, 1.489, 0.0, 0.0, 2.02, 0.47, 8.93, 297.0, 1.0e6, 0.383e7);
+  eos[1] = DavisReactants(1.890, 4.115e10, 1.0e6, 297.0, 1.8, 4.6, 0.34, 0.56, 0.0,
+                          0.4265, 0.001074e10);
+  eos[2] =
+      DavisProducts(0.798311, 0.58, 1.35, 2.66182, 0.75419, 3.2e10, 0.001072e10, 0.0);
 
-  TempArray<Real> rho(new Real [NMAT]);
-  auto vfrac = std::make_unique<Real []>(NMAT);
-  auto sie = std::make_unique<Real []>(NMAT);
-  auto temp = std::make_unique<Real []>(NMAT);
-  auto press = std::make_unique<Real []>(NMAT);
+  TempArray<Real> rho(new Real[NMAT]);
+  auto vfrac = std::make_unique<Real[]>(NMAT);
+  auto sie = std::make_unique<Real[]>(NMAT);
+  auto temp = std::make_unique<Real[]>(NMAT);
+  auto press = std::make_unique<Real[]>(NMAT);
 
-  auto vfrac_flag = std::make_unique<Real []>(NMAT);
-  auto sie_flag = std::make_unique<Real []>(NMAT);
-  auto mass_flag = std::make_unique<Real []>(NMAT);
-  auto mats = std::make_unique<int []>(NMAT);
+  auto vfrac_flag = std::make_unique<Real[]>(NMAT);
+  auto sie_flag = std::make_unique<Real[]>(NMAT);
+  auto mass_flag = std::make_unique<Real[]>(NMAT);
+  auto mats = std::make_unique<int[]>(NMAT);
 
   srand(time(NULL));
-  for (int i = 0; i < NMAT; i++) lambda[i] = nullptr;
+  for (int i = 0; i < NMAT; i++)
+    lambda[i] = nullptr;
 
   std::chrono::duration<double> sum_time = std::chrono::duration<double>::zero();
   int nsuccess = 0;
@@ -101,29 +100,28 @@ int main(int argc, char *argv[]) {
     set_state(rho, vfrac, sie, eos);
     Real sie_tot = 0.0;
     Real mass_tot = 0.0;
-    for (int i = 0 ; i < NMAT; i++) {
-      //std::cout << i << " " << rho[i] << " " << vfrac[i] << " " << sie[i] << std::endl;
-      mass_flag[i] = rho[i]*vfrac[i];
-      mass_tot += rho[i]*vfrac[i];
-      sie_tot += rho[i]*vfrac[i]*sie[i];
+    for (int i = 0; i < NMAT; i++) {
+      // std::cout << i << " " << rho[i] << " " << vfrac[i] << " " << sie[i] << std::endl;
+      mass_flag[i] = rho[i] * vfrac[i];
+      mass_tot += rho[i] * vfrac[i];
+      sie_tot += rho[i] * vfrac[i] * sie[i];
       sie_flag[i] = sie[i];
       vfrac_flag[i] = vfrac[i];
       mats[i] = i;
     }
     sie_tot /= mass_tot;
-    printf("Input set #%i:\nSIE: %e V: 1.0\n", n+1, sie_tot);
+    printf("Input set #%i:\nSIE: %e V: 1.0\n", n + 1, sie_tot);
     print_values(NMAT, sie, "sie");
     print_values(NMAT, vfrac, "vfrac");
     print_values(NMAT, rho, "rho");
     print_values(NMAT, mass_flag, "mass");
-    //std::cout << std::endl;
+    // std::cout << std::endl;
     auto start = std::chrono::high_resolution_clock::now();
-    bool pte_base_success {PTE(NMAT, eos, 1.0, sie_tot, rho, vfrac, sie,
-                               temp, press, lambda)};
-    bool pte_flag_success
-      {pte_closure_flag_offset(NMAT, eos, 1.0, sie_tot, mats.get(),
-                               mass_flag.get(), vfrac_flag.get(),
-                               sie_flag.get(), lambda)};
+    bool pte_base_success{
+        PTE(NMAT, eos, 1.0, sie_tot, rho, vfrac, sie, temp, press, lambda)};
+    bool pte_flag_success{pte_closure_flag_offset(NMAT, eos, 1.0, sie_tot, mats.get(),
+                                                  mass_flag.get(), vfrac_flag.get(),
+                                                  sie_flag.get(), lambda)};
     if (pte_base_success && pte_flag_success) {
       printf("both solvers succeeded\n");
     } else if (!pte_base_success && !pte_flag_success) {
@@ -138,16 +136,18 @@ int main(int argc, char *argv[]) {
     compare_values(NMAT, sie, sie_flag, "sie");
     auto stop = std::chrono::high_resolution_clock::now();
     sum_time += stop - start;
-    //nsuccess += (success ? 1 : 0);
+    // nsuccess += (success ? 1 : 0);
   }
 
-  //std::cout << "PTE solver returned in " << n << " iterations:" << std::endl;
-  //for (int i = 0 ; i < NMAT; i++) {
-  //  std::cout << i << " " << rho[i] << " " << vfrac[i] << " " << sie[i] << " " << " " << rho[i]*vfrac[i]/rho_tot << " " << press[i] << " " << temp[i] << std::endl;
+  // std::cout << "PTE solver returned in " << n << " iterations:" << std::endl;
+  // for (int i = 0 ; i < NMAT; i++) {
+  //  std::cout << i << " " << rho[i] << " " << vfrac[i] << " " << sie[i] << " " << " " <<
+  //  rho[i]*vfrac[i]/rho_tot << " " << press[i] << " " << temp[i] << std::endl;
   //}
-  //std::cout << "Finished " << NTRIAL << " solves in " << sum_time.count() << " seconds" << std::endl;
-  //std::cout << "Solves/second = " << NTRIAL/sum_time.count() << std::endl;
-  //std::cout << "Success: " << nsuccess << "   Failure: " << NTRIAL-nsuccess << std::endl;
+  // std::cout << "Finished " << NTRIAL << " solves in " << sum_time.count() << " seconds"
+  // << std::endl; std::cout << "Solves/second = " << NTRIAL/sum_time.count() << std::endl;
+  // std::cout << "Success: " << nsuccess << "   Failure: " << NTRIAL-nsuccess <<
+  // std::endl;
 
   finalize_bd_eos(NMAT, eos, 1);
   return 0;

--- a/utils/root-finding-1d/root_finding.hpp
+++ b/utils/root-finding-1d/root_finding.hpp
@@ -24,10 +24,10 @@
 
 // #include <iostream> // debug
 // #include <iomanip>
-#include <stdio.h>
-#include <math.h>
-#include <assert.h>
 #include "../ports-of-call/portability.hpp"
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
 
 #define ROOT_DEBUG (0)
 #define ROOT_VERBOSE (0)
@@ -36,399 +36,379 @@
 #define MY_SIGN(x) (x > 0) - (x < 0)
 
 namespace RootFinding1D {
-  constexpr const int SECANT_NITER_MAX {1000};
-  constexpr const int BISECT_NITER_MAX {1000};
-  constexpr const int BISECT_REG_MAX {1000};
-  enum class Status { SUCCESS = 0, FAIL = 1 };
+constexpr const int SECANT_NITER_MAX{1000};
+constexpr const int BISECT_NITER_MAX{1000};
+constexpr const int BISECT_REG_MAX{1000};
+enum class Status { SUCCESS = 0, FAIL = 1 };
 
-  /*
-    // TODO: Something like this would be nice
-    friend std::ostream& operator<< (std::ostream& os, const RootCounts& c) {
-    Real tot = c.total();
-    std::vector<Real> percents(c.nbins_,0);
-    for (int i = 0; i < c.nbins_; i++) {
-    percents[i] = (100.*c.counts_[i] / tot);
-    }
-    os << "\n********** ROOT FINDING *********\n"
-    << "   ITERATIONS          PERCENTAGE\n";
-    for (int i = 0; i < c.more_; i++) {
-    os << "         "
-    << std::right << std::setw(4)
-    << i
-    << "             "
-    << std::right << std::setw(3)
-    << percents[i] << "\n";
-    }
-    os << "         more             "
-    << std::right << std::setw(3)
-    << percents[c.more_] << "\n"
-    << "*********************************\n"
-    << std::endl;
-    return os;
-    }
-  */
-  class RootCounts {
-  private:
-    static constexpr int nbins_ {15};
-    mutable Real counts_[nbins_];
+/*
+  // TODO: Something like this would be nice
+  friend std::ostream& operator<< (std::ostream& os, const RootCounts& c) {
+  Real tot = c.total();
+  std::vector<Real> percents(c.nbins_,0);
+  for (int i = 0; i < c.nbins_; i++) {
+  percents[i] = (100.*c.counts_[i] / tot);
+  }
+  os << "\n********** ROOT FINDING *********\n"
+  << "   ITERATIONS          PERCENTAGE\n";
+  for (int i = 0; i < c.more_; i++) {
+  os << "         "
+  << std::right << std::setw(4)
+  << i
+  << "             "
+  << std::right << std::setw(3)
+  << percents[i] << "\n";
+  }
+  os << "         more             "
+  << std::right << std::setw(3)
+  << percents[c.more_] << "\n"
+  << "*********************************\n"
+  << std::endl;
+  return os;
+  }
+*/
+class RootCounts {
+ private:
+  static constexpr int nbins_{15};
+  mutable Real counts_[nbins_];
 
-  public:
-    PORTABLE_INLINE_FUNCTION
-    RootCounts()
-    {
-      for (int i{0}; i < nbins_; ++i)
-        counts_[i] = 0;
-    }
-    PORTABLE_INLINE_FUNCTION void reset() {
-      for (int i {0}; i < nbins_; ++i)
-        counts_[i] = 0;
-    }
-    PORTABLE_INLINE_FUNCTION void increment(int i) const {
-      assert(i < nbins_ && i >= 0);
-      counts_[i] += 1;
-    }
-    PORTABLE_INLINE_FUNCTION Real total() const {
-      Real tot {1.e-20};
-      for (int i {0}; i < nbins_; ++i)
-        tot += counts_[i];
-      return tot;
-    }
-    PORTABLE_INLINE_FUNCTION const Real& operator[](const int i) const {
-      assert(i < nbins_ && i >= 0);
-      return counts_[i];
-    }
-    PORTABLE_INLINE_FUNCTION Real& operator[](const int i) {
-      assert(i < nbins_ && i >= 0);
-      return counts_[i];
-    }
-    PORTABLE_INLINE_FUNCTION void print_counts() const {
-      for (int i{0}; i < nbins_; ++i)
-        printf("%e\n", counts_[i]);
-    }
-    PORTABLE_INLINE_FUNCTION int nBins() const { return nbins_; }
-    PORTABLE_INLINE_FUNCTION int more() const { return nbins_ - 1; }
-  };
-
-  // solves for f(x,params) - ytarget = 0
-  template <typename T>
+ public:
   PORTABLE_INLINE_FUNCTION
-  Status findRoot(const T& f,
-                  const Real ytarget, Real xguess,
-                  const Real xmin, const Real xmax,
-                  const Real xtol, const Real ytol,
-                  Real& xroot,
-                  const RootCounts& counts) {
-    Status status;
-    
-    // first check if we're at the max or min values
-    // TODO: these short-circuits almost never happen. Should they be removed?
-    // ~JMM
-    const Real fmax   = f(xmax);
-    const Real errmax = fabs(fmax - ytarget) / (fabs(fmax) + ytol);
-    if (errmax < ytol) {
-      xroot = xmax;
-      counts.increment(0);
-      return Status::SUCCESS;
-    }
-    const Real fmin   = f(xmin);
-    const Real errmin = fabs(fmin - ytarget) / (fabs(fmin) + ytol);
-    if (errmin < ytol) {
-      xroot = xmin;
-      counts.increment(0);
-      return Status::SUCCESS;
-    }
+  RootCounts() {
+    for (int i{0}; i < nbins_; ++i)
+      counts_[i] = 0;
+  }
+  PORTABLE_INLINE_FUNCTION void reset() {
+    for (int i{0}; i < nbins_; ++i)
+      counts_[i] = 0;
+  }
+  PORTABLE_INLINE_FUNCTION void increment(int i) const {
+    assert(i < nbins_ && i >= 0);
+    counts_[i] += 1;
+  }
+  PORTABLE_INLINE_FUNCTION Real total() const {
+    Real tot{1.e-20};
+    for (int i{0}; i < nbins_; ++i)
+      tot += counts_[i];
+    return tot;
+  }
+  PORTABLE_INLINE_FUNCTION const Real &operator[](const int i) const {
+    assert(i < nbins_ && i >= 0);
+    return counts_[i];
+  }
+  PORTABLE_INLINE_FUNCTION Real &operator[](const int i) {
+    assert(i < nbins_ && i >= 0);
+    return counts_[i];
+  }
+  PORTABLE_INLINE_FUNCTION void print_counts() const {
+    for (int i{0}; i < nbins_; ++i)
+      printf("%e\n", counts_[i]);
+  }
+  PORTABLE_INLINE_FUNCTION int nBins() const { return nbins_; }
+  PORTABLE_INLINE_FUNCTION int more() const { return nbins_ - 1; }
+};
 
-    if (xguess >= xmax) xguess = xmax - xtol;
-    if (xguess <= xmin) xguess = xmin + xtol;
-    
-    // Next try Secant
-    status = secant(f, ytarget, xguess, xmin, xmax,
-                    xtol, ytol, xroot, counts);
-    if (status == Status::SUCCESS) return status;
-    
+// solves for f(x,params) - ytarget = 0
+template <typename T>
+PORTABLE_INLINE_FUNCTION Status findRoot(const T &f, const Real ytarget, Real xguess,
+                                         const Real xmin, const Real xmax,
+                                         const Real xtol, const Real ytol, Real &xroot,
+                                         const RootCounts &counts) {
+  Status status;
+
+  // first check if we're at the max or min values
+  // TODO: these short-circuits almost never happen. Should they be removed?
+  // ~JMM
+  const Real fmax = f(xmax);
+  const Real errmax = fabs(fmax - ytarget) / (fabs(fmax) + ytol);
+  if (errmax < ytol) {
+    xroot = xmax;
+    counts.increment(0);
+    return Status::SUCCESS;
+  }
+  const Real fmin = f(xmin);
+  const Real errmin = fabs(fmin - ytarget) / (fabs(fmin) + ytol);
+  if (errmin < ytol) {
+    xroot = xmin;
+    counts.increment(0);
+    return Status::SUCCESS;
+  }
+
+  if (xguess >= xmax) xguess = xmax - xtol;
+  if (xguess <= xmin) xguess = xmin + xtol;
+
+  // Next try Secant
+  status = secant(f, ytarget, xguess, xmin, xmax, xtol, ytol, xroot, counts);
+  if (status == Status::SUCCESS) return status;
+
 #if ROOT_DEBUG
-    if (isnan(xroot)) {
-      fprintf(stderr, "xroot is nan after secant\n");
-    }
+  if (isnan(xroot)) {
+    fprintf(stderr, "xroot is nan after secant\n");
+  }
 #endif
 
 // Secant failed. Try bisection.
 #if ROOT_VERBOSE
-    fprintf(stderr,
-            "\n\nRoot finding. Secant failed. Trying bisection.\n"
-            "\txguess  = %.10g\n"
-            "\tytarget = %.10g\n"
-            "\txmin    = %.10g\n"
-            "\txmax    = %.10g\n",
-            xguess, ytarget, xmin, xmax);
+  fprintf(stderr,
+          "\n\nRoot finding. Secant failed. Trying bisection.\n"
+          "\txguess  = %.10g\n"
+          "\tytarget = %.10g\n"
+          "\txmin    = %.10g\n"
+          "\txmax    = %.10g\n",
+          xguess, ytarget, xmin, xmax);
 #endif
-    status = bisect(f, ytarget, xguess, xmin, xmax,
-                    xtol, ytol, xroot, counts);
-    
-    // Check for something horrible happening
-    if (isnan(xroot) || isinf(xroot)) {
+  status = bisect(f, ytarget, xguess, xmin, xmax, xtol, ytol, xroot, counts);
+
+  // Check for something horrible happening
+  if (isnan(xroot) || isinf(xroot)) {
 #if ROOT_DEBUG
-      fprintf(stderr, "xroot is nan after bisection\n");
+    fprintf(stderr, "xroot is nan after bisection\n");
+#endif
+    return Status::FAIL;
+  }
+  if (xroot < xmin) return Status::FAIL;
+  if (xroot > xmax) return Status::FAIL;
+
+  return status;
+}
+
+template <typename T>
+PORTABLE_INLINE_FUNCTION Status secant(const T &f, const Real ytarget, const Real xguess,
+                                       const Real xmin, const Real xmax, const Real xtol,
+                                       const Real ytol, Real &xroot,
+                                       const RootCounts &counts) {
+  Real dx;
+  Real x_last, y, yp, ym, dyNum, dyDen, dy;
+
+  Real x = xguess;
+  unsigned int iter{0};
+  for (iter = 0; iter < SECANT_NITER_MAX; ++iter) {
+    x_last = x;
+    dx = fabs(1.e-7 * x) + xtol;
+    y = f(x) - ytarget;
+    yp = f(x + dx);
+    ym = f(x - dx);
+    dyNum = yp - ym;
+    dyDen = (2. * dx);
+    dy = dyNum / dyDen;
+    x -= y / dy;
+    if (isnan(x) || isinf(x)) {
+      // can't recover from this
+#if ROOT_DEBUG
+      fprintf(stderr,
+              "\n\n[secant]: NAN or out-of-bounds detected!\n"
+              "\txguess  = %.10e\n"
+              "\tytarget = %.10e\n"
+              "\tx       = %.10e\n"
+              "\tx_last  = %.10e\n"
+              "\tx_min   = %.10e\n"
+              "\tx_max   = %.10e\n"
+              "\ty       = %.10e\n"
+              "\tdx      = %.10e\n"
+              "\typ      = %.10e\n"
+              "\tym      = %.10e\n"
+              "\tdyNum   = %.10e\n"
+              "\tdyDen   = %.10e\n"
+              "\tdy      = %.10e\n"
+              "\titer    = %d\n"
+              "\tsign x  = %d\n",
+              xguess, ytarget, x, x_last, xmin, xmax, y, dx, yp, ym, dyNum, dyDen, dy,
+              iter, (int)MY_SIGN(x));
+#endif
+#if ROOT_NAN_OK
+      if (isinf(x)) {
+        if (x < xmin) x = xmin;
+        if (x > xmax) x = xmax;
+      } else {
+        counts.increment(counts.more());
+        return Status::FAIL;
+      }
+#else
+      counts.increment(counts.more());
+      return Status::FAIL;
+#endif
+      // if (x < xmin)
+      //  x = xmin;
+      // if (x > xmax)
+      //  x = xmax;
+    }
+    if (fabs(x - x_last) / (fabs(x) + xtol) < xtol) break;
+  }
+  // increment iter
+  ++iter;
+  if (iter < counts.nBins()) {
+    counts.increment(iter);
+  } else {
+    counts.increment(counts.more());
+  }
+  xroot = x;
+
+  y = f(x);
+  const Real frac_error = fabs(y - ytarget) / (fabs(y) + ytol);
+#if ROOT_DEBUG
+  if (frac_error > ytol) {
+    fprintf(stderr,
+            "\n\n[secant]: Failed via too large yerror.\n"
+            "\tfractional error = %.10e\n"
+            "\tx                = %.10e\n"
+            "\ty                = %.10e\n"
+            "\tytarget          = %.10e\n"
+            "\typ               = %.10e\n"
+            "\tym               = %.10e\n"
+            "\tdy               = %.10e\n"
+            "\tdx               = %.10e\n"
+            "\titer             = %d\n",
+            frac_error, x, y, ytarget, yp, ym, dy, dx, iter);
+  }
+  if (fabs(x - x_last) > xtol) {
+    fprintf(stderr,
+            "\n\n[secant]: failed via dx too big.\n"
+            "\tfractional error = %.10e\n"
+            "\tx                = %.10e\n"
+            "\tx_last           = %.10e\n"
+            "\tdx               = %.10e\n"
+            "\ty                = %.10e\n"
+            "\tytarget          = %.10e\n"
+            "\typ               = %.10e\n"
+            "\tym               = %.10e\n"
+            "\tdy               = %.10e\n"
+            "\tdx               = %.10e\n"
+            "\titer             = %d\n",
+            frac_error, x, x_last, fabs(x - x_last), y, ytarget, yp, ym, dy, dx, iter);
+  }
+#endif
+
+  const int secant_failed =
+      (fabs(x - x_last) > xtol || fabs(frac_error) > ytol || isnan(x) || isinf(x));
+  return secant_failed ? Status::FAIL : Status::SUCCESS;
+}
+
+template <typename T>
+PORTABLE_INLINE_FUNCTION Status bisect(const T &f, const Real ytarget, const Real xguess,
+                                       const Real xmin, const Real xmax, const Real xtol,
+                                       const Real ytol, Real &xroot,
+                                       const RootCounts &counts) {
+  Real xl, xr, fl, fr, dx;
+
+  Real grow = 0.01;
+  Real x = xguess;
+  if (fabs(x) < xtol) {
+    x += 2. * xtol;
+  }
+  // do { // Try to find reasonable region for bisection
+  for (int i{0}; i < BISECT_REG_MAX; ++i) {
+    dx = fabs(grow * x);
+    xl = x - dx;
+    xr = x + dx;
+    fl = f(xl) - ytarget;
+    fr = f(xr) - ytarget;
+    grow *= 1.1;
+    if (fl * fr < 0.0 || xl < xmin || xr > xmax) break;
+    if (i > BISECT_REG_MAX - 2) {
+#if ROOT_DEBUG
+      fprintf(stderr,
+              "\n\n[Bisect]: expanding region failed\n"
+              "\txl   = %.10g\n"
+              "\txr   = %.10g\n"
+              "\tfl   = %.10g\n"
+              "\tfr   = %.10g\n"
+              "\tdx   = %.10g\n"
+              "\tgrow = %.10g\n",
+              xl, xr, fl, fr, dx, grow);
 #endif
       return Status::FAIL;
     }
-    if (xroot < xmin) return Status::FAIL;
-    if (xroot > xmax) return Status::FAIL;
-    
-    return status;
   }
 
-  template <typename T>
-  PORTABLE_INLINE_FUNCTION
-  Status secant(const T& f,
-                const Real ytarget, const Real xguess,
-                const Real xmin, const Real xmax,
-                const Real xtol, const Real ytol,
-                Real& xroot,
-                const RootCounts& counts) {
-    Real dx;
-    Real x_last, y, yp, ym, dyNum, dyDen, dy;
-    
-    Real         x    = xguess;
-    unsigned int iter {0};
-    for (iter = 0; iter < SECANT_NITER_MAX; ++iter) {
-      x_last = x;
-      dx     = fabs(1.e-7 * x) + xtol;
-      y      = f(x) - ytarget;
-      yp     = f(x + dx);
-      ym     = f(x - dx);
-      dyNum  = yp - ym;
-      dyDen  = (2. * dx);
-      dy     = dyNum / dyDen;
-      x -= y / dy;
-      if (isnan(x) || isinf(x)) {
-        // can't recover from this
-#if ROOT_DEBUG
-        fprintf(stderr,
-                "\n\n[secant]: NAN or out-of-bounds detected!\n"
-                "\txguess  = %.10e\n"
-                "\tytarget = %.10e\n"
-                "\tx       = %.10e\n"
-                "\tx_last  = %.10e\n"
-                "\tx_min   = %.10e\n"
-                "\tx_max   = %.10e\n"
-                "\ty       = %.10e\n"
-                "\tdx      = %.10e\n"
-                "\typ      = %.10e\n"
-                "\tym      = %.10e\n"
-                "\tdyNum   = %.10e\n"
-                "\tdyDen   = %.10e\n"
-                "\tdy      = %.10e\n"
-                "\titer    = %d\n"
-                "\tsign x  = %d\n",
-                xguess, ytarget, x, x_last, xmin, xmax, y, dx, yp, ym, dyNum,
-                dyDen, dy, iter, (int)MY_SIGN(x));
-#endif
-#if ROOT_NAN_OK
-        if (isinf(x)) {
-          if (x < xmin)
-            x = xmin;
-          if (x > xmax)
-            x = xmax;
-        } else {
-          counts.increment(counts.more());
-          return Status::FAIL;
-        }
-#else
-        counts.increment(counts.more());
-        return Status::FAIL;
-#endif
-        //if (x < xmin)
-        //  x = xmin;
-        //if (x > xmax)
-        //  x = xmax;
-      }
-      if (fabs(x - x_last) / (fabs(x) + xtol) < xtol)
-        break;
-    }
-    // increment iter
-    ++iter;
-    if (iter < counts.nBins()) {
-      counts.increment(iter);
-    } else {
-      counts.increment(counts.more());
-    }
-    xroot = x;
-    
-    y                     = f(x);
-    const Real frac_error = fabs(y - ytarget) / (fabs(y) + ytol);
-#if ROOT_DEBUG
-    if (frac_error > ytol) {
-      fprintf(stderr,
-              "\n\n[secant]: Failed via too large yerror.\n"
-              "\tfractional error = %.10e\n"
-              "\tx                = %.10e\n"
-              "\ty                = %.10e\n"
-              "\tytarget          = %.10e\n"
-              "\typ               = %.10e\n"
-              "\tym               = %.10e\n"
-              "\tdy               = %.10e\n"
-              "\tdx               = %.10e\n"
-              "\titer             = %d\n",
-              frac_error, x, y, ytarget, yp, ym, dy, dx, iter);
-    }
-    if (fabs(x - x_last) > xtol) {
-      fprintf(stderr,
-              "\n\n[secant]: failed via dx too big.\n"
-              "\tfractional error = %.10e\n"
-              "\tx                = %.10e\n"
-              "\tx_last           = %.10e\n"
-              "\tdx               = %.10e\n"
-              "\ty                = %.10e\n"
-              "\tytarget          = %.10e\n"
-              "\typ               = %.10e\n"
-              "\tym               = %.10e\n"
-              "\tdy               = %.10e\n"
-              "\tdx               = %.10e\n"
-              "\titer             = %d\n",
-              frac_error, x, x_last, fabs(x - x_last), y, ytarget, yp, ym, dy,
-              dx, iter);
-    }
-#endif
-    
-    const int secant_failed =
-      (fabs(x - x_last) > xtol
-       || fabs(frac_error) > ytol
-       || isnan(x) || isinf(x));
-    return secant_failed ? Status::FAIL : Status::SUCCESS;
+  // force back onto the bisection region
+  if (xr > xmax) {
+    xr = xmax;
+    fr = f(xr) - ytarget;
   }
-  
-  template <typename T>
-  PORTABLE_INLINE_FUNCTION
-  Status bisect(const T& f,
-                const Real ytarget, const Real xguess,
-                const Real xmin, const Real xmax,
-                const Real xtol, const Real ytol,
-                Real& xroot,
-                const RootCounts& counts) {
-    Real xl, xr, fl, fr, dx;
+  if (xl < xmin) {
+    xl = xmin;
+    fl = f(xl) - ytarget;
+  }
 
-    Real grow = 0.01;
-    Real x    = xguess;
-    if (fabs(x) < xtol) {
-      x += 2. * xtol;
-    }
-    //do { // Try to find reasonable region for bisection
-    for (int i {0}; i < BISECT_REG_MAX; ++i) {
-      dx = fabs(grow * x);
-      xl = x - dx;
-      xr = x + dx;
-      fl = f(xl) - ytarget;
-      fr = f(xr) - ytarget;
-      grow *= 1.1;
-      if (fl * fr < 0.0 || xl < xmin || xr > xmax)
-        break;
-      if (i > BISECT_REG_MAX-2) {
-#if ROOT_DEBUG
-        fprintf(stderr,
-                "\n\n[Bisect]: expanding region failed\n"
-                "\txl   = %.10g\n"
-                "\txr   = %.10g\n"
-                "\tfl   = %.10g\n"
-                "\tfr   = %.10g\n"
-                "\tdx   = %.10g\n"
-                "\tgrow = %.10g\n",
-                xl,xr,fl,fr,dx,grow);
-#endif
-        return Status::FAIL;
-      }
-    }
-
-    // force back onto the bisection region
-    if (xr > xmax) {
+  // if they have the same sign, change that.
+  // if we can't fix it, fail.
+  if (fl * fr > 0) {
+    xl = xmin;
+    fl = f(xl) - ytarget;
+    if (fl * fr > 0) {
       xr = xmax;
       fr = f(xr) - ytarget;
-    }
-    if (xl < xmin) {
-      xl = xmin;
-      fl = f(xl) - ytarget;
-    }
-
-    // if they have the same sign, change that.
-    // if we can't fix it, fail.
-    if (fl * fr > 0) {
-      xl = xmin;
-      fl = f(xl) - ytarget;
       if (fl * fr > 0) {
-        xr = xmax;
-        fr = f(xr) - ytarget;
-        if (fl * fr > 0) {
 #if ROOT_DEBUG
-          Real il = f(xl);
-          Real ir = f(xr);
-          fprintf(stderr,
-                  "\n\n[bisect]: fl*fr > 0!\n"
-                  "\txguess  = %.10e\n"
-                  "\tytarget = %.10e\n"
-                  "\txl      = %.10e\n"
-                  "\txr      = %.10e\n"
-                  "\tfl      = %.10e\n"
-                  "\tfr      = %.10e\n"
-                  "\til      = %.10e\n"
-                  "\tir      = %.10e\n",
-                  xguess, ytarget, xl, xr, fl, fr, il, ir);
-          int    nx = 300;
-          Real   dx = (xmax - xmin) / (nx - 1);
-          fprintf(stderr, "Area map:\nx\ty\n");
-          for (int i = 0; i < nx; i++) {
-            fprintf(stderr, "%.4f\t%.4e\n", x + i * dx, f(x + i * dx));
-          }
-#endif
-          return Status::FAIL;
+        Real il = f(xl);
+        Real ir = f(xr);
+        fprintf(stderr,
+                "\n\n[bisect]: fl*fr > 0!\n"
+                "\txguess  = %.10e\n"
+                "\tytarget = %.10e\n"
+                "\txl      = %.10e\n"
+                "\txr      = %.10e\n"
+                "\tfl      = %.10e\n"
+                "\tfr      = %.10e\n"
+                "\til      = %.10e\n"
+                "\tir      = %.10e\n",
+                xguess, ytarget, xl, xr, fl, fr, il, ir);
+        int nx = 300;
+        Real dx = (xmax - xmin) / (nx - 1);
+        fprintf(stderr, "Area map:\nx\ty\n");
+        for (int i = 0; i < nx; i++) {
+          fprintf(stderr, "%.4f\t%.4e\n", x + i * dx, f(x + i * dx));
         }
-      }
-    }
-    
-    for (int i {0}; i < BISECT_NITER_MAX; ++i) {
-      Real xm = 0.5 * (xl + xr);
-      Real fm = f(xm) - ytarget;
-      if (fl * fm <= 0) {
-        xr = xm;
-        fr = fm;
-      } else {
-        xl = xm;
-        fl = fm;
-      }
-      if (xr - xl < xtol) {
-        xroot = 0.5 * (xl + xr);
-        return Status::SUCCESS;
-      }
-    }
-    
-    xroot = 0.5 * (xl + xr);
-    
-    if (isnan(xroot)) {
-#if ROOT_DEBUG
-      Real il = f(xl);
-      Real ir = f(xr);
-      fprintf(stderr,
-              "\n\n[bisect]: NAN DETECTED!\n"
-              "\txguess  = %.10e\n"
-              "\tytarget = %.10e\n"
-              "\txl      = %.10e\n"
-              "\txr      = %.10e\n"
-              "\tdx      = %.10e\n"
-              "\tgrow    = %.10e\n"
-              "\txtol    = %.10e\n"
-              "\tfl      = %.10e\n"
-              "\tfr      = %.10e\n"
-              "\til      = %.10e\n"
-              "\tir      = %.10e\n"
-              "\txmin    = %.10e\n"
-              "\txmax    = %.10e\n",
-              xguess, ytarget, xl, xr, dx, grow, xtol, fl, fr, il, ir,
-              xmin, xmax);
 #endif
+        return Status::FAIL;
+      }
     }
-    return Status::FAIL;
   }
-  // ----------------------------------------------------------------------
+
+  for (int i{0}; i < BISECT_NITER_MAX; ++i) {
+    Real xm = 0.5 * (xl + xr);
+    Real fm = f(xm) - ytarget;
+    if (fl * fm <= 0) {
+      xr = xm;
+      fr = fm;
+    } else {
+      xl = xm;
+      fl = fm;
+    }
+    if (xr - xl < xtol) {
+      xroot = 0.5 * (xl + xr);
+      return Status::SUCCESS;
+    }
+  }
+
+  xroot = 0.5 * (xl + xr);
+
+  if (isnan(xroot)) {
+#if ROOT_DEBUG
+    Real il = f(xl);
+    Real ir = f(xr);
+    fprintf(stderr,
+            "\n\n[bisect]: NAN DETECTED!\n"
+            "\txguess  = %.10e\n"
+            "\tytarget = %.10e\n"
+            "\txl      = %.10e\n"
+            "\txr      = %.10e\n"
+            "\tdx      = %.10e\n"
+            "\tgrow    = %.10e\n"
+            "\txtol    = %.10e\n"
+            "\tfl      = %.10e\n"
+            "\tfr      = %.10e\n"
+            "\til      = %.10e\n"
+            "\tir      = %.10e\n"
+            "\txmin    = %.10e\n"
+            "\txmax    = %.10e\n",
+            xguess, ytarget, xl, xr, dx, grow, xtol, fl, fr, il, ir, xmin, xmax);
+#endif
+  }
+  return Status::FAIL;
 }
+// ----------------------------------------------------------------------
+} // namespace RootFinding1D
 
 #undef ROOT_DEBUG
 #undef ROOT_VERBOSE

--- a/utils/sp5/singularity_eos_sp5.hpp
+++ b/utils/sp5/singularity_eos_sp5.hpp
@@ -14,57 +14,56 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
-
 #ifndef _SINGULARITY_EOS_UTILS_SP5_SINGULARITY_EOS_SP5_HPP_
 #define _SINGULARITY_EOS_UTILS_SP5_SINGULARITY_EOS_SP5_HPP_
 
 namespace SP5 {
 
-  constexpr char defaultSesFileName[]  = "sesame_table.sp5";
-  
-  namespace Depends {
-    constexpr char logRhoLogSie[] = "dependsLogRhoLogSie";
-    constexpr char logRhoLogT[]   = "dependsLogRhoLogT";
-    constexpr char coldCurve[]    = "coldCurve";
-  }
-  
-  namespace Offsets {
-    constexpr char messageName[] = "interpretation";
-    constexpr char message[]
-    = "All quantities are functions of log_10(X)\n"
-      "for X = density rho, temperature T, or specific internal energy sie\n"
-      "where conversion is X = 10^{Xlog} - Xoffset\n";
-    constexpr char rho[]    = "rhoOffset";
-    constexpr char T[]      = "TOffset";
-    constexpr char sie[]    = "sieOffset";
-  }
-  
-  namespace Material {
-    constexpr char exchangeCoefficient[] = "exchangeCoefficient";
-    constexpr char meanAtomicMass[]      = "meanAtomicMass";
-    constexpr char meanAtomicNumber[]    = "meanAtomicNumber";
-    constexpr char solidBulkModulus[]    = "solidBulkModulus";
-    constexpr char normalDensity[]       = "normalDensity";
-    constexpr char comments[]            = "comments";
-    constexpr char matid[]               = "matid";
-    constexpr char name[]                = "name";
-  }
-  
-  namespace Fields {
-    constexpr char P[]              = "pressure";
-    constexpr char sie[]            = "specific internal energy";
-    constexpr char T[]              = "temperature";
-    constexpr char bMod[]           = "bulk modulus";
-    constexpr char dPdRho[]         = "dPdRho";
-    constexpr char dPdE[]           = "dPdE";
-    constexpr char dTdRho[]         = "dTdRho";
-    constexpr char dTdE[]           = "dTdE";
-    constexpr char dEdRho[]         = "dEdRho";
-    constexpr char dEdT[]           = "dEdT";
-    constexpr char mask[]           = "mask";
-    constexpr char transitionMask[] = "transition mask";
-  }
-  
-}
+constexpr char defaultSesFileName[] = "sesame_table.sp5";
+
+namespace Depends {
+constexpr char logRhoLogSie[] = "dependsLogRhoLogSie";
+constexpr char logRhoLogT[] = "dependsLogRhoLogT";
+constexpr char coldCurve[] = "coldCurve";
+} // namespace Depends
+
+namespace Offsets {
+constexpr char messageName[] = "interpretation";
+constexpr char message[] =
+    "All quantities are functions of log_10(X)\n"
+    "for X = density rho, temperature T, or specific internal energy sie\n"
+    "where conversion is X = 10^{Xlog} - Xoffset\n";
+constexpr char rho[] = "rhoOffset";
+constexpr char T[] = "TOffset";
+constexpr char sie[] = "sieOffset";
+} // namespace Offsets
+
+namespace Material {
+constexpr char exchangeCoefficient[] = "exchangeCoefficient";
+constexpr char meanAtomicMass[] = "meanAtomicMass";
+constexpr char meanAtomicNumber[] = "meanAtomicNumber";
+constexpr char solidBulkModulus[] = "solidBulkModulus";
+constexpr char normalDensity[] = "normalDensity";
+constexpr char comments[] = "comments";
+constexpr char matid[] = "matid";
+constexpr char name[] = "name";
+} // namespace Material
+
+namespace Fields {
+constexpr char P[] = "pressure";
+constexpr char sie[] = "specific internal energy";
+constexpr char T[] = "temperature";
+constexpr char bMod[] = "bulk modulus";
+constexpr char dPdRho[] = "dPdRho";
+constexpr char dPdE[] = "dPdE";
+constexpr char dTdRho[] = "dTdRho";
+constexpr char dTdE[] = "dTdE";
+constexpr char dEdRho[] = "dEdRho";
+constexpr char dEdT[] = "dEdT";
+constexpr char mask[] = "mask";
+constexpr char transitionMask[] = "transition mask";
+} // namespace Fields
+
+} // namespace SP5
 
 #endif // _SINGULARITY_EOS_UTILS_SP5_SINGULARITY_EOS_SP5_HPP_


### PR DESCRIPTION
A long-awaited change: automated formatting. I put a `.clang-format` file I like in the highest level of the repo and ran it on all source.

At the moment, this is just a by hand procedure---run clang-format on files you modify. In the long term, of course, we should automate this. @mauneyc-LANL perhaps this is something that can go in the cmake?

It's possible to automate checking that formatting has been applied in the automated tests, but I don't really want to do that until we can type `make format` and format the whole repo. It would otherwise be a bit cumbersome.