### PR TITLE
Updates for dependencies spack

### DIFF
--- a/spack-repo/packages/singularity-eos_deps/package.py
+++ b/spack-repo/packages/singularity-eos_deps/package.py
@@ -1,4 +1,4 @@
-# dependency package for singulary
+# dependency package for singulary-eos
 
 import os
 from spack import *
@@ -10,29 +10,113 @@ class SingularityEosDeps(BundlePackage):
 
     version("main", branch="main")
 
-    variant("use_cuda", default=False, description="Enable cuda support")
+    variant(
+            "cuda",
+            default=False,
+            description="Use cuda"
+    )
 
-    depends_on("cmake", type="build")
-    depends_on("hdf5~mpi+cxx+hl", type=("build", "run"))
-    depends_on("eigen@3.3.9", type="build")
-    depends_on("kokkos@3:", when="+use_cuda", type=("build", "run"))
-    depends_on("kokkos-kernels", when="+use_cuda", type=("build", "run"))
-    depends_on("eospac", type=("build","run"))
+    variant(
+            "kokkos",
+            default=False,
+            description="Use kokkos"
+    )
+
+    variant(
+            "linalg", 
+            default="eigen", 
+            description="Linear algebra library",
+            values=("eigen" ,"kokkos"),
+            multi=False
+    )
+    variant(
+            "build_extra",
+            values=("sesame","stellarcollapse", "none"), 	
+            default="none",
+            description="Build converters",
+            multi=True
+    )
+
+    variant(
+            "enable_tests",
+            default=False,
+            description="Build tests"
+    )
+
+    depends_on("hdf5~mpi+cxx+hl")
+    depends_on("cuda@11:", when="+cuda")
+    depends_on("kokkos@3:", when="+kokkos")
+    depends_on("eigen@3.3.9", when="linalg=eigen")
+    depends_on("kokkos-kernels", when="linalg=kokkos")
+    depends_on("mpark-variant")
+    depends_on("eospac")
+
+    depends_on("cmake@3.12:")
+    depends_on("catch2@2.13.4:2.13.6")
+    depends_on(
+            "mpark-variant",
+#            patches=patch("cuda_compatibility.patch"),
+            when="+cuda"
+    )
+
+    conflicts(
+            "linalg=eigen",
+            when="+cuda"
+    )
+    
+#    patch("cuda_compatibility.patch", when="+cuda")
+
 
     phases=["install"]
 
     def setup_run_environment(self, env):
         env.set('HDF5_ROOT', self.spec['hdf5'].prefix)
-        # this is still WIP
-        env.set('SINGULARITY_EOS_LOADER', os.path.join(self.spec.prefix, f"load_env-{self.spec.full_hash(length=4)}.sh"))
-
+        env.set('SINGULARITYEOS_TCF', join_path(self.prefix, "singularity_tc.cmake"))
+    
     def install(self, spec, prefix):
-        mod_script = os.path.join(spec.prefix, f"load_env-{spec.full_hash(length=4)}.sh")
-       
-        with open(os.path.join(mod_script), "w") as f:
-            f.write(f"# load env {spec.short_spec}")
-            f.write("")
-            for dep in spec.dependencies(deptype="build"):
-                f.write(dep.format())
+        cmake_args_map={
+            "SINGULARITY_USE_HDF5": "ON",
+            "SINGULARITY_USE_FORTRAN": "ON",
+            "SINGULARITY_USE_KOKKOS": "OFF",
+            "SINGULARITY_USE_EOSPAC": "OFF",
+            "SINGULARITY_USE_CUDA": "OFF",
+            "SINGULARITY_USE_KOKKOSKERNELS": "OFF",
+            "SINGULARITY_BUILD_CLOSURE": "ON",
+            "SINGULARITY_BUILD_TESTS": "OFF",
+            "SINGULARITY_TEST_SESAME": "OFF",
+            "SINGULARITY_TEST_STELLAR_COLLAPSE": "OFF",
+            "SINGULARITY_BUILD_SESAME2SPINER": "OFF",	
+            "SINGULARITY_BUILD_STELLARCOLLAPSE2SPINER": "OFF",
+            "SINGULARITY_INVERT_AT_SETUP": "OFF",
+            "SINGULARITY_BETTER_DEBUG_FLAGS": "ON",
+            "SINGULARITY_HIDE_MORE_WARNINGS": "OFF",
+        }
 
+        if "+cuda" in spec:
+            cmake_args_map["SINGULARITY_USE_CUDA"] = "ON"
+        if "+kokkos" in spec:
+            cmake_args_map["SINGULARITY_USE_KOKKOS"] = "ON"
+            if spec.variants["linalg"].value == "kokkos":
+                cmake_args_map["SINGULARITY_USE_KOKKOSKERNELS"] = "ON"
+
+        
+        if "sesame" in spec.variants["build_extra"]:
+            cmake_args_map["SINGULARITY_BUILD_SESAME2SPINER"] = "ON"
+            if "+enable_tests" in spec:
+                cmake_args_map["SINGULARITY_TEST_SESAME"] = "ON"
+        if "stellarcollapse" in spec.variants["build_extra"]:
+            cmake_args_map["SINGULARITY_BUILD_STELLARCOLLAPSE2SPINER"] = "ON"
+            if "+enable_tests" in spec:
+                cmake_args_map["SINGULARITY_TEST_STELLAR_COLLAPSE"] = "ON"
+
+        if "+enable_tests" in spec:
+            cmake_args_map["SINGULARITY_BUILD_TESTS"] = "ON"
+
+        with working_dir('spack-build', create=True):
+            with open("singularity_tc.cmake", 'w') as cmtcf:
+                for k,v in cmake_args_map.items():
+                    cmtcf.write("set(" +k + " " + v + " CACHE BOOL \"\")\n")
+            install("singularity_tc.cmake", join_path(prefix, "singularity_tc.cmake"))
+            
+        
 


### PR DESCRIPTION
This updates the spackage for the dependencies package.

Variants are:

- cuda: on/off, enable cuda (`+cuda`)
- kokkos: on/off, enable kokkos (`+kokkos`)
- linalg: eigen - kokkos, select linear algebra (` linalg=kokkos`)
- build_extra: sesame - stellarcollapse, build other apps (` build_extra=sesame`)
- enable_tests: on/off, turns on testing (`+enable_tests`)

Some validity checking of variants/dependencies is added, though not to what the current cmake does.

**New Feature**: When this spackage is used to bring in the dependencies, a pre-configured CMake file is generated that attempts to set the CMake cache variables to cut-down on the amount of typing when invoking the configure stage of CMake. For example:

```bash
$> spack install singularity-eos_deps+enable_tests build_extra=sesame,stellarcollapse
$> spack load singularity-eos_deps
$> echo $SINGULARITYEOS_TCF
<spack_top>/opt/spack/linux-manjaro21-skylake/gcc-11.1.0/singularity-eos_deps-main-fvpce2yuotr6uqczk6wmeg7coyldcgma/singularity_tc.cmake
$> cat $SINGULARITYEOS_TCF
set(SINGULARITY_USE_HDF5 ON CACHE BOOL "")
set(SINGULARITY_USE_FORTRAN ON CACHE BOOL "")
set(SINGULARITY_USE_KOKKOS OFF CACHE BOOL "")
set(SINGULARITY_USE_EOSPAC OFF CACHE BOOL "")
set(SINGULARITY_USE_CUDA OFF CACHE BOOL "")
set(SINGULARITY_USE_KOKKOSKERNELS OFF CACHE BOOL "")
set(SINGULARITY_BUILD_CLOSURE ON CACHE BOOL "")
set(SINGULARITY_BUILD_TESTS ON CACHE BOOL "")
set(SINGULARITY_TEST_SESAME ON CACHE BOOL "")
set(SINGULARITY_TEST_STELLAR_COLLAPSE ON CACHE BOOL "")
set(SINGULARITY_BUILD_SESAME2SPINER ON CACHE BOOL "")
set(SINGULARITY_BUILD_STELLARCOLLAPSE2SPINER ON CACHE BOOL "")
set(SINGULARITY_INVERT_AT_SETUP OFF CACHE BOOL "")
set(SINGULARITY_BETTER_DEBUG_FLAGS ON CACHE BOOL "")
set(SINGULARITY_HIDE_MORE_WARNINGS OFF CACHE BOOL "")
```

How this works:
`spack` generates the cmake script when the deps package is installed. It places the script in the prefix path (usually inside spack)
when the deps package is loaded (`spack load singularity-eos_deps`), an environment variable `SINGULARITYEOS_TCF` is exported, which is the full path to the script file. Users may directly use or copy this file to simplify building with cmake:

```bash
<in the build directory>
$> spack load singularity-eos_deps
$> cp $SINGULARITYEOS_TCF ./singularity_config.cmake
$> cmake -C singularity_config.cmake -DCMAKE_BUILD_TYPE=Debug <path/to/source>
```

The user may override the options in the configuration file

```bash
$> cmake -C singularity_config.cmake -DCMAKE_BUILD_TYPE=Debug -DSINGULARITY_TEST_SESAME=OFF <path/to/source>
```

Opinions welcome. @dholladay00 @jonahm-LANL @ktsai7 