### PR TITLE
fix issues with duplicate names

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,6 +141,7 @@ before_script:
             ..
     - make -j
     - ./sesame2spiner/sesame2spiner -s materials.sp5 ../sesame2spiner/examples/unit_tests/*.dat
+    - ./sesame2spiner/sesame2spiner -s duplicates.sp5 ../sesame2spiner/examples/duplicate-test/*.dat
     - make test
 
 ########

--- a/sesame2spiner/examples/duplicate-test/air.dat
+++ b/sesame2spiner/examples/duplicate-test/air.dat
@@ -1,0 +1,24 @@
+# ======================================================================
+#  Example input deck for sesame2spiner,
+#  a tool for converting eospac to spiner
+#  Author: Jonah Miller (jonahm@lanl.gov)
+#  © 2021. Triad National Security, LLC. All rights reserved.  This
+#  program was produced under U.S. Government contract 89233218CNA000001
+#  for Los Alamos National Laboratory (LANL), which is operated by Triad
+#  National Security, LLC for the U.S.  Department of Energy/National
+#  Nuclear Security Administration. All rights in the program are
+#  reserved by Triad National Security, LLC, and the U.S. Department of
+#  Energy/National Nuclear Security Administration. The Government is
+#  granted for itself and others acting on its behalf a nonexclusive,
+#  paid-up, irrevocable worldwide license in this material to reproduce,
+#  prepare derivative works, distribute copies to the public, perform
+#  publicly and display publicly, and to permit others to do so.
+# ======================================================================
+matid = 5030
+name = air
+# These set the number of grid points per decade
+# for each variable. The default is 50 points
+# per decade.
+numrho/decade = 40
+numT/decade = 40
+numSie/decade = 40

--- a/sesame2spiner/examples/duplicate-test/air2.dat
+++ b/sesame2spiner/examples/duplicate-test/air2.dat
@@ -1,0 +1,24 @@
+# ======================================================================
+#  Example input deck for sesame2spiner,
+#  a tool for converting eospac to spiner
+#  Author: Jonah Miller (jonahm@lanl.gov)
+#  © 2021. Triad National Security, LLC. All rights reserved.  This
+#  program was produced under U.S. Government contract 89233218CNA000001
+#  for Los Alamos National Laboratory (LANL), which is operated by Triad
+#  National Security, LLC for the U.S.  Department of Energy/National
+#  Nuclear Security Administration. All rights in the program are
+#  reserved by Triad National Security, LLC, and the U.S. Department of
+#  Energy/National Nuclear Security Administration. The Government is
+#  granted for itself and others acting on its behalf a nonexclusive,
+#  paid-up, irrevocable worldwide license in this material to reproduce,
+#  prepare derivative works, distribute copies to the public, perform
+#  publicly and display publicly, and to permit others to do so.
+# ======================================================================
+matid = 5030
+name = air
+# These set the number of grid points per decade
+# for each variable. The default is 50 points
+# per decade.
+numrho/decade = 40
+numT/decade = 40
+numSie/decade = 40

--- a/sesame2spiner/examples/duplicate-test/steel.dat
+++ b/sesame2spiner/examples/duplicate-test/steel.dat
@@ -1,0 +1,26 @@
+# ======================================================================
+#  Example input deck for sesame2spiner,
+#  a tool for converting eospac to spiner
+#  Author: Jonah Miller (jonahm@lanl.gov)
+#  © 2021. Triad National Security, LLC. All rights reserved.  This
+#  program was produced under U.S. Government contract 89233218CNA000001
+#  for Los Alamos National Laboratory (LANL), which is operated by Triad
+#  National Security, LLC for the U.S.  Department of Energy/National
+#  Nuclear Security Administration. All rights in the program are
+#  reserved by Triad National Security, LLC, and the U.S. Department of
+#  Energy/National Nuclear Security Administration. The Government is
+#  granted for itself and others acting on its behalf a nonexclusive,
+#  paid-up, irrevocable worldwide license in this material to reproduce,
+#  prepare derivative works, distribute copies to the public, perform
+#  publicly and display publicly, and to permit others to do so.
+# ======================================================================
+
+matid = 4272
+name = metal
+rhomin = 1e-2
+Tmin = 1
+# These shrink logarithm of bounds
+# by a fraction of the total interval <= 1
+shrinklRhoBounds = 0.15,
+shrinklTBounds = 0.15,
+shrinkleBounds = 0.5

--- a/sesame2spiner/examples/duplicate-test/titanium.dat
+++ b/sesame2spiner/examples/duplicate-test/titanium.dat
@@ -1,0 +1,25 @@
+# ======================================================================
+#  Example input deck for sesame2spiner,
+#  a tool for converting eospac to spiner
+#  Author: Jonah Miller (jonahm@lanl.gov)
+#  © 2021. Triad National Security, LLC. All rights reserved.  This
+#  program was produced under U.S. Government contract 89233218CNA000001
+#  for Los Alamos National Laboratory (LANL), which is operated by Triad
+#  National Security, LLC for the U.S.  Department of Energy/National
+#  Nuclear Security Administration. All rights in the program are
+#  reserved by Triad National Security, LLC, and the U.S. Department of
+#  Energy/National Nuclear Security Administration. The Government is
+#  granted for itself and others acting on its behalf a nonexclusive,
+#  paid-up, irrevocable worldwide license in this material to reproduce,
+#  prepare derivative works, distribute copies to the public, perform
+#  publicly and display publicly, and to permit others to do so.
+# ======================================================================
+
+matid = 2961
+name = metal
+# These set the number of grid points per decade
+# for each variable. The default is 50 points
+# per decade.
+numrho/decade = 30
+numT/decade = 25
+numSie/decade = 15


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

In issue #47 @dholladay00 discovered that if two materials in a sesame2spiner file have the same "name" metadata, HDF5 throws an error. This PR adds guard rails so this can't happen, and also adds guard rails against a similar error when duplicate matids are requested.

Strategy uses a simple `std::unordered_list` to see what has been used already.

Resolves #47

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
