### PR TITLE
Fix the issue in extrapolation

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -18,3 +18,10 @@ target_link_libraries(get_sound_speed_press PRIVATE
   eos
   singularity-eos::libs
   singularity-eos::flags)
+
+add_executable(get_sesame_state
+  get_sesame_state.cpp)
+target_link_libraries(get_sesame_state PRIVATE
+  eos
+  singularity-eos::libs
+  singularity-eos::flags)

--- a/example/get_sesame_state.cpp
+++ b/example/get_sesame_state.cpp
@@ -1,0 +1,180 @@
+//------------------------------------------------------------------------------
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//------------------------------------------------------------------------------
+
+// This is a simple utility program to print out a full thermodynamic
+// state using both eospac and SpinerEOS for a material of a given
+// matid. For simplicity, the utility is CPU-only.
+
+// C++ headers
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+// Needed to import the eos models
+#include <singularity-eos/eos/eos.hpp>
+
+// For simplicity. Most things live in the singularity namespace
+using namespace singularity;
+
+constexpr int iPC = 0;
+constexpr int iRT = 1;
+constexpr int iRE = 2;
+
+inline void PrintStateOfRhoT(const double rho, const double T, EOS eos[3]) {
+  Real press[3];
+  Real dp[2];
+  Real sie[3];
+  Real dsie[2];
+  Real cv[3];
+  Real dcv[2];
+  Real bmod[3];
+  Real dbmod[2];
+  Real gam[3];
+  Real dgam[2];
+  for (int i = 0; i < 3; ++i) {
+    press[i] = eos[i].PressureFromDensityTemperature(rho, T);
+    sie[i] = eos[i].InternalEnergyFromDensityTemperature(rho, T);
+    cv[i] = eos[i].SpecificHeatFromDensityTemperature(rho, T);
+    bmod[i] = eos[i].BulkModulusFromDensityTemperature(rho, T);
+    gam[i] = eos[i].GruneisenParamFromDensityTemperature(rho, T);
+  }
+  for (int i = 0; i < 2; ++i) {
+    dp[i] = press[i + 1] - press[0];
+    dsie[i] = sie[i + 1] - sie[0];
+    dcv[i] = cv[i + 1] - cv[0];
+    dbmod[i] = bmod[i + 1] - bmod[0];
+    dgam[i] = gam[i + 1] - gam[0];
+  }
+  printf("# =================================================================== #\n"
+         "# State of rho, T                                                     #\n"
+         "# =================================================================== #\n"
+         "# rho = %.8e \n"
+         "# T   = %.8e \n"
+         "# =================================================================== #\n"
+         "#  P          | sie         | cv          | bmod        | gamma       #\n"
+         "# =================================================================== #\n"
+         "# eospac                                                              #\n"
+         "# ------------------------------------------------------------------- #\n"
+         "| %-11.4e | %-11.4e | %-11.4e | %-11.4e | %-11.4e |\n"
+         "# ------------------------------------------------------------------- #\n"
+         "# Spiner(rho, T)                                                      #\n"
+         "# ------------------------------------------------------------------- #\n"
+         "| %-11.4e | %-11.4e | %-11.4e | %-11.4e | %-11.4e |\n"
+         "# ------------------------------------------------------------------- #\n"
+         "# difference                                                          #\n"
+         "# ------------------------------------------------------------------- #\n"
+         "| %-11.4e | %-11.4e | %-11.4e | %-11.4e | %-11.4e |\n"
+         "# ------------------------------------------------------------------- #\n"
+         "# Spiner(rho, sie)                                                    #\n"
+         "# ------------------------------------------------------------------- #\n"
+         "| %-11.4e | %-11.4e | %-11.4e | %-11.4e | %-11.4e |\n"
+         "# ------------------------------------------------------------------- #\n"
+         "# difference                                                          #\n"
+         "# ------------------------------------------------------------------- #\n"
+         "| %-11.4e | %-11.4e | %-11.4e | %-11.4e | %-11.4e |\n"
+         "# ------------------------------------------------------------------- #\n",
+         rho, T, press[iPC], sie[iPC], cv[iPC], bmod[iPC], gam[iPC], press[iRT], sie[iRT],
+         cv[iRT], bmod[iRT], gam[iRT], dp[0], dsie[0], dcv[0], dbmod[0], dgam[0],
+         press[iRE], sie[iRE], cv[iRE], bmod[iRE], gam[iRE], dp[1], dsie[1], dcv[1],
+         dbmod[1], dgam[1]);
+}
+
+inline void PrintStateOfRhoSie(const double rho, const double sie, EOS eos[3]) {
+  Real press[3];
+  Real dp[2];
+  Real T[3];
+  Real dT[2];
+  Real cv[3];
+  Real dcv[2];
+  Real bmod[3];
+  Real dbmod[2];
+  Real gam[3];
+  Real dgam[2];
+  for (int i = 0; i < 3; ++i) {
+    press[i] = eos[i].PressureFromDensityInternalEnergy(rho, sie);
+    T[i] = eos[i].TemperatureFromDensityInternalEnergy(rho, sie);
+    cv[i] = eos[i].SpecificHeatFromDensityInternalEnergy(rho, sie);
+    bmod[i] = eos[i].BulkModulusFromDensityInternalEnergy(rho, sie);
+    gam[i] = eos[i].GruneisenParamFromDensityInternalEnergy(rho, sie);
+  }
+  for (int i = 0; i < 2; ++i) {
+    dp[i] = press[i + 1] - press[0];
+    dT[i] = T[i + 1] - T[0];
+    dcv[i] = cv[i + 1] - cv[0];
+    dbmod[i] = bmod[i + 1] - bmod[0];
+    dgam[i] = gam[i + 1] - gam[0];
+  }
+  printf("# =================================================================== #\n"
+         "# State of rho, sie                                                   #\n"
+         "# =================================================================== #\n"
+         "# rho = %.8e \n"
+         "# sie = %.8e \n"
+         "# =================================================================== #\n"
+         "#  P          | T           | cv          | bmod        | gamma       #\n"
+         "# =================================================================== #\n"
+         "# eospac                                                              #\n"
+         "# ------------------------------------------------------------------- #\n"
+         "| %-11.4e | %-11.4e | %-11.4e | %-11.4e | %-11.4e |\n"
+         "# ------------------------------------------------------------------- #\n"
+         "# Spiner(rho, T)                                                      #\n"
+         "# ------------------------------------------------------------------- #\n"
+         "| %-11.4e | %-11.4e | %-11.4e | %-11.4e | %-11.4e |\n"
+         "# ------------------------------------------------------------------- #\n"
+         "# difference                                                          #\n"
+         "# ------------------------------------------------------------------- #\n"
+         "| %-11.4e | %-11.4e | %-11.4e | %-11.4e | %-11.4e |\n"
+         "# ------------------------------------------------------------------- #\n"
+         "# Spiner(rho, sie)                                                    #\n"
+         "# ------------------------------------------------------------------- #\n"
+         "| %-11.4e | %-11.4e | %-11.4e | %-11.4e | %-11.4e |\n"
+         "# ------------------------------------------------------------------- #\n"
+         "# difference                                                          #\n"
+         "# ------------------------------------------------------------------- #\n"
+         "| %-11.4e | %-11.4e | %-11.4e | %-11.4e | %-11.4e |\n"
+         "# ------------------------------------------------------------------- #\n",
+         rho, sie, press[iPC], T[iPC], cv[iPC], bmod[iPC], gam[iPC], press[iRT], T[iRT],
+         cv[iRT], bmod[iRT], gam[iRT], dp[0], dT[0], dcv[0], dbmod[0], dgam[0],
+         press[iRE], T[iRE], cv[iRE], bmod[iRE], gam[iRE], dp[1], dT[1], dcv[1], dbmod[1],
+         dgam[1]);
+}
+
+int main(int argc, char *argv[]) {
+  // In case we're doing a Kokkos backend
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  Kokkos::initialize();
+#endif
+  { // begin kokkos scope
+    if (argc < 6) {
+      std::cerr << "Usage: " << argv[0] << " matid sp5_filename rho T sie" << std::endl;
+      // std::cerr << "Arguments given: " << argc << std::endl;
+      std::exit(1);
+    }
+
+    const int matid = std::atoi(argv[1]);
+    const std::string sp5_filename = argv[2];
+    const Real rho = std::atof(argv[3]);
+    const Real T = std::atof(argv[4]);
+    const Real sie = std::atof(argv[5]);
+
+    EOS eos[3];
+    eos[iPC] = EOSPAC(matid);
+    eos[iRT] = SpinerEOSDependsRhoT(sp5_filename, matid);
+    eos[iRE] = SpinerEOSDependsRhoSie(sp5_filename, matid);
+    PrintStateOfRhoT(rho, T, eos);
+    std::cout << std::endl;
+    PrintStateOfRhoSie(rho, sie, eos);
+  }
+}

--- a/sesame2spiner/generate_files.cpp
+++ b/sesame2spiner/generate_files.cpp
@@ -239,11 +239,11 @@ void getMatBounds(int i, int matid, const SesameMetadata &metadata, const Params
   };
 
   Real rhoMin = params.Get("rhomin", TinyShift(metadata.rhoMin, 1));
-  Real rhoMax = params.Get("rhomax", TinyShift(metadata.rhoMax, -1));
+  Real rhoMax = params.Get("rhomax", metadata.rhoMax);
   Real TMin = params.Get("Tmin", TinyShift(metadata.TMin, 1));
-  Real TMax = params.Get("Tmax", TinyShift(metadata.TMax, -1));
+  Real TMax = params.Get("Tmax", metadata.TMax);
   Real sieMin = params.Get("siemin", TinyShift(metadata.sieMin, 1));
-  Real sieMax = params.Get("siemax", TinyShift(metadata.sieMax, -1));
+  Real sieMax = params.Get("siemax", metadata.sieMax);
 
   checkValInMatBounds(matid, "rhoMin", rhoMin, metadata.rhoMin, metadata.rhoMax);
   checkValInMatBounds(matid, "rhoMax", rhoMax, metadata.rhoMin, metadata.rhoMax);

--- a/sesame2spiner/io_eospac.hpp
+++ b/sesame2spiner/io_eospac.hpp
@@ -83,8 +83,10 @@ class Bounds {
         int Nmax = static_cast<int>((max - min) / dxguess);
         int Nanchor = static_cast<int>((anchor_point - min) / dxguess);
         Real dx = (anchor_point - min) / static_cast<Real>(Nanchor + 1);
-        max = dx * (Nmax) + min;
-        N += 1;
+        int Nmax_new = static_cast<int>((max - min) / dx);
+        Nmax_new = std::max(Nmax, Nmax_new);
+        max = dx * (Nmax_new) + min;
+        N = Nmax_new;
       }
     }
 

--- a/singularity-eos/eos/eos_spiner.cpp
+++ b/singularity-eos/eos/eos_spiner.cpp
@@ -339,7 +339,8 @@ herr_t SpinerEOSDependsRhoT::loadDataboxes_(const std::string &matid_str, hid_t 
   gm1Max_.copyMetadata(PMax_);
   sielTMax_.copyMetadata(PMax_);
   for (int j = 0; j < numRho_; j++) {
-    Real rho = PMax_.range(0).x(j);
+    Real lRho = PMax_.range(0).x(j);
+    Real rho = rho_(lRho);
     PMax_(j) = P_(j, numT_ - 1);
     dEdTMax_(j) = dEdT_(j, numT_ - 1);
     gm1Max_(j) = dPdE_(j, numT_ - 1) / (rho + EPS); // max gruneisen

--- a/test/eos_unit_tests.cpp
+++ b/test/eos_unit_tests.cpp
@@ -345,6 +345,13 @@ SCENARIO("SpinerEOS depends on Rho and T", "[SpinerEOS],[DependsRhoT][EOSPAC]") 
       REQUIRE(nw_gm1 == 0);
       REQUIRE(nw_cv == 0);
     }
+    AND_THEN("P(rho, sie) correct for extrapolation regime") {
+      Real rho = 1;
+      Real sie = 2.43e16;
+      Real P_pac = eospac.PressureFromDensityInternalEnergy(rho, sie);
+      Real P_spi = airEOS.PressureFromDensityInternalEnergy(rho, sie);
+      REQUIRE(isClose(P_pac, P_spi));
+    }
     airEOS_host.Finalize();
     airEOS.Finalize();
   }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@annapiegra noticed that `SpinerEOSDependsRhoT` was producing an artifact near the top of the table, right around when the code switches to extrapolation. This was caused by two issues:
1. `sesame2spiner` offsets the grid log grid bounds slightly based on STP. The intent is that this regridding sets up exactly one grid point at standard density and one at standard temperature. To do so, I change the grid spacing and bounds slightly from what's specified in the file. This machinery was accidentally removing too many points from the top of the grid. It now removes *exactly* one point, meaning the upper bound of the table is closer to what's expected.
2. There was a bug in the extrapolation routines of `SpinerEOSDependsRhoT` where the Gruneisen parameter used for the ideal gas extrapolation was computed incorrectly.

Both bugs are now fixed. I am also adding a unit test to check for this behavior. 

Finally, this PR includes a new utility in the examples directory, `get_sesame_state`. This is built if you build examples. You pass it a matid, a spiner file, a density, a temperature, and an energy. It then uses both the spiner and eospac backends to print a few relevant calls at (density, temperature) and (density,energy) pairs. This utility was pretty useful for debugging this problem, and I think it'll be useful going forward.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x]  Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
