### PR TITLE
Correct Gruneisen parameter formula

### DIFF
--- a/singularity-eos/eos/eos.hpp
+++ b/singularity-eos/eos/eos.hpp
@@ -174,7 +174,7 @@ class Gruneisen {
   // static constexpr const char _eos_type[] = {"Gruneisen"};
   PORTABLE_INLINE_FUNCTION
   Real Gamma(const Real rho) const {
-    return rho < _rho0 ? _G0 : _G0 + _b * (rho / _rho0 - 1.0);
+    return rho < _rho0 ? _G0 : _G0 * _rho0 / rho + _b * (1 - _rho0 / rho);
   }
   static constexpr const unsigned long _preferred_input =
       thermalqs::density | thermalqs::specific_internal_energy;


### PR DESCRIPTION
Fix bug in the Gruneisen parameter for the Gruneisen EOS

## PR Summary

As implemented, the energy derivative of the pressure for this EOS would take the following form:
![Gruneisen1](https://user-images.githubusercontent.com/83598606/149428291-804c739a-bc36-4781-99f1-de7c88a53a34.png)

However, this form violates a key property of the Gruneisen EOS where the energy derivative should be constant when the parameter b = 0. Changing the first rho to rho_0 fixes this problem in the above equation which results in a Gruneisen parameter given by

![Gruneisen2](https://user-images.githubusercontent.com/83598606/149428732-dc90f838-0eaf-42f5-b8e7-76525f6303c3.png)

which is consistent with the energy derivative being constant when b=0. This is also consistent with the corrected EOS in other hydocodes.

Note that this is part of updating documentation so I'll update the documentation in a separate MR.

@chadmeyer can you review this

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
