### PR TITLE
Fix for JWL EOS

### DIFF
--- a/singularity-eos/eos/eos_jwl.cpp
+++ b/singularity-eos/eos/eos_jwl.cpp
@@ -17,11 +17,11 @@
 
 namespace singularity {
 
-PORTABLE_FUNCTION Real JWL::ReferenceEnergy(const Real rho) const {
+PORTABLE_FUNCTION Real JWL::ReferencePressure(const Real rho) const {
   const Real x = _rho0 / rho;
   return _A * std::exp(-_R1 * x) + _B * std::exp(-_R2 * x);
 }
-PORTABLE_FUNCTION Real JWL::ReferencePressure(const Real rho) const {
+PORTABLE_FUNCTION Real JWL::ReferenceEnergy(const Real rho) const {
   const Real x = _rho0 / rho;
   return _A / (_rho0 * _R1) * std::exp(-_R1 * x) +
          _B / (_rho0 * _R2) * std::exp(-_R2 * x);


### PR DESCRIPTION
## PR Summary

It appears that the reference energy and pressure for the JWL EOS were swapped as a typo.

The reference curve for the JWL EOS is an isentrope and a quick sanity check is that the pressure should be exactly equal to the volume derivative of the energy along the isentrope. This fix makes that true.

My fix is also consistent with xRAGE.

## PR Checklist

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
