### PR TITLE
Try the ideal gas PTE solution as initial guesses for PTE solver

### DIFF
--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -483,7 +483,7 @@ template <int nmat, typename EOSIndexer, typename RealIndexer, typename LambdaIn
 PORTABLE_INLINE_FUNCTION void
 try_ideal_pte(EOSIndexer &&eos, const Real vfrac_tot, const Real utot, const Real rho[nmat],
               RealIndexer &&vfrac, RealIndexer &&sie, RealIndexer &&temp, RealIndexer &&press,
-              LambdaIndexer &&lambda, const OFFSETTER ofst) {
+              LambdaIndexer &&lambda, const OFFSETTER ofst, Real Cache[nmat][MAX_NUM_LAMBDAS]) {
   Real A[nmat], B[nmat];
   Real rhoBsum = 0.0;
   Real Asum = 0.0;
@@ -585,7 +585,7 @@ pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot, const Real sie_tot
 
   // at this point we have initial guesses for rho, vfrac, sie, pressure, temperature
   // try to solve for PTE assuming an ideal gas to reset initial guess
-  try_ideal_pte<nmat,EOSIndexer,RealIndexer,LambdaIndexer,OFFSETTER>(eos, vfrac_tot, utot, rhobar, vfrac, sie, temp, press, lambda, ofst);
+  try_ideal_pte<nmat,EOSIndexer,RealIndexer,LambdaIndexer,OFFSETTER>(eos, vfrac_tot, utot, rhobar, vfrac, sie, temp, press, lambda, ofst, Cache);
 
   Real u[nmat];
   Real esum = 0.0;

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -480,9 +480,9 @@ PORTABLE_INLINE_FUNCTION static void pte_residual(const Real vfrac_tot, const Re
 }
 
 template <int nmat, typename RealIndexer>
-PORTABLE_INLINE_FUNCTION
-bool CheckPTE(const Real rho_total, RealIndexer &&vfrac, const Real rhobar[nmat],
-              RealIndexer &&press, RealIndexer &&temp, Real residual[2 * nmat]) {
+PORTABLE_INLINE_FUNCTION bool CheckPTE(const Real rho_total, RealIndexer &&vfrac,
+                                       const Real rhobar[nmat], RealIndexer &&press,
+                                       RealIndexer &&temp, Real residual[2 * nmat]) {
   using namespace mix_params;
   Real mean_p = vfrac[0] * press[0];
   Real mean_t = rhobar[0] * temp[0];
@@ -498,8 +498,8 @@ bool CheckPTE(const Real rho_total, RealIndexer &&vfrac, const Real rhobar[nmat]
   error_p = std::sqrt(error_p);
   error_t = std::sqrt(error_t);
   // Check for convergence
-  bool converged_p = (error_p < pte_rel_tolerance_p * std::abs(mean_p) ||
-                 error_p < pte_abs_tolerance_p);
+  bool converged_p =
+      (error_p < pte_rel_tolerance_p * std::abs(mean_p) || error_p < pte_abs_tolerance_p);
   bool converged_t =
       (error_t < pte_rel_tolerance_t * mean_t || error_t < pte_abs_tolerance_t);
   return (converged_p && converged_t);
@@ -508,31 +508,33 @@ bool CheckPTE(const Real rho_total, RealIndexer &&vfrac, const Real rhobar[nmat]
 template <int nmat, typename RealIndexer>
 PORTABLE_INLINE_FUNCTION void
 get_ideal_pte(const Real vfrac_tot, const Real utot, const Real rho[nmat],
-              RealIndexer &&vfrac, RealIndexer &&sie, RealIndexer &&temp, RealIndexer &&press,
-              Real &Pequil, Real &Tequil) {
+              RealIndexer &&vfrac, RealIndexer &&sie, RealIndexer &&temp,
+              RealIndexer &&press, Real &Pequil, Real &Tequil) {
   Real rhoBsum = 0.0;
   Real Asum = 0.0;
   for (int m = 0; m < nmat; m++) {
-    //A[m] = vfrac[m] * press[m]/temp[m];
+    // A[m] = vfrac[m] * press[m]/temp[m];
     Asum += vfrac[m] * press[m] / temp[m];
-    //B[m] = sie[m]/temp[m];
+    // B[m] = sie[m]/temp[m];
     rhoBsum += rho[m] * sie[m] / temp[m];
   }
 
-  Tequil = utot/rhoBsum;
-  Pequil = Tequil * Asum/vfrac_tot;
+  Tequil = utot / rhoBsum;
+  Pequil = Tequil * Asum / vfrac_tot;
 }
 
 template <int nmat, typename EOSIndexer, typename RealIndexer, typename LambdaIndexer,
           typename OFFSETTER>
 PORTABLE_INLINE_FUNCTION void
-try_ideal_pte(EOSIndexer &&eos, const Real vfrac_tot, const Real utot, const Real rhobar[nmat],
-              RealIndexer &&vfrac, RealIndexer &&sie, RealIndexer &&temp, RealIndexer &&press,
-              LambdaIndexer &&lambda, const OFFSETTER ofst, Real Cache[nmat][MAX_NUM_LAMBDAS],
+try_ideal_pte(EOSIndexer &&eos, const Real vfrac_tot, const Real utot,
+              const Real rhobar[nmat], RealIndexer &&vfrac, RealIndexer &&sie,
+              RealIndexer &&temp, RealIndexer &&press, LambdaIndexer &&lambda,
+              const OFFSETTER ofst, Real Cache[nmat][MAX_NUM_LAMBDAS],
               Real residual[2 * nmat]) {
   Real Pequil, Tequil;
-  get_ideal_pte<nmat, RealIndexer>(vfrac_tot, utot, rhobar, vfrac, sie, temp, press, Pequil, Tequil);
-  const Real alpha = Pequil/Tequil;
+  get_ideal_pte<nmat, RealIndexer>(vfrac_tot, utot, rhobar, vfrac, sie, temp, press,
+                                   Pequil, Tequil);
+  const Real alpha = Pequil / Tequil;
 
   Real etrial[nmat], vtrial[nmat], ttrial[nmat], ptrial[nmat], utrial[nmat];
   for (int m = 0; m < nmat; m++) {
@@ -541,13 +543,16 @@ try_ideal_pte(EOSIndexer &&eos, const Real vfrac_tot, const Real utot, const Rea
     vtrial[m] = vfrac[m] * press[m] / (temp[m] * alpha);
   }
   for (int m = 0; m < nmat; m++) {
-    ttrial[m] = eos[ofst(m)].TemperatureFromDensityInternalEnergy(rhobar[m]/vtrial[m], etrial[m], Cache[m]);
+    ttrial[m] = eos[ofst(m)].TemperatureFromDensityInternalEnergy(rhobar[m] / vtrial[m],
+                                                                  etrial[m], Cache[m]);
     if (eos[ofst(m)].PreferredInput() ==
         (thermalqs::density | thermalqs::specific_internal_energy)) {
-      ptrial[m] = eos[ofst(m)].PressureFromDensityInternalEnergy(rhobar[m]/vtrial[m], etrial[m], Cache[m]);
+      ptrial[m] = eos[ofst(m)].PressureFromDensityInternalEnergy(rhobar[m] / vtrial[m],
+                                                                 etrial[m], Cache[m]);
     } else if (eos[ofst(m)].PreferredInput() ==
                (thermalqs::density | thermalqs::temperature)) {
-      ptrial[m] = eos[ofst(m)].PressureFromDensityTemperature(rhobar[m]/vtrial[m], ttrial[m], Cache[m]);
+      ptrial[m] = eos[ofst(m)].PressureFromDensityTemperature(rhobar[m] / vtrial[m],
+                                                              ttrial[m], Cache[m]);
     }
   }
 
@@ -556,7 +561,7 @@ try_ideal_pte(EOSIndexer &&eos, const Real vfrac_tot, const Real utot, const Rea
 
   Real res0 = 0.0;
   Real res1 = 0.0;
-  for (int m = 0; m < 2*nmat; m++) {
+  for (int m = 0; m < 2 * nmat; m++) {
     res0 += residual[m] * residual[m];
     res1 += res_new[m] * res_new[m];
   }
@@ -567,10 +572,10 @@ try_ideal_pte(EOSIndexer &&eos, const Real vfrac_tot, const Real utot, const Rea
       temp[m] = ttrial[m];
       sie[m] = etrial[m];
       vfrac[m] = vtrial[m];
-      residual[2*m] = res_new[2*m];
-      residual[2*m+1] = res_new[2*m+1];
+      residual[2 * m] = res_new[2 * m];
+      residual[2 * m + 1] = res_new[2 * m + 1];
     }
-  } 
+  }
 
   return;
 }
@@ -618,7 +623,6 @@ pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot, const Real sie_tot
     }
   }
 
-
   Real u[nmat];
   Real esum = 0.0;
   for (int m = 0; m < nmat; ++m)
@@ -637,8 +641,9 @@ pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot, const Real sie_tot
 
   // at this point we have initial guesses for rho, vfrac, sie, pressure, temperature
   // try to solve for PTE assuming an ideal gas to reset initial guess
-  try_ideal_pte<nmat,EOSIndexer,RealIndexer,LambdaIndexer,OFFSETTER>(eos, vfrac_tot, utot,
-    rhobar, vfrac, sie, temp, press, lambda, ofst, Cache, residual);
+  try_ideal_pte<nmat, EOSIndexer, RealIndexer, LambdaIndexer, OFFSETTER>(
+      eos, vfrac_tot, utot, rhobar, vfrac, sie, temp, press, lambda, ofst, Cache,
+      residual);
 
   Real vtemp[nmat], rtemp[nmat], utemp[nmat];
   Real dpde[nmat], dtde[nmat], dpdv[nmat], dtdv[nmat];
@@ -651,7 +656,8 @@ pte_closure_josh_impl(EOSIndexer &&eos, const Real vfrac_tot, const Real sie_tot
   // get the initial residual
   for (niter = 0; niter < pte_max_iter; ++niter) {
     // Calculate errors and break of converged
-    converged = CheckPTE<nmat, RealIndexer>(rho_total, vfrac, rhobar, press, temp, residual);
+    converged =
+        CheckPTE<nmat, RealIndexer>(rho_total, vfrac, rhobar, press, temp, residual);
     if (converged) break;
 
     for (int m = 0; m < nmat; m++) {

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -483,7 +483,7 @@ template <int nmat, typename EOSIndexer, typename RealIndexer, typename LambdaIn
 PORTABLE_INLINE_FUNCTION void
 try_ideal_pte(EOSIndexer &&eos, const Real vfrac_tot, const Real utot, const Real rho[nmat],
               RealIndexer &&vfrac, RealIndexer &&sie, RealIndexer &&temp, RealIndexer &&press,
-              LambdaIndexer &&lambda const OFFSETTER ofst) {
+              LambdaIndexer &&lambda, const OFFSETTER ofst) {
   Real A[nmat], B[nmat];
   Real rhoBsum = 0.0;
   Real Asum = 0.0;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This PR adds a new call that solves for PTE assuming an ideal gas form, which is simple and analytic, and can replace the initial guesses for the full PTE solve based on some measure of whether the new guess is better.  The metric that decides if the new guess is superior can probably use work.  When the mixture is of ideal gases, this new guess is the exact result, and some reordering of the subsequent solve means that in that case no Newton iterations are performed.  This leads to a pretty substantial performance win for problems with ideal gases or when the ideal gas assumption isn't unreasonable in the relevant part of the EOS.

Curious if people have thoughts.  @chadmeyer @jhp-lanl @jonahm-LANL 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
