### PR TITLE
Add eospac variant to spackage

### DIFF
--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -39,6 +39,7 @@ class SingularityEos(CMakePackage, CudaPackage):
 
     # TODO: do we always depend on eospac? 
     depends_on("eospac")
+    variant("eospac", default=True, description="Pull in EOSPAC")
 
     # building/testing/docs
     depends_on("cmake@3.14:")

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -37,8 +37,6 @@ class SingularityEos(CMakePackage, CudaPackage):
     # TODO: decide if this should stay in the source tree, or split out a seperate dependency build
     #depends_on("mpark-variant")
 
-    # TODO: do we always depend on eospac? 
-    depends_on("eospac")
     variant("eospac", default=True, description="Pull in EOSPAC")
 
     # building/testing/docs
@@ -52,6 +50,8 @@ class SingularityEos(CMakePackage, CudaPackage):
 
     # linear algebra when not using GPUs
     depends_on("eigen@3.3.8", when="~cuda")
+
+    depends_on("eospac", when="+eospac")
 
     # set up kokkos offloading dependencies
     for _flag in ("~cuda", "+cuda", "~openmp", "+openmp"):


### PR DESCRIPTION

## PR Summary

Make eospac a variant in singularity-eos spackage. (Eospac was already listed as a dependency)

Spack looks for eospac in the spec to determine if eospac should be pulled in:           self.define("SINGULARITY_USE_EOSPAC", "^eospac" in self.spec)

## PR Checklist

Spack env builds on CTS1_intel. 

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
