### PR TITLE
remove explicit C++ variant of hdf5

### DIFF
--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -80,7 +80,7 @@ class SingularityEos(CMakePackage, CudaPackage):
 
     # NOTE: these are set so that dependencies in downstream projects share common MPI dependence
     for _flag in ("~mpi", "+mpi"):
-        depends_on("hdf5+cxx+hl" + _flag, when=_flag)
+        depends_on("hdf5+hl" + _flag, when=_flag)
         depends_on("py-h5py" + _flag, when=_flag)
         depends_on("kokkos-nvcc-wrapper" + _flag, when="+cuda+kokkos"+_flag)
 


### PR DESCRIPTION
Changes `hdf5` dependency variants from `hdf5+cxx+hl` to `hdf5+hl`

## PR Summary

@annapiegra reported conflicts with using the `+cxx` variant. Removed this from `package.py`

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
