### PR TITLE
Fast, approximate and invertible logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ option (SINGULARITY_BUILD_CLOSURE "Mixed cell closure" ON)
 option (SINGULARITY_TEST_SESAME "Test the Sesame table readers" OFF)
 option (SINGULARITY_TEST_STELLAR_COLLAPSE "Test the stellar collapse table readers" OFF)
 option (SINGULARITY_USE_SINGLE_LOGS "Use single precision logs. Can harm accuracy." OFF)
+option (SINGULARITY_USE_TRUE_LOG_GRIDDING "Use grids that conform to log spacing." OFF)
 
 if (SINGULARITY_SUBMODULE_MODE)
   set(SINGULARITY_BETTER_DEBUG_FLAGS OFF CACHE BOOL "" FORCE)
@@ -273,6 +274,10 @@ endif ()
 if (SINGULARITY_USE_SINGLE_LOGS)
   target_compile_definitions(singularity-eos::flags INTERFACE
       SINGULARITY_USE_SINGLE_LOGS)
+endif()
+if (SINGULARITY_USE_TRUE_LOG_GRIDDING)
+  target_compile_definitions(singularity-eos::flags INTERFACE
+      SINGULARITY_USE_TRUE_LOG_GRIDDING)
 endif()
 
 # required package ports of call

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,6 @@ option (SINGULARITY_BUILD_CLOSURE "Mixed cell closure" ON)
 option (SINGULARITY_TEST_SESAME "Test the Sesame table readers" OFF)
 option (SINGULARITY_TEST_STELLAR_COLLAPSE "Test the stellar collapse table readers" OFF)
 option (SINGULARITY_USE_SINGLE_LOGS "Use single precision logs. Can harm accuracy." OFF)
-option (SINGULARITY_FMATH_USE_ORDER_4 "4th order interpolant for fast logs. Default is 7th order." OFF)
-option (SINGULARITY_FMATH_USE_ORDER_5 "5th order interpolant for fast logs. Default is 7th order." OFF)
 
 if (SINGULARITY_SUBMODULE_MODE)
   set(SINGULARITY_BETTER_DEBUG_FLAGS OFF CACHE BOOL "" FORCE)
@@ -275,17 +273,6 @@ endif ()
 if (SINGULARITY_USE_SINGLE_LOGS)
   target_compile_definitions(singularity-eos::flags INTERFACE
       SINGULARITY_USE_SINGLE_LOGS)
-endif()
-if (SINGULARITY_FMATH_USE_ORDER_4 AND SINGULARITY_FMATH_USE_ORDER_5)
-  message(FATAL_ERROR "Order 4 and order 5 interpolation both specified. Please specify only one or zero. If no specification is made, order 7 will be used.")
-endif()
-if (SINGULARITY_FMATH_USE_ORDER_4)
-  target_compile_definitions(singularity-eos::flags INTERFACE
-    SINGULARITY_FMATH_USE_ORDER_4)
-endif()
-if (SINGULARITY_FMATH_USE_ORDER_5)
-  target_compile_definitions(singularity-eos::flags INTERFACE
-    SINGULAIRTY_FMATH_USE_ORDER_5)
 endif()
 
 # required package ports of call

--- a/doc/sphinx/src/contributing.rst
+++ b/doc/sphinx/src/contributing.rst
@@ -2,3 +2,74 @@
 
 Contributing
 =============
+
+
+Fast Logs and Approximate Log Gridding
+---------------------------------------
+
+When spanning many orders of magnitude, Logarithmic grids are a
+natural choice. Even spacing in log space corresponds to exponential
+spacing in the original linear space. In other words, the grid spacing
+is proportional to the value of the independent variable.
+
+One can perform log-linear or log-log interpolation by simply
+converting to log space, interpolating as one normally would, and then
+converting back out. Unfortunately, logarithms and exponents are
+transcendental functions, meaning they are expensive to compute and it
+is thus expensive to transform in and out of log space.
+
+To avoid this issue, we construct a space that is *approximately*
+logarithmically spaced, but not quite exactly. The requirements for
+this space are that the transformation into and out of this space is
+fast to compute, continuous, differentiable, analytically invertible,
+and close to taking a logarithm or exponentiation (depending on which
+way you're going).
+
+To achieve this, we leverage the internal representation of a floating
+point number in the IEE standard. In particular, a floating point
+number :math:`x` is represented as a mantissa and an exponent in base
+2:
+
+.. math::
+
+   x = m 2^e
+
+for mantissa :math:`m` and exponent :math:`e`. The mantiss is
+guaranteed to be on the interval :math:`[1/2, 1)`. The standard
+library of most low-level languages provides a performant and portable
+routine to pick apart this represnetation, ``frexp``, which given a
+number :math:`x`, return :math:`m` and :math:`e`.
+
+The log in base 2 ``lg`` of :math:`x` is then given by the logarithm
+of the mantissa plus the exponent:
+
+.. math::
+
+   \lg(x) = \lg(m) + e
+
+Therefore, if we can find a fast, invertible approximation to
+:math:`\lg(m)`, we will have achieved our goal. It turns out the
+expression
+
+.. math::
+
+   2 (x - 1)
+
+works pretty well, so we use that. (To convince yourself of this note
+that for :math:`x=1/2` this expression returns -1 and for :math:`x=1`,
+it returns 0, which are the correct values of :math:`\lg(x)` at the
+bounds of the interval.) Thus our approximate, invertible expression
+for :math:`\lg` is just
+
+.. math::
+
+   2 (m - 1) + e
+
+for the mantissa and exponent extracted via ``frexp``. The absolute
+error of this approximation is about 0.1 at its largest, which
+translates to a relative error of at most 25 percent. This error is
+acceptable, for the reasoning stated above.
+
+To invert, we use the built in function that inverts ``frexp``,
+``ldexp``, which combines the mantissa and exponent into the original
+floating point representation.

--- a/doc/sphinx/src/contributing.rst
+++ b/doc/sphinx/src/contributing.rst
@@ -65,10 +65,11 @@ for :math:`\lg` is just
 
    2 (m - 1) + e
 
-for the mantissa and exponent extracted via ``frexp``. The absolute
-error of this approximation is about 0.1 at its largest, which
-translates to a relative error of at most 25 percent. This error is
-acceptable, for the reasoning stated above.
+for the mantissa and exponent extracted via ``frexp``. This differs
+from :math:`lg` by a maximum of about 0.1, which translates to at most
+a 25 percent difference. As discussed above, however, the function
+itself is an exact representation of itself and the difference from
+:math:`lg` is acceptable.
 
 To invert, we use the built in function that inverts ``frexp``,
 ``ldexp``, which combines the mantissa and exponent into the original

--- a/doc/sphinx/src/getting-started.rst
+++ b/doc/sphinx/src/getting-started.rst
@@ -79,4 +79,3 @@ Going Deeper
 * To learn about the available equations of state, look :ref:`here <models>`.
 * To learn about our mixed-cell closure models, such as pressure-temperature equilibrium, look at :ref:`using-closures`.
 * If you're interested in contributing, check out our :ref:`documentation for developers <contributing>`.
-

--- a/doc/sphinx/src/models.rst
+++ b/doc/sphinx/src/models.rst
@@ -448,9 +448,96 @@ parameters with units related to their non-subscripted counterparts.
 Spiner EOS
 ````````````
 
+Spiner EOS is a tabulated reader for the `Sesame`_ database of material
+equations of state. Materials include things like water, dry air,
+iron, or steel. This model comes in two flavors:
+``SpinerEOSDependsRhoT`` and ``SpinerEOSDependsRhoSie``. The former
+tabulates all quantities of interest in terms of density and
+temperature. The latter also includes tables in terms of density and
+specific internal energy.
+
+Tabulating in terms of density and pressure means that computing,
+e.g., pressure in terms of density and internal energy requires
+solving the equation:
+
+.. math::
+
+   e_0 = e(\rho, T)
+
+for temperature :math:`T` given density :math:`\rho` and specific
+internal energy :math:`e_0`. This is in general not closed
+algebraically and must be solved using a
+root-find. ``SpinerEOSDependsRhoT`` performs this root find in-line,
+and the result is performant, thanks to library's ability to take and
+cache initial guesses. ``SpinerEOSDependsRhoSie`` circumvents this
+issue by tabulating in terms of both specific internal energy and
+temperature.
+
+Both models use (approximately) log-linear interpolation on a grid
+that is (approximately) uniformly spaced on a log scale. Thermodynamic
+derivatives are tabulated and interpolated, rather than computed from
+the interpolating function. This approach allows for significantly
+higher fidelity approximations of these derivatives.
+
 Stellar Collapse EOS
 ````````````````````
+
+This model provides finite temperature nuclear equations of state
+suitable for core collapse supernova and compact object (such as
+neutron star) simulations. These models assume nuclear statistical
+equilibrium (NSE). It reads tabulated data in the `Stellar Collapse`_
+format, as first presented by `O'Connor and Ott`_.
+
+Like ``SpinerEOSDependsRhoT``, ``StellarCollapse`` tabulateds all
+quantities in terms of density and temperature on a logarithmically
+spaced grid. And similarly, it requires an in-line root-find to
+compute quantities in terms of density and specific internal
+energy. Unlike most of the other models in ``singularity-eos``,
+``StellarCollapse`` also depends on a third quantity, the electron
+fraction,
+
+.. math::
+
+   Y_e = \frac{n_e}{n_p + n_n}
+
+which measures the number fraction of electrons to baryons. Symmetric
+matter has a :math:`Y_e` of 0.5, while cold neutron stars, have a
+:math:`Y_e` approximately less than 0.1.
+
+As with ``SpinerEOSDependsRhoT``, the Stellar Collapse tables tabulate
+thermodynamic derivatives separately, rather than reconstruct them
+from interpolants. However, the tabulated values can contain
+artifacts, such as unphysical spikes. To mitigate this issue, the
+thermodynamic derivatives are cleaned via a `median filter`_. The bulk
+modulus is then recomputed from these thermodynamic derivatives via:
+
+.. math::
+
+   B_S(\rho, T) = \rho \left(\frac{\partial P}{\partial\rho}\right)_e + \frac{P}{\rho} \left(\frac{\partial P}{\partial e}\right)_\rho
+
+Note that ``StellarCollapse`` is a relativistic model, and thus the
+sound speed is given by
+
+.. math::
+
+   c_s^2 = \frac{B_S}{w}
+
+where :math:`w = \rho h` for specific entalpy :math:`h` is the
+enthalpy by volume, rather than the density :math:`rho`. This ensures
+the sound speed is bounded from above by the speed of light.
+
+.. _Stellar Collapse: https://stellarcollapse.org/equationofstate.html
+
+.. _O'connor and Ott`: https://doi.org/10.1088/0264-9381/27/11/114103
+
+.. _median filter: https://en.wikipedia.org/wiki/Median_filter
 
 EOSPAC EOS
 ````````````
 
+This is a striaghtforward wrapper of the `EOSPAC`_ library for the
+`Sesame`_ database.
+
+.. _Sesame: https://www.lanl.gov/org/ddste/aldsc/theoretical/physics-chemistry-materials/sesame-database.php
+
+.. _EOSPAC: https://laws.lanl.gov/projects/data/eos/eospacReleases.php

--- a/sesame2spiner/io_eospac.hpp
+++ b/sesame2spiner/io_eospac.hpp
@@ -65,15 +65,15 @@ class Bounds {
       min += offset;
       max += offset;
 
-      min = std::log10(std::abs(min));
-      max = std::log10(std::abs(max));
+      min = singularity::Math::log10(std::abs(min));
+      max = singularity::Math::log10(std::abs(max));
       Real delta = max - min;
       min += 0.5 * shrinkRange * delta;
       max -= 0.5 * shrinkRange * delta;
 
       if (!(std::isnan(anchor_point))) {
         anchor_point += offset;
-        anchor_point = std::log10(std::abs(anchor_point));
+        anchor_point = singularity::Math::log10(std::abs(anchor_point));
       }
     }
 
@@ -93,7 +93,7 @@ class Bounds {
     grid = RegularGrid1D(min, max, N);
   }
 
-  inline Real log2lin(Real xl) const { return pow(10., xl) - offset; }
+  inline Real log2lin(Real xl) const { return singularity::Math::pow10(xl) - offset; }
   inline Real i2lin(int i) const { return log2lin(grid.x(i)); }
 
   friend std::ostream &operator<<(std::ostream &os, const Bounds &b) {

--- a/sesame2spiner/io_eospac.hpp
+++ b/sesame2spiner/io_eospac.hpp
@@ -65,15 +65,15 @@ class Bounds {
       min += offset;
       max += offset;
 
-      min = singularity::Math::log10(std::abs(min));
-      max = singularity::Math::log10(std::abs(max));
+      min = singularity::FastMath::log10(std::abs(min));
+      max = singularity::FastMath::log10(std::abs(max));
       Real delta = max - min;
       min += 0.5 * shrinkRange * delta;
       max -= 0.5 * shrinkRange * delta;
 
       if (!(std::isnan(anchor_point))) {
         anchor_point += offset;
-        anchor_point = singularity::Math::log10(std::abs(anchor_point));
+        anchor_point = singularity::FastMath::log10(std::abs(anchor_point));
       }
     }
 
@@ -93,7 +93,7 @@ class Bounds {
     grid = RegularGrid1D(min, max, N);
   }
 
-  inline Real log2lin(Real xl) const { return singularity::Math::pow10(xl) - offset; }
+  inline Real log2lin(Real xl) const { return singularity::FastMath::pow10(xl) - offset; }
   inline Real i2lin(int i) const { return log2lin(grid.x(i)); }
 
   friend std::ostream &operator<<(std::ostream &os, const Bounds &b) {

--- a/singularity-eos/eos/eos.hpp
+++ b/singularity-eos/eos/eos.hpp
@@ -499,10 +499,10 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   static PORTABLE_FORCEINLINE_FUNCTION Real toLog_(const Real x, const Real offset) {
     // return std::log10(x + offset + EPS);
     // return std::log10(std::abs(std::max(x,-offset) + offset)+EPS);
-    return Math::log10(std::abs(std::max(x, -offset) + offset) + EPS);
+    return FastMath::log10(std::abs(std::max(x, -offset) + offset) + EPS);
   }
   static PORTABLE_FORCEINLINE_FUNCTION Real fromLog_(const Real lx, const Real offset) {
-    return Math::pow10(lx) - offset;
+    return FastMath::pow10(lx) - offset;
   }
   PORTABLE_INLINE_FUNCTION Real __attribute__((always_inline))
   lRho_(const Real rho) const noexcept {
@@ -698,10 +698,10 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
 
   static PORTABLE_FORCEINLINE_FUNCTION Real toLog_(const Real x, const Real offset) {
     // return std::log10(std::abs(std::max(x,-offset) + offset)+EPS);
-    return Math::log10(std::abs(std::max(x, -offset) + offset) + EPS);
+    return FastMath::log10(std::abs(std::max(x, -offset) + offset) + EPS);
   }
   static PORTABLE_FORCEINLINE_FUNCTION Real fromLog_(const Real lx, const Real offset) {
-    return Math::pow10(lx) - offset;
+    return FastMath::pow10(lx) - offset;
   }
   PORTABLE_FUNCTION
   Real interpRhoT_(const Real rho, const Real T, const Spiner::DataBox &db,

--- a/singularity-eos/eos/eos.hpp
+++ b/singularity-eos/eos/eos.hpp
@@ -502,7 +502,7 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
     return Math::log10(std::abs(std::max(x, -offset) + offset) + EPS);
   }
   static PORTABLE_FORCEINLINE_FUNCTION Real fromLog_(const Real lx, const Real offset) {
-    return std::pow(10., lx) - offset;
+    return Math::pow10(lx) - offset;
   }
   PORTABLE_INLINE_FUNCTION Real __attribute__((always_inline))
   lRho_(const Real rho) const noexcept {
@@ -701,7 +701,7 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
     return Math::log10(std::abs(std::max(x, -offset) + offset) + EPS);
   }
   static PORTABLE_FORCEINLINE_FUNCTION Real fromLog_(const Real lx, const Real offset) {
-    return std::pow(10., lx) - offset;
+    return std::pow10(lx) - offset;
   }
   PORTABLE_FUNCTION
   Real interpRhoT_(const Real rho, const Real T, const Spiner::DataBox &db,
@@ -867,12 +867,14 @@ class StellarCollapse : public EosBase<StellarCollapse> {
 
   PORTABLE_INLINE_FUNCTION __attribute__((always_inline)) Real
   toLog_(const Real x, const Real offset) const noexcept {
-    // return std::log10(x + offset + EPS);
-    // return std::log10(std::abs(std::max(x,-offset) + offset)+EPS);
-    return Math::log10(std::abs(std::max(x, -offset) + offset) + EPS);
+    // StellarCollapse can't use fast logs, unless we re-grid onto the
+    // "fast log grid"
+    return std::log10(std::abs(std::max(x, -offset) + offset) + EPS);
   }
   PORTABLE_INLINE_FUNCTION Real __attribute__((always_inline))
   fromLog_(const Real lx, const Real offset) const noexcept {
+    // StellarCollapse can't use fast logs, unless we re-grid onto the
+    // "fast log grid"
     return std::pow(10., lx) - offset;
   }
   PORTABLE_INLINE_FUNCTION Real __attribute__((always_inline))

--- a/singularity-eos/eos/eos.hpp
+++ b/singularity-eos/eos/eos.hpp
@@ -701,7 +701,7 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
     return Math::log10(std::abs(std::max(x, -offset) + offset) + EPS);
   }
   static PORTABLE_FORCEINLINE_FUNCTION Real fromLog_(const Real lx, const Real offset) {
-    return std::pow10(lx) - offset;
+    return Math::pow10(lx) - offset;
   }
   PORTABLE_FUNCTION
   Real interpRhoT_(const Real rho, const Real T, const Spiner::DataBox &db,

--- a/test/eos_unit_tests.cpp
+++ b/test/eos_unit_tests.cpp
@@ -133,8 +133,8 @@ SCENARIO("Test that fast logs are invertible and run on device", "[FastMath]") {
           "try out the fast math", 0, NX, PORTABLE_LAMBDA(const int i) {
             constexpr Real machine_eps = std::numeric_limits<Real>::epsilon();
             constexpr Real acceptable_err = 100 * machine_eps;
-            const Real lx = singularity::Math::log10(x[i]);
-            const Real elx = singularity::Math::pow10(lx);
+            const Real lx = singularity::FastMath::log10(x[i]);
+            const Real elx = singularity::FastMath::pow10(lx);
             const Real rel_err = 2.0 * std::abs(x[i] - elx) /
                                  (std::abs(x[i]) + std::abs(elx) + machine_eps);
             n_wrong_ie() += (rel_err > acceptable_err);
@@ -144,7 +144,7 @@ SCENARIO("Test that fast logs are invertible and run on device", "[FastMath]") {
 #endif
       REQUIRE(nw_ie == 0);
     }
-    free(x);
+    PORTABLE_FREE(x);
   }
 }
 

--- a/test/eos_unit_tests.cpp
+++ b/test/eos_unit_tests.cpp
@@ -132,7 +132,7 @@ SCENARIO("Test that fast logs are invertible and run on device", "[FastMath]") {
       portableFor(
           "try out the fast math", 0, NX, PORTABLE_LAMBDA(const int i) {
             constexpr Real machine_eps = std::numeric_limits<Real>::epsilon();
-	    constexpr Real acceptable_err = 100*machine_eps;
+            constexpr Real acceptable_err = 100 * machine_eps;
             const Real lx = singularity::Math::log10(x[i]);
             const Real elx = singularity::Math::pow10(lx);
             const Real rel_err = 2.0 * std::abs(x[i] - elx) /

--- a/utils/fast-math/logs.hpp
+++ b/utils/fast-math/logs.hpp
@@ -31,7 +31,7 @@
  *
  * 2. The function must be invertible, meaning you can go back to
  * "linear space." Ideally it is also continuous.
- * 
+ *
  * 3. The function and its inverse must be fast.
  *
  * To meet these constraints, we approximate a logarithm by using
@@ -50,7 +50,7 @@
  *
  * So that mantissa = 0.5 returns log_2(0.5) = -1 and mantissa (1)
  * yields 0.
- * 
+ *
  * Then the approximate log of the whole thing is the approximation of
  * the log of the mantissa, plus the exponent:
  *
@@ -80,20 +80,20 @@ double lg(const double x) {
   const float y = frexpf((float)x, &n); // faster but less accurate
 #endif // SINGULARITY_USE_SINGLE_LOGS
 
-  return 2*(y - 1) + n;
+  return 2 * (y - 1) + n;
 }
 
 PORTABLE_FORCEINLINE_FUNCTION
 double log10(const double x) {
   constexpr double LOG2OLOG10 = 0.301029995663981195;
-  return LOG2OLOG10*lg(x);
+  return LOG2OLOG10 * lg(x);
 }
 
 PORTABLE_FORCEINLINE_FUNCTION
 double pow2(const double x) {
   const int flr = std::floor(x);
   const double remainder = x - flr;
-  const double mantissa = 0.5*(remainder + 1);
+  const double mantissa = 0.5 * (remainder + 1);
   const double exponent = flr + 1;
 #ifndef SINGULARITY_USE_SINGLE_LOGS
   return ldexp(mantissa, exponent);
@@ -105,7 +105,7 @@ double pow2(const double x) {
 PORTABLE_FORCEINLINE_FUNCTION
 double pow10(const double x) {
   constexpr double LOG10OLOG2 = 3.321928094887362626;
-  return pow2(LOG10OLOG2*x);
+  return pow2(LOG10OLOG2 * x);
 }
 
 } // namespace Math

--- a/utils/fast-math/logs.hpp
+++ b/utils/fast-math/logs.hpp
@@ -19,6 +19,30 @@
 #include <cmath>
 #include <ports-of-call/portability.hpp>
 
+/*
+ * These functions are for use when moving to and from the gridding space
+ * for Spiner grids.
+ *
+ * The core idea here is to move onto a grid that's roughly
+ * logarithmically spaced. It doesn't actually matter if that grid is
+ * EXACTLY logarithmic. Just that it is approximately so.
+ *
+ * It is important that the function that we use to translate to "grid
+ * space" is invertible and fast.
+ *
+ * To meet these constraints, we approximate a logarithm by using
+ * frexp and ldexp to split a real number into its mantissa + exponent.
+ * to truly take the log, one needs to take the log of the mantissa.
+ * However, the first term in the logarithm's Taylor series is linear.
+ * Thus a linear approximation to log, for small numbers is valid.
+ * We use that linear approximation, which turns out to be:
+ * 2*(mantissa - 1)
+ * Then the approximate log of the whole thing is the approximation of
+ * the log of the mantissa, plus the exponent:
+ * 2*(mantissa - 1) + exponent
+ * Which is a continuous, invertible function.
+ */
+
 namespace singularity {
 namespace Math {
 

--- a/utils/fast-math/logs.hpp
+++ b/utils/fast-math/logs.hpp
@@ -72,28 +72,48 @@ namespace singularity {
 namespace FastMath {
 
 PORTABLE_FORCEINLINE_FUNCTION
-double lg(const double x) {
-
-#ifdef SINGULARITY_USE_TRUE_LOG_GRIDDING
-  // Slower but conforms exactly to log grid spacing
-#ifndef SINGULARITY_USE_SINGLE_LOGS
-  return std::log2(x);
-#else // SINGULARITY_USE_SINGLE_LOGS
-  return std::log2f(x);
-#endif // SINGULARITY_USE_SINGLE_LOGS
-#else //  SINGULARITY_USE_TRUE_LOG_GRIDDING
+double fastlg(const double x) {
   int n;
 #ifndef SINGULARITY_USE_SINGLE_LOGS
-  // This is the default expression
+  // double precision is default
   const double y = frexp(x, &n);
 #else
   // faster but less accurate
   const float y = frexpf((float)x, &n);
 #endif // SINGULARITY_USE_SINGLE_LOGS
-
   return 2 * (y - 1) + n;
-#endif // SINGULARITY_USE_TRUE_LOG_GRIDDING
+}
 
+PORTABLE_FORCEINLINE_FUNCTION
+double fastpow2(const double x) {
+
+  const int flr = std::floor(x);
+  const double remainder = x - flr;
+  const double mantissa = 0.5 * (remainder + 1);
+  const double exponent = flr + 1;
+#ifndef SINGULARITY_USE_SINGLE_LOGS
+  // double precision is default
+  return ldexp(mantissa, exponent);
+#else
+  // Faster but less accurate
+  return ldexpf((float)mantissa, exponent);
+#endif // SINGULARITY_USE_SINGLE_LOGS
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+double lg(const double x) {
+
+#ifndef SINGULARITY_USE_TRUE_LOG_GRIDDING
+  // Default expression
+  return fastlg(x);
+#else
+#ifndef SINGULARITY_USE_SINGLE_LOGS
+  // double precision is default
+  return std::log2(x);
+#else
+  return std::log2f(x);
+#endif // SINGULARITY_USE_SINGLE_LOGS
+#endif // SINGULARITY_USE_TRUE_LOG_GRIDDING
 }
 
 PORTABLE_FORCEINLINE_FUNCTION
@@ -104,24 +124,15 @@ double log10(const double x) {
 
 PORTABLE_FORCEINLINE_FUNCTION
 double pow2(const double x) {
-#ifdef SINGULARITY_USE_TRUE_LOG_GRIDDING
-  // Slower but conforms exactly to log grid spacing
-#ifndef SINGULARITY_USE_SINGLE_LOGS
-  return std::exp2(x);
-#else // SINGULARITY_USE_SINGLE_LOGS
-  returtn std::exp2f(x);
-#endif // SINGULARITY_USE_SINGLE_LOGS
-#else // SINGULARITY_USE_TRUE_LOG_GRIDDING
-  // This is the default expression
-  const int flr = std::floor(x);
-  const double remainder = x - flr;
-  const double mantissa = 0.5 * (remainder + 1);
-  const double exponent = flr + 1;
-#ifndef SINGULARITY_USE_SINGLE_LOGS
-  return ldexp(mantissa, exponent);
+#ifndef SINGULARITY_USE_TRUE_LOG_GRIDDING
+  // Default expression
+  return fastpow2(x);
 #else
-  // Faster but less accurate
-  return ldexpf(mantissa, exponent);
+#ifndef SINGULARITY_USE_SINGLE_LOGS
+  // double precision is default
+  return std::exp2(x);
+#else
+  return std::exp2f(x);
 #endif // SINGULARITY_USE_SINGLE_LOGS
 #endif // SINGULARITY_USE_TRUE_LOG_GRIDDING
 }

--- a/utils/fast-math/logs.hpp
+++ b/utils/fast-math/logs.hpp
@@ -14,6 +14,7 @@
 
 #ifndef _SINGULARITY_EOS_UTILS_FAST_MATH_LOGS_
 #define _SINGULARITY_EOS_UTILS_FAST_MATH_LOGS_
+#include <cassert>
 #include <cmath>
 #include <ports-of-call/portability.hpp>
 

--- a/utils/fast-math/logs.hpp
+++ b/utils/fast-math/logs.hpp
@@ -74,6 +74,7 @@ namespace FastMath {
 PORTABLE_FORCEINLINE_FUNCTION
 double fastlg(const double x) {
   int n;
+  assert(x > 0 && "log divergent for x <= 0");
 #ifndef SINGULARITY_USE_SINGLE_LOGS
   // double precision is default
   const double y = frexp(x, &n);
@@ -102,6 +103,8 @@ double fastpow2(const double x) {
 
 PORTABLE_FORCEINLINE_FUNCTION
 double lg(const double x) {
+
+  assert(x > 0 && "log divergent for x <= 0");
 
 #ifndef SINGULARITY_USE_TRUE_LOG_GRIDDING
   // Default expression

--- a/utils/fast-math/logs.hpp
+++ b/utils/fast-math/logs.hpp
@@ -23,43 +23,41 @@ namespace singularity {
 namespace Math {
 
 PORTABLE_FORCEINLINE_FUNCTION
-double log10(const double x) {
+double lg(const double x) {
 
-  // const double ILOG10 = 1./std::log(10.0);
-  constexpr double ILOG10 = 0.43429448190325176;
-
-  int n{};
-  constexpr const double LOG2OLOG10 = 0.301029995663981195;
+  int n;
 #ifndef SINGULARITY_USE_SINGLE_LOGS
   const double y = frexp(x, &n); // default is double precision
 #else
   const float y = frexpf((float)x, &n); // faster but less accurate
-#endif
-#ifdef SINGULARITY_FMATH_USE_ORDER_4
-  // 4th order approximation to log(x) x in [0.5, 1.0)
-  const double expr =
-      -2.36697629372863 +
-      y * (5.2672858163176 +
-           y * (-5.1242620871906 + (2.91607506431871 - 0.69212249971711 * y) * y));
-#elif defined(SINGULARITY_FMATH_USE_ORDER_5)
-  // 5th order approximation to log(x) x in [0.5, 1.0)
-  const double expr =
-      -2.5396743497743 +
-      y * (6.420250933346 +
-           y * (-8.150589926467 +
-                y * (6.830564334687 + (-3.192132453902 + 0.6315814621098 * y) * y)));
+#endif // SINGULARITY_USE_SINGLE_LOGS
+
+  return 2*(y - 1) + n;
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+double log10(const double x) {
+  constexpr double LOG2OLOG10 = 0.301029995663981195;
+  return LOG2OLOG10*lg(x);
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+double pow2(const double x) {
+  const int flr = std::floor(x);
+  const double remainder = x - flr;
+  const double mantissa = 0.5*(remainder + 1);
+  const double exponent = flr + 1;
+#ifndef SINGULARITY_USE_SINGLE_LOGS
+  return ldexp(mantissa, exponent);
 #else
-  // 7the order approximation to log(x) x in [0.5, 1.0)
-  const double expr =
-      -2.808428971 +
-      y * (8.648808309 +
-           y * (-15.910426569 +
-                y * (21.53943522 +
-                     y * (-19.56870772 +
-                          y * (11.318698784 + (-3.770730277 + 0.5513512194 * y) * y)))));
-#endif // SINGULARITY_FMATH_USE_ORDER
-  // log10 x using frexp
-  return ILOG10 * expr + n * LOG2OLOG10;
+  return ldexpf(mantissa, exponent);
+#endif // SINGULARITY_USE_SINGLE_LOGS
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+double pow10(const double x) {
+  constexpr double LOG10OLOG2 = 3.321928094887362626;
+  return pow2(LOG10OLOG2*x);
 }
 
 } // namespace Math

--- a/utils/fast-math/logs.hpp
+++ b/utils/fast-math/logs.hpp
@@ -68,7 +68,7 @@
  */
 
 namespace singularity {
-namespace Math {
+namespace FastMath {
 
 PORTABLE_FORCEINLINE_FUNCTION
 double lg(const double x) {
@@ -108,7 +108,7 @@ double pow10(const double x) {
   return pow2(LOG10OLOG2 * x);
 }
 
-} // namespace Math
+} // namespace FastMath
 } // namespace singularity
 
 #endif //  _SINGULARITY_EOS_UTILS_FAST_MATH_LOGS_

--- a/utils/fast-math/logs.hpp
+++ b/utils/fast-math/logs.hpp
@@ -74,14 +74,26 @@ namespace FastMath {
 PORTABLE_FORCEINLINE_FUNCTION
 double lg(const double x) {
 
+#ifdef SINGULARITY_USE_TRUE_LOG_GRIDDING
+  // Slower but conforms exactly to log grid spacing
+#ifndef SINGULARITY_USE_SINGLE_LOGS
+  return std::log2(x);
+#else // SINGULARITY_USE_SINGLE_LOGS
+  return std::log2f(x);
+#endif // SINGULARITY_USE_SINGLE_LOGS
+#else //  SINGULARITY_USE_TRUE_LOG_GRIDDING
   int n;
 #ifndef SINGULARITY_USE_SINGLE_LOGS
-  const double y = frexp(x, &n); // default is double precision
+  // This is the default expression
+  const double y = frexp(x, &n);
 #else
-  const float y = frexpf((float)x, &n); // faster but less accurate
+  // faster but less accurate
+  const float y = frexpf((float)x, &n);
 #endif // SINGULARITY_USE_SINGLE_LOGS
 
   return 2 * (y - 1) + n;
+#endif // SINGULARITY_USE_TRUE_LOG_GRIDDING
+
 }
 
 PORTABLE_FORCEINLINE_FUNCTION
@@ -92,6 +104,15 @@ double log10(const double x) {
 
 PORTABLE_FORCEINLINE_FUNCTION
 double pow2(const double x) {
+#ifdef SINGULARITY_USE_TRUE_LOG_GRIDDING
+  // Slower but conforms exactly to log grid spacing
+#ifndef SINGULARITY_USE_SINGLE_LOGS
+  return std::exp2(x);
+#else // SINGULARITY_USE_SINGLE_LOGS
+  returtn std::exp2f(x);
+#endif // SINGULARITY_USE_SINGLE_LOGS
+#else // SINGULARITY_USE_TRUE_LOG_GRIDDING
+  // This is the default expression
   const int flr = std::floor(x);
   const double remainder = x - flr;
   const double mantissa = 0.5 * (remainder + 1);
@@ -99,8 +120,10 @@ double pow2(const double x) {
 #ifndef SINGULARITY_USE_SINGLE_LOGS
   return ldexp(mantissa, exponent);
 #else
+  // Faster but less accurate
   return ldexpf(mantissa, exponent);
 #endif // SINGULARITY_USE_SINGLE_LOGS
+#endif // SINGULARITY_USE_TRUE_LOG_GRIDDING
 }
 
 PORTABLE_FORCEINLINE_FUNCTION

--- a/utils/fast-math/logs.hpp
+++ b/utils/fast-math/logs.hpp
@@ -117,12 +117,6 @@ double lg(const double x) {
 }
 
 PORTABLE_FORCEINLINE_FUNCTION
-double log10(const double x) {
-  constexpr double LOG2OLOG10 = 0.301029995663981195;
-  return LOG2OLOG10 * lg(x);
-}
-
-PORTABLE_FORCEINLINE_FUNCTION
 double pow2(const double x) {
 #ifndef SINGULARITY_USE_TRUE_LOG_GRIDDING
   // Default expression
@@ -135,6 +129,12 @@ double pow2(const double x) {
   return std::exp2f(x);
 #endif // SINGULARITY_USE_SINGLE_LOGS
 #endif // SINGULARITY_USE_TRUE_LOG_GRIDDING
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+double log10(const double x) {
+  constexpr double LOG2OLOG10 = 0.301029995663981195;
+  return LOG2OLOG10 * lg(x);
 }
 
 PORTABLE_FORCEINLINE_FUNCTION

--- a/utils/fast-math/logs.hpp
+++ b/utils/fast-math/logs.hpp
@@ -57,14 +57,15 @@
  * 2*(mantissa - 1) + exponent
  *
  * Which is a continuous, invertible function that approximates lg
- * only relatively accurately. The absolute error of this
- * approximation is about 0.1 at its largest. This translates to a
- * relative error of at most 25%.
+ * only relatively accurately. The absolute difference of this
+ * function from lg is about 0.1 at its largest. This translates to a
+ * relative difference of at most 25%.
  *
- * However, we don't mind this error, as we're only interested in
+ * However, we don't mind this difference, as we're only interested in
  * generating a grid spacing "close enough" to log spacing. As long as
  * we can go into and out of "grid space" reliably and quickly, we're
- * happy.
+ * happy, and this function is an EXACT map into and out of that
+ * space.
  */
 
 namespace singularity {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This PR emerged from a discussion with @jdolence . @jdolence noticed that when using fast logs, the following was not true:
```C++
std::abs(pow(10., singularity::Math::Log10(x)) - x) < EPSILON
```
for some `EPSILON`. This was because we do fast logs, but we don't have a fast exponential to undo it in the exact same, approximate way. This may have implications for the accuracy of `P(rho,sie)` calls for `SpinerEOSDependsRhoT` though it should be a small effect.

To resolve this, @jdolence and I revisited the idea of log-linear interpolation. The reason we use log space is because logs are easy, and the grid spacing for a logarithmically spaced grid is roughly proportional to the size of the independent variable. *It doesn't actually matter that it be a logarithm exactly.* What matters is that we have a function to map into "grid space" which is approximately logarithmic and is fast and invertible.

This leads me to build off the fast log method I had previously implemented with @dholladay00 . `frexp` is invertible. Just as `frexp` picks apart the internal representation of a floating point number into mantissa and exponent (in base 2), there's an expression, `ldexp`, which reconstructs the floating point number from the mantissa and exponent. Thus we just need an invertible, continuous, differentiable function which approximately and quickly maps the mantissa `m` to `lg(m`). It turns out `2*(m - 1)` does nicely.

So that's what this PR introduces:
1. Replace the old fast `log10` with an even faster, more approximate `log10` which is easier to invert
2. Introduce a fast `pow10`, which exactly inverts the fast `log10`, up to almost machine precision.
3. Adds a test that proves this invertibility.
4. In `sesame2spiner` and `SpinerEOS`, use the fast `log10` and fast `pow10` everywhere when going to and from grid space, to ensure that we're consistent everywhere.
5. **Do not** use the fast math versions for `StellarCollapse`, as the stellar collapse tables are not re-interpolated, and we need to be faithful to the original log-log representation in the table. A future change would be to re-interpolate these tables so we can use fast math.
6. Document these changes thoroughly in comments and in the sphinx docs, because they're not intuitive. I also took the opportunity to fill in a little bit of missing documentation about models.

I am running the tests on Darwin, and I also plan to do a quick and dirty performance/accuracy comparison between the new data and the old. @dholladay00 and @annapiegra at your convenience (not necessarily before merge) it would be nice to run this through the spiner-eospac comparison pipeline.

I also ping @brryan and @lroberts36 because perhaps we should take this approach in the stellar collapse tables, as well as opacities in singularity-opac for Phoebus as well.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
