### PR TITLE
Fix vector interface on GPUs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,7 +152,7 @@ before_script:
     - sed -i "1s;^;#%Module\n;" ${modName}
     - module use ${CI_PROJECT_DIR}/spack_env
     - module load loads # module load compiler, deps, etc.
-    - if [ "DO_GPU" = "true" ]; then module load cuda; fi
+    - if [ "$DO_GPU" = "true" ]; then module load cuda; fi
     - module list
     - mkdir -p build install
     - cd build
@@ -168,6 +168,7 @@ before_script:
             -DSINGULARITY_USE_CUDA=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOS=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOSKERNELS=${SINGULARITY_USE_CUDA:-OFF} \
+            -DSINGULARITY_USE_FORTRAN=$([ "$SINGULARITY_USE_FORTRAN" = "true" ] && echo ON || echo OFF) \
             -DSINGULARITY_USE_FORTRAN=$([ ${SINGULARITY_USE_FORTRAN} == "true" ] && echo ON || echo OFF) \
             ..
     - make -j

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -290,7 +290,7 @@ test_x86_volta_gpu_temp:
     - spack repo add --scope site ${CI_PROJECT_DIR}/spack-repo
     - spack repo list
     - spack install --only dependencies ${SINGULARITY_EOS_SPACK_SPEC}
-    - spack load kokkos-nvcc-wrapper kokkos kokkos-kernels eospac hdf5+hl
+    - spack load kokkos-nvcc-wrapper kokkos kokkos-kernels eospac hdf5+hl py-h5py py-numpy
     - mkdir -p bin && cd bin
     - rm -rf ./*
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,75 +184,75 @@ before_script:
 # Jobs #
 ########
 
-# format:
-#   <<: *job_def
-#   extends: .clang-format
-#   allow_failure: true
-# 
-# pages_check:
-#   <<: *job_def
-#   extends: .sphinx-doc
-#   only:
-#     refs:
-#       - merge_requests
-#       - pipelines
-#   except:
-# 
-# pages:
-#   <<: *job_def
-#   extends: .sphinx-doc
-#   artifacts:
-#     paths:
-#       - public
-#   only:
-#     refs:
-#       - main
-#   except:
-#     refs:
-#       - pipelines
-# 
-# test_gnu_skylake:
-#   <<: *job_def
-#   extends: .test
-#   variables:
-#     <<: *skylake
-# 
-# test_gnu_power9:
-#   <<: *job_def
-#   extends: .test
-#   variables:
-#     <<: *power9
-# 
-# test_gnu_power9_gpu:
-#   <<: *job_def
-#   extends: .test
-#   variables:    
-#     <<: *power9
-#     <<: *gpu
-# 
-# # TODO(JMM): This test doesn't work
-# # and needs to be repaired.
-# test_x86_volta_gpu:
-#   <<: *job_def
-#   extends: .test
-#   allow_failure: true
-#   variables:    
-#     <<: *x86volta
-#     <<: *gpu
-# 
-# install_gnu_skylake_fort:
-#   <<: *job_def
-#   extends: .test
-#   variables:
-#     <<: *skylake
-#     <<: *fort
-# 
-# install_gnu_skylake_nofort:
-#   <<: *job_def
-#   extends: .test
-#   variables:
-#     <<: *skylake
-#     <<: *nofort
+format:
+  <<: *job_def
+  extends: .clang-format
+  allow_failure: true
+
+pages_check:
+  <<: *job_def
+  extends: .sphinx-doc
+  only:
+    refs:
+      - merge_requests
+      - pipelines
+  except:
+
+pages:
+  <<: *job_def
+  extends: .sphinx-doc
+  artifacts:
+    paths:
+      - public
+  only:
+    refs:
+      - main
+  except:
+    refs:
+      - pipelines
+
+test_gnu_skylake:
+  <<: *job_def
+  extends: .test
+  variables:
+    <<: *skylake
+
+test_gnu_power9:
+  <<: *job_def
+  extends: .test
+  variables:
+    <<: *power9
+
+test_gnu_power9_gpu:
+  <<: *job_def
+  extends: .test
+  variables:    
+    <<: *power9
+    <<: *gpu
+
+# TODO(JMM): This test doesn't work
+# and needs to be repaired.
+test_x86_volta_gpu:
+  <<: *job_def
+  extends: .test
+  allow_failure: true
+  variables:    
+    <<: *x86volta
+    <<: *gpu
+
+install_gnu_skylake_fort:
+  <<: *job_def
+  extends: .test
+  variables:
+    <<: *skylake
+    <<: *fort
+
+install_gnu_skylake_nofort:
+  <<: *job_def
+  extends: .test
+  variables:
+    <<: *skylake
+    <<: *nofort
 
 # Temporary job that builds everything
 # for the x86-volta nodes from scratch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,15 +46,15 @@ before_script:
   BUILD_TYPE: "Release"
 
 .gpu: &gpu
-  DO_GPU: true
-  SINGULARITY_USE_CUDA: true
+  DO_GPU: "true"
+  SINGULARITY_USE_CUDA: "true"
   SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+tests+cuda+kokkos cuda_arch=70 +kokkos-kernels%gcc@${SINGULARITY_EOS_GCC_VERSION}"
 
 .fort: &fort
-  SINGULARITY_USE_FORTRAN: true
+  SINGULARITY_USE_FORTRAN: "true"
 
 .nofort: &nofort
-  SINGULARITY_USE_FORTRAN: false
+  SINGULARITY_USE_FORTRAN: "false"
 
 .skylake: &skylake
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=skylake-gold,skylake-platinum"
@@ -151,7 +151,7 @@ before_script:
     - sed -i "1s;^;#%Module\n;" ${modName}
     - module use ${CI_PROJECT_DIR}/spack_env
     - module load loads # module load compiler, deps, etc.
-    - if [ "$DO_GPU" ]; then module load cuda; fi
+    - if [ "$DO_GPU" = "true" ]; then module load cuda; fi
     - module list
     - mkdir -p build install
     - cd build
@@ -258,12 +258,11 @@ install_gnu_skylake_nofort:
 # for the x86-volta nodes from scratch
 test_x86_volta_gpu_temp:
   stage: build_n_test
-  extends:
-    - .job
+  extends: .job
   variables:
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=volta-x86"
-    DO_GPU: true
-    SINGULARITY_USE_CUDA: true
+    DO_GPU: "true"
+    SINGULARITY_USE_CUDA: "true"
     SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+tests+cuda+kokkos cuda_arch=70 +kokkos-kernels%gcc@${SINGULARITY_EOS_GCC_VERSION}"
   script:
     - unset SPACK_ROOT
@@ -300,7 +299,7 @@ test_x86_volta_gpu_temp:
             -DSINGULARITY_USE_CUDA=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOS=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOSKERNELS=${SINGULARITY_USE_CUDA:-OFF} \
-            -DSINGULARITY_USE_FORTRAN=$([ "$SINGULARITY_USE_FORTRAN" ] && echo ON || echo OFF) \
+            -DSINGULARITY_USE_FORTRAN=${SINGULARITY_USE_FORTRAN:-OFF} \
             ..
     - make -j
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -259,6 +259,8 @@ install_gnu_skylake_nofort:
 # for the x86-volta nodes from scratch
 test_x86_volta_gpu_temp:
   stage: build_n_test
+  extends:
+    - .job
   variables:
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=volta-x86"
     DO_GPU: "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ before_script:
     DO_GPU: "true"
 
 .x86volta: &x86volta
-    SCHEDULER_PARAMETERS: "--nodes=1 --partition=x96-volta"
+    SCHEDULER_PARAMETERS: "--nodes=1 --partition=volta-x86"
     DO_GPU: "true"
 
 #################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,25 +46,24 @@ before_script:
   BUILD_TYPE: "Release"
 
 .gpu: &gpu
-  SINGULARITY_USE_CUDA: "true"
+  DO_GPU: true
+  SINGULARITY_USE_CUDA: true
   SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+tests+cuda+kokkos cuda_arch=70 +kokkos-kernels%gcc@${SINGULARITY_EOS_GCC_VERSION}"
 
 .fort: &fort
-  SINGULARITY_USE_FORTRAN: "true"
+  SINGULARITY_USE_FORTRAN: true
 
 .nofort: &nofort
-  SINGULARITY_USE_FORTRAN: "false"
+  SINGULARITY_USE_FORTRAN: false
 
 .skylake: &skylake
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=skylake-gold,skylake-platinum"
 
 .power9: &power9
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=power9"
-    DO_GPU: "true"
 
 .x86volta: &x86volta
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=volta-x86"
-    DO_GPU: "true"
 
 #################
 # General Setup #
@@ -152,7 +151,7 @@ before_script:
     - sed -i "1s;^;#%Module\n;" ${modName}
     - module use ${CI_PROJECT_DIR}/spack_env
     - module load loads # module load compiler, deps, etc.
-    - if [ "$DO_GPU" = "true" ]; then module load cuda; fi
+    - if [ "$DO_GPU" ]; then module load cuda; fi
     - module list
     - mkdir -p build install
     - cd build
@@ -168,7 +167,7 @@ before_script:
             -DSINGULARITY_USE_CUDA=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOS=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOSKERNELS=${SINGULARITY_USE_CUDA:-OFF} \
-            -DSINGULARITY_USE_FORTRAN=$([ ${SINGULARITY_USE_FORTRAN} == "true" ] && echo ON || echo OFF) \
+            -DSINGULARITY_USE_FORTRAN=${SINGULARITY_USE_FORTRAN:-OFF} \
             ..
     - make -j
     - |
@@ -263,8 +262,8 @@ test_x86_volta_gpu_temp:
     - .job
   variables:
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=volta-x86"
-    DO_GPU: "true"
-    SINGULARITY_USE_CUDA: "true"
+    DO_GPU: true
+    SINGULARITY_USE_CUDA: true
     SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+tests+cuda+kokkos cuda_arch=70 +kokkos-kernels%gcc@${SINGULARITY_EOS_GCC_VERSION}"
   script:
     - unset SPACK_ROOT
@@ -301,7 +300,7 @@ test_x86_volta_gpu_temp:
             -DSINGULARITY_USE_CUDA=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOS=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOSKERNELS=${SINGULARITY_USE_CUDA:-OFF} \
-            -DSINGULARITY_USE_FORTRAN=$([ ${SINGULARITY_USE_FORTRAN} == "true" ] && echo ON || echo OFF) \
+            -DSINGULARITY_USE_FORTRAN=$([ "$SINGULARITY_USE_FORTRAN" ] && echo ON || echo OFF) \
             ..
     - make -j
     - |
@@ -313,4 +312,3 @@ test_x86_volta_gpu_temp:
         ./sesame2spiner/sesame2spiner -s duplicates.sp5 ../sesame2spiner/examples/duplicate-test/*.dat;
         make test;
       fi
-      

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,7 +60,10 @@ before_script:
 
 .power9: &power9
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=power9"
-    POWER9: "true"
+    DO_GPU: "true"
+
+.x86volta: &x86volta
+    SCHEDULER_PARAMETERS: "--nodes=1 --partition=x96-volta"
 
 #################
 # General Setup #
@@ -148,7 +151,7 @@ before_script:
     - sed -i "1s;^;#%Module\n;" ${modName}
     - module use ${CI_PROJECT_DIR}/spack_env
     - module load loads # module load compiler, deps, etc.
-    - if [ "$POWER9" = "true" ]; then module load cuda; fi
+    - if [ "DO_GPU" = "true" ]; then module load cuda; fi
     - module list
     - mkdir -p build install
     - cd build
@@ -225,6 +228,13 @@ test_gnu_power9_gpu:
   extends: .test
   variables:    
     <<: *power9
+    <<: *gpu
+
+test_x86_volta_gpu:
+  <<: *job_def
+  extends: .test
+  variables:    
+    <<: *x86volta
     <<: *gpu
 
 install_gnu_skylake_fort:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -266,8 +266,8 @@ test_x86_volta_gpu_temp:
       - merge_requests
   variables:
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=volta-x86"
-    DO_GPU: "true"
     SINGULARITY_USE_CUDA: "true"
+    SINGULARITY_USE_FORTRAN: "false"
     SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+tests+cuda+kokkos cuda_arch=70 +kokkos-kernels%gcc@${SINGULARITY_EOS_GCC_VERSION}"
   script:
     - echo "Starting script"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,7 +168,7 @@ before_script:
             -DSINGULARITY_USE_CUDA=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOS=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOSKERNELS=${SINGULARITY_USE_CUDA:-OFF} \
-            -DSINGULARITY_USE_FORTRAN=$([ ${SINGULARITY_USE_FORTRAN} = "true" ] && echo ON || echo OFF) \
+            -DSINGULARITY_USE_FORTRAN=$([ ${SINGULARITY_USE_FORTRAN} == "true" ] && echo ON || echo OFF) \
             ..
     - make -j
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -258,13 +258,19 @@ install_gnu_skylake_nofort:
 # for the x86-volta nodes from scratch
 test_x86_volta_gpu_temp:
   stage: build_n_test
-  extends: .job
+  tags:
+    - darwin-slurm-shared
+  only:
+    refs:
+      - main
+      - merge_requests
   variables:
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=volta-x86"
     DO_GPU: "true"
     SINGULARITY_USE_CUDA: "true"
     SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+tests+cuda+kokkos cuda_arch=70 +kokkos-kernels%gcc@${SINGULARITY_EOS_GCC_VERSION}"
   script:
+    - echo "Starting script"
     - unset SPACK_ROOT
     - rm -rf spack ${HOME}/.spack
     - echo "Spack Version:" ${XCAP_OSS_SPACK_REF}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,75 +184,75 @@ before_script:
 # Jobs #
 ########
 
-format:
-  <<: *job_def
-  extends: .clang-format
-  allow_failure: true
-
-pages_check:
-  <<: *job_def
-  extends: .sphinx-doc
-  only:
-    refs:
-      - merge_requests
-      - pipelines
-  except:
-
-pages:
-  <<: *job_def
-  extends: .sphinx-doc
-  artifacts:
-    paths:
-      - public
-  only:
-    refs:
-      - main
-  except:
-    refs:
-      - pipelines
-
-test_gnu_skylake:
-  <<: *job_def
-  extends: .test
-  variables:
-    <<: *skylake
-
-test_gnu_power9:
-  <<: *job_def
-  extends: .test
-  variables:
-    <<: *power9
-
-test_gnu_power9_gpu:
-  <<: *job_def
-  extends: .test
-  variables:    
-    <<: *power9
-    <<: *gpu
-
-# TODO(JMM): This test doesn't work
-# and needs to be repaired.
-test_x86_volta_gpu:
-  <<: *job_def
-  extends: .test
-  allow_failure: true
-  variables:    
-    <<: *x86volta
-    <<: *gpu
-
-install_gnu_skylake_fort:
-  <<: *job_def
-  extends: .test
-  variables:
-    <<: *skylake
-    <<: *fort
-
-install_gnu_skylake_nofort:
-  <<: *job_def
-  extends: .test
-  variables:
-    <<: *skylake
-    <<: *nofort
+# format:
+#   <<: *job_def
+#   extends: .clang-format
+#   allow_failure: true
+# 
+# pages_check:
+#   <<: *job_def
+#   extends: .sphinx-doc
+#   only:
+#     refs:
+#       - merge_requests
+#       - pipelines
+#   except:
+# 
+# pages:
+#   <<: *job_def
+#   extends: .sphinx-doc
+#   artifacts:
+#     paths:
+#       - public
+#   only:
+#     refs:
+#       - main
+#   except:
+#     refs:
+#       - pipelines
+# 
+# test_gnu_skylake:
+#   <<: *job_def
+#   extends: .test
+#   variables:
+#     <<: *skylake
+# 
+# test_gnu_power9:
+#   <<: *job_def
+#   extends: .test
+#   variables:
+#     <<: *power9
+# 
+# test_gnu_power9_gpu:
+#   <<: *job_def
+#   extends: .test
+#   variables:    
+#     <<: *power9
+#     <<: *gpu
+# 
+# # TODO(JMM): This test doesn't work
+# # and needs to be repaired.
+# test_x86_volta_gpu:
+#   <<: *job_def
+#   extends: .test
+#   allow_failure: true
+#   variables:    
+#     <<: *x86volta
+#     <<: *gpu
+# 
+# install_gnu_skylake_fort:
+#   <<: *job_def
+#   extends: .test
+#   variables:
+#     <<: *skylake
+#     <<: *fort
+# 
+# install_gnu_skylake_nofort:
+#   <<: *job_def
+#   extends: .test
+#   variables:
+#     <<: *skylake
+#     <<: *nofort
 
 # Temporary job that builds everything
 # for the x86-volta nodes from scratch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -260,8 +260,11 @@ install_gnu_skylake_nofort:
 test_x86_volta_gpu_temp:
   stage: build_n_test
   variables:
-    << *x86volta
-    << *gpu
+    SCHEDULER_PARAMETERS: "--nodes=1 --partition=volta-x86"
+    DO_GPU: "true"
+    SINGULARITY_USE_CUDA: "true"
+    SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+tests+cuda+kokkos cuda_arch=70 +kokkos-kernels%gcc@${SINGULARITY_EOS_GCC_VERSION}"
+
   script:
     - unset SPACK_ROOT
     - rm -rf spack ${HOME}/.spack

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,7 +168,6 @@ before_script:
             -DSINGULARITY_USE_CUDA=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOS=${SINGULARITY_USE_CUDA:-OFF} \
             -DSINGULARITY_USE_KOKKOSKERNELS=${SINGULARITY_USE_CUDA:-OFF} \
-            -DSINGULARITY_USE_FORTRAN=$([ "$SINGULARITY_USE_FORTRAN" = "true" ] && echo ON || echo OFF) \
             -DSINGULARITY_USE_FORTRAN=$([ ${SINGULARITY_USE_FORTRAN} == "true" ] && echo ON || echo OFF) \
             ..
     - make -j
@@ -232,9 +231,12 @@ test_gnu_power9_gpu:
     <<: *power9
     <<: *gpu
 
+# TODO(JMM): This test doesn't work
+# and needs to be repaired.
 test_x86_volta_gpu:
   <<: *job_def
   extends: .test
+  allow_failure: true
   variables:    
     <<: *x86volta
     <<: *gpu
@@ -252,3 +254,59 @@ install_gnu_skylake_nofort:
   variables:
     <<: *skylake
     <<: *nofort
+
+# Temporary job that builds everything
+# for the x86-volta nodes from scratch
+test_x86_volta_gpu_temp:
+  stage: build_n_test
+  variables:
+    << *x86volta
+    << *gpu
+  script:
+    - unset SPACK_ROOT
+    - rm -rf spack ${HOME}/.spack
+    - echo "Spack Version:" ${XCAP_OSS_SPACK_REF}
+    - git clone https://github.com/spack/spack.git
+    - cd spack && git checkout ${XCAP_OSS_SPACK_REF##*-} && cd ${CI_PROJECT_DIR}
+    - source ${CI_PROJECT_DIR}/spack/share/spack/setup-env.sh
+    - export SPACK_ARCH=`./spack/bin/spack arch`
+    - echo ${SPACK_ARCH}
+    - export PLATFORM="${SPACK_ARCH%%-*}"
+    - echo ${PLATFORM}
+    - module load gcc/${SINGULARITY_EOS_GCC_VERSION}
+    - module load cuda
+    - module load cmake
+    - module list
+    - spack compiler find
+    - spack external find
+    - spack repo add --scope site ${CI_PROJECT_DIR}/spack-repo
+    - spack repo list
+    - spack install --only dependencies ${SINGULARITY_EOS_SPACK_SPEC}
+    - spack load kokkos-nvcc-wrapper kokkos kokkos-kernels eospac hdf5+hl
+    - mkdir -p bin && cd bin
+    - rm -rf ./*
+    - |
+      cmake -DCMAKE_INSTALL_PREFIX=${CI_PROJECT_DIR}/install \
+            -DSINGULARITY_USE_EOSPAC=ON \
+            -DSINGULARITY_USE_HDF5=ON \
+            -DSINGULARITY_BUILD_SESAME2SPINER=ON \
+            -DSINGULARITY_BUILD_STELLARCOLLAPSE2SPINER=ON \
+            -DSINGULARITY_BUILD_TESTS=ON \
+            -DSINGULARITY_TEST_SESAME=ON \
+            -DSINGULARITY_TEST_STELLAR_COLLAPSE=ON \
+            -DSINGULARITY_USE_CUDA=${SINGULARITY_USE_CUDA:-OFF} \
+            -DSINGULARITY_USE_KOKKOS=${SINGULARITY_USE_CUDA:-OFF} \
+            -DSINGULARITY_USE_KOKKOSKERNELS=${SINGULARITY_USE_CUDA:-OFF} \
+            -DSINGULARITY_USE_FORTRAN=$([ ${SINGULARITY_USE_FORTRAN} == "true" ] && echo ON || echo OFF) \
+            ..
+    - make -j
+    - |
+      if [[ ${CI_JOB_NAME} =~ "install" ]];
+      then
+        make install;
+      else
+        ./sesame2spiner/sesame2spiner -s materials.sp5 ../sesame2spiner/examples/unit_tests/*.dat;
+        ./sesame2spiner/sesame2spiner -s duplicates.sp5 ../sesame2spiner/examples/duplicate-test/*.dat;
+        make test;
+      fi
+      

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -264,7 +264,6 @@ test_x86_volta_gpu_temp:
     DO_GPU: "true"
     SINGULARITY_USE_CUDA: "true"
     SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+tests+cuda+kokkos cuda_arch=70 +kokkos-kernels%gcc@${SINGULARITY_EOS_GCC_VERSION}"
-
   script:
     - unset SPACK_ROOT
     - rm -rf spack ${HOME}/.spack

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,7 @@ before_script:
 
 .x86volta: &x86volta
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=x96-volta"
+    DO_GPU: "true"
 
 #################
 # General Setup #

--- a/singularity-eos/eos/CMakeLists.txt
+++ b/singularity-eos/eos/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 set(EOS_SRCS
     eos.hpp
+    eos_base.hpp
     modifiers/eos_unitsystem.hpp
     modifiers/scaled_eos.hpp
     modifiers/shifted_eos.hpp

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -68,11 +68,11 @@ class EosBase {
                                        LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           temperatures[i] =
-              static_cast<CRTP const &>(*this).TemperatureFromDensityInternalEnergy(
-                  rhos[i], sies[i], lambdas[i]);
+              copy.TemperatureFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -82,10 +82,11 @@ class EosBase {
                                                    LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          sies[i] = static_cast<CRTP const &>(*this).InternalEnergyFromDensityTemperature(
-              rhos[i], temperatures[i], lambdas[i]);
+          sies[i] = copy.InternalEnergyFromDensityTemperature(rhos[i], temperatures[i],
+                                                              lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -95,10 +96,11 @@ class EosBase {
                                              LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          pressures[i] = static_cast<CRTP const &>(*this).PressureFromDensityTemperature(
-              rhos[i], temperatures[i], lambdas[i]);
+          pressures[i] =
+              copy.PressureFromDensityTemperature(rhos[i], temperatures[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -108,11 +110,11 @@ class EosBase {
                                                 LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           pressures[i] =
-              static_cast<CRTP const &>(*this).PressureFromDensityInternalEnergy(
-                  rhos[i], sies[i], lambdas[i]);
+              copy.PressureFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -122,10 +124,11 @@ class EosBase {
                                                  LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          cvs[i] = static_cast<CRTP const &>(*this).SpecificHeatFromDensityTemperature(
-              rhos[i], temperatures[i], lambdas[i]);
+          cvs[i] = copy.SpecificHeatFromDensityTemperature(rhos[i], temperatures[i],
+                                                           lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -135,10 +138,11 @@ class EosBase {
                                                     LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          cvs[i] = static_cast<CRTP const &>(*this).SpecificHeatFromDensityInternalEnergy(
-              rhos[i], sies[i], lambdas[i]);
+          cvs[i] =
+              copy.SpecificHeatFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -148,10 +152,11 @@ class EosBase {
                                                 LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          bmods[i] = static_cast<CRTP const &>(*this).BulkModulusFromDensityTemperature(
-              rhos[i], temperatures[i], lambdas[i]);
+          bmods[i] = copy.BulkModulusFromDensityTemperature(rhos[i], temperatures[i],
+                                                            lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -161,11 +166,11 @@ class EosBase {
                                                    LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           bmods[i] =
-              static_cast<CRTP const &>(*this).BulkModulusFromDensityInternalEnergy(
-                  rhos[i], sies[i], lambdas[i]);
+              copy.BulkModulusFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -175,10 +180,11 @@ class EosBase {
                                                    LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          gm1s[i] = static_cast<CRTP const &>(*this).GruneisenParamFromDensityTemperature(
-              rhos[i], temperatures[i], lambdas[i]);
+          gm1s[i] = copy.GruneisenParamFromDensityTemperature(rhos[i], temperatures[i],
+                                                              lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -188,11 +194,11 @@ class EosBase {
                                                       LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           gm1s[i] =
-              static_cast<CRTP const &>(*this).GruneisenParamFromDensityInternalEnergy(
-                  rhos[i], sies[i], lambdas[i]);
+              copy.GruneisenParamFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename LambdaIndexer>
@@ -202,11 +208,11 @@ class EosBase {
                       LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          static_cast<CRTP const &>(*this).FillEos(rhos[i], temps[i], energies[i],
-                                                   presses[i], cvs[i], bmods[i], output,
-                                                   lambdas[i]);
+          copy.FillEos(rhos[i], temps[i], energies[i], presses[i], cvs[i], bmods[i],
+                       output, lambdas[i]);
         });
   }
   template <typename RealIndexer, typename LambdaIndexer>
@@ -216,11 +222,11 @@ class EosBase {
                      LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          static_cast<CRTP const &>(*this).PTofRE(rhos[i], sies[i], lambdas[i],
-                                                  presses[i], temps[i], dpdrs[i],
-                                                  dpdes[i], dtdrs[i], dtdes[i]);
+          copy.PTofRE(rhos[i], sies[i], lambdas[i], presses[i], temps[i], dpdrs[i],
+                      dpdes[i], dtdrs[i], dtdes[i]);
         });
   }
   // Scalar version of PTofRE


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

It turns out the vector interface on GPUs was only working on Power9s thanks to undefined behavior. This PR fixes it. The issue was that the `*this` pointer was being captured in the lambdas in the portable for in the base class.

To rectify, I dereference the `*this` pointer to make a copy of the derived class to pass into the `portableFor`.

To correctly test this, we need a CI build matrix for x86-volta nodes. I have added one, but some extra eyes from, e.g., @ktsai7, @junghans , or @dholladay00  would be welcome.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
