### PR TITLE
Fix kokkos-kernels depends condition

### DIFF
--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -62,7 +62,7 @@ class SingularityEos(CMakePackage, CudaPackage):
 
     # fix for older spacks
     if spack.version.Version(spack.main.get_version()) >= spack.version.Version("0.17"):
-        depends_on("kokkos-kernels ~shared")
+        depends_on("kokkos-kernels ~shared", when="+kokkos-kernels")
 
     for _flag in list(CudaPackage.cuda_arch_values):
         depends_on("kokkos cuda_arch=" +_flag, when="+cuda+kokkos cuda_arch=" + _flag)


### PR DESCRIPTION
The fix for older spack versions would append `kokkos-kernels` to specs that did not specify it. Here, a `when` is added to ensure it is only included when requested in the spec.