### PR TITLE
Report Minimum Density and Temeprature in an EOS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ before_script:
     DO_GPU: "true"
 
 .x86volta: &x86volta
-    SCHEDULER_PARAMETERS: "--nodes=1 --partition=x96-volta"
+    SCHEDULER_PARAMETERS: "--nodes=1 --partition=volta-x86"
     DO_GPU: "true"
 
 #################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,7 +60,10 @@ before_script:
 
 .power9: &power9
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=power9"
-    POWER9: "true"
+    DO_GPU: "true"
+
+.x86volta: &x86volta
+    SCHEDULER_PARAMETERS: "--nodes=1 --partition=x96-volta"
 
 #################
 # General Setup #
@@ -148,7 +151,7 @@ before_script:
     - sed -i "1s;^;#%Module\n;" ${modName}
     - module use ${CI_PROJECT_DIR}/spack_env
     - module load loads # module load compiler, deps, etc.
-    - if [ "$POWER9" = "true" ]; then module load cuda; fi
+    - if [ "DO_GPU" = "true" ]; then module load cuda; fi
     - module list
     - mkdir -p build install
     - cd build
@@ -225,6 +228,13 @@ test_gnu_power9_gpu:
   extends: .test
   variables:    
     <<: *power9
+    <<: *gpu
+
+test_x86_volta_gpu:
+  <<: *job_def
+  extends: .test
+  variables:    
+    <<: *x86volta
     <<: *gpu
 
 install_gnu_skylake_fort:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,7 @@ before_script:
 
 .x86volta: &x86volta
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=x96-volta"
+    DO_GPU: "true"
 
 #################
 # General Setup #

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "utils/eigen"]
 	path = utils/eigen
 	url = https://gitlab.com/libeigen/eigen.git
-[submodule "utils/json"]
-	path = utils/json
-	url = https://github.com/nlohmann/json.git
 [submodule "utils/spiner"]
 	path = utils/spiner
 	url = ../spiner.git

--- a/singularity-eos/eos/CMakeLists.txt
+++ b/singularity-eos/eos/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 set(EOS_SRCS
     eos.hpp
+    eos_base.hpp
     modifiers/eos_unitsystem.hpp
     modifiers/scaled_eos.hpp
     modifiers/shifted_eos.hpp

--- a/singularity-eos/eos/eos.hpp
+++ b/singularity-eos/eos/eos.hpp
@@ -411,6 +411,22 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   struct Lambda {
     enum Index { lRho = 0, lT = 1 };
   };
+  // Generic functions provided by the base class. These contain
+  // e.g. the vector overloads that use the scalar versions declared
+  // here We explicitly list, rather than using the macro because we
+  // overload some methods.
+  using EosBase<SpinerEOSDependsRhoT>::TemperatureFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoT>::InternalEnergyFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoT>::PressureFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoT>::PressureFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoT>::SpecificHeatFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoT>::SpecificHeatFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoT>::BulkModulusFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoT>::BulkModulusFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoT>::GruneisenParamFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoT>::GruneisenParamFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoT>::PTofRE;
+  using EosBase<SpinerEOSDependsRhoT>::FillEos;
 
   SpinerEOSDependsRhoT(const std::string &filename, int matid,
                        bool reproduciblity_mode = false);
@@ -462,9 +478,6 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
                               Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const;
-  // Generic functions provided by the base class. These contain e.g. the vector
-  // overloads that use the scalar versions declared here
-  SG_ADD_BASE_CLASS_USINGS(SpinerEOSDependsRhoT)
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
   std::string filename() const { return std::string(filename_); }
   std::string materialName() const { return std::string(materialName_); }
@@ -483,6 +496,8 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
            materialName_);
     return;
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rhoMin(); }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return T_(lTMin_); }
   static PORTABLE_FORCEINLINE_FUNCTION int nlambda() { return _n_lambda; }
   inline RootFinding1D::Status rootStatus() const { return status_; }
   inline TableStatus tableStatus() const { return whereAmI_; }
@@ -607,6 +622,23 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   struct SP5Tables {
     Spiner::DataBox P, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho;
   };
+  // Generic functions provided by the base class. These contain
+  // e.g. the vector overloads that use the scalar versions declared
+  // here We explicitly list, rather than using the macro because we
+  // overload some methods.
+  using EosBase<SpinerEOSDependsRhoSie>::TemperatureFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoSie>::InternalEnergyFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoSie>::PressureFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoSie>::PressureFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoSie>::SpecificHeatFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoSie>::SpecificHeatFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoSie>::BulkModulusFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoSie>::BulkModulusFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoSie>::GruneisenParamFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoSie>::GruneisenParamFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoSie>::PTofRE;
+  using EosBase<SpinerEOSDependsRhoSie>::FillEos;
+
   PORTABLE_INLINE_FUNCTION SpinerEOSDependsRhoSie()
       : memoryStatus_(DataStatus::Deallocated) {}
   SpinerEOSDependsRhoSie(const std::string &filename, int matid,
@@ -657,9 +689,7 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   void ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
                               Real &bmod, Real &dpde, Real &dvdt,
                               Real *lambda = nullptr) const;
-  // Generic functions provided by the base class. These contain e.g. the vector
-  // overloads that use the scalar versions declared here
-  SG_ADD_BASE_CLASS_USINGS(SpinerEOSDependsRhoSie)
+
   PORTABLE_FUNCTION
   unsigned long PreferredInput() const { return _preferred_input; }
   std::string filename() const { return std::string(filename_); }
@@ -674,6 +704,9 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   Real TMax() const { return fromLog_(T_.range(0).max(), lTOffset_); }
   Real sieMin() const { return fromLog_(sie_.range(0).min(), lEOffset_); }
   Real sieMax() const { return fromLog_(sie_.range(0).max(), lEOffset_); }
+
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rhoMin(); }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return TMin(); }
 
   static PORTABLE_FORCEINLINE_FUNCTION int nlambda() { return _n_lambda; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
@@ -751,6 +784,23 @@ class StellarCollapse : public EosBase<StellarCollapse> {
   struct Lambda {
     enum Index { Ye = 0, lT = 1 };
   };
+
+  // Generic functions provided by the base class. These contain
+  // e.g. the vector overloads that use the scalar versions declared
+  // here We explicitly list, rather than using the macro because we
+  // overload some methods.
+  using EosBase<StellarCollapse>::TemperatureFromDensityInternalEnergy;
+  using EosBase<StellarCollapse>::InternalEnergyFromDensityTemperature;
+  using EosBase<StellarCollapse>::PressureFromDensityTemperature;
+  using EosBase<StellarCollapse>::PressureFromDensityInternalEnergy;
+  using EosBase<StellarCollapse>::SpecificHeatFromDensityTemperature;
+  using EosBase<StellarCollapse>::SpecificHeatFromDensityInternalEnergy;
+  using EosBase<StellarCollapse>::BulkModulusFromDensityTemperature;
+  using EosBase<StellarCollapse>::BulkModulusFromDensityInternalEnergy;
+  using EosBase<StellarCollapse>::GruneisenParamFromDensityTemperature;
+  using EosBase<StellarCollapse>::GruneisenParamFromDensityInternalEnergy;
+  using EosBase<StellarCollapse>::PTofRE;
+  using EosBase<StellarCollapse>::FillEos;
 
   StellarCollapse(const std::string &filename, bool use_sp5 = false,
                   bool filter_bmod = true);
@@ -834,6 +884,8 @@ class StellarCollapse : public EosBase<StellarCollapse> {
            filename_, lRhoMin_, lRhoMax_, lTMin_, lTMax_, YeMin_, YeMax_);
     return;
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rhoMin(); }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return TMin(); }
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return _n_lambda; }
   inline RootFinding1D::Status rootStatus() const { return status_; }
@@ -1037,9 +1089,23 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                 Real &press, Real &cv, Real &bmod,
                                                 Real &dpde, Real &dvdt,
                                                 Real *lambda = nullptr) const;
-  // Generic functions provided by the base class. These contain e.g. the vector
-  // overloads that use the scalar versions declared here
-  SG_ADD_BASE_CLASS_USINGS(EOSPAC)
+
+  // Generic functions provided by the base class. These contain
+  // e.g. the vector overloads that use the scalar versions declared
+  // here We explicitly list, rather than using the macro because we
+  // overload some methods.
+  using EosBase<SpinerEOSDependsRhoSie>::TemperatureFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoSie>::InternalEnergyFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoSie>::PressureFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoSie>::PressureFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoSie>::SpecificHeatFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoSie>::SpecificHeatFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoSie>::BulkModulusFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoSie>::BulkModulusFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoSie>::GruneisenParamFromDensityTemperature;
+  using EosBase<SpinerEOSDependsRhoSie>::GruneisenParamFromDensityInternalEnergy;
+  using EosBase<SpinerEOSDependsRhoSie>::PTofRE;
+  using EosBase<SpinerEOSDependsRhoSie>::FillEos;
 
   // TODO (JHP): Change EOSPAC vector implementations to be more performant
   // template<typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -1128,6 +1194,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     printf("EOSPAC parameters:\nmatid = %s\n", matid_);
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rho_min_; }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return temp_min_; }
 
  private:
   static constexpr const unsigned long _preferred_input =
@@ -1150,6 +1218,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   Real bmod_ref_ = 1;
   Real dpde_ref_ = 1;
   Real dvdt_ref_ = 1;
+  Real rho_min_ = 0;
+  Real temp_min_ = 0;
 };
 #endif // SINGULARITY_USE_EOSPAC
 

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -35,6 +35,7 @@ namespace eos_base {
 // This Macro adds the `using` statements that allow for the base class
 // vector functionality to overload the scalar implementations in the derived
 // classes
+// TODO(JMM): Should we have more macros that capture just some of these?
 #define SG_ADD_BASE_CLASS_USINGS(EOSDERIVED)                                             \
   using EosBase<EOSDERIVED>::TemperatureFromDensityInternalEnergy;                       \
   using EosBase<EOSDERIVED>::InternalEnergyFromDensityTemperature;                       \
@@ -46,6 +47,8 @@ namespace eos_base {
   using EosBase<EOSDERIVED>::BulkModulusFromDensityInternalEnergy;                       \
   using EosBase<EOSDERIVED>::GruneisenParamFromDensityTemperature;                       \
   using EosBase<EOSDERIVED>::GruneisenParamFromDensityInternalEnergy;                    \
+  using EosBase<EOSDERIVED>::MinimumDensity;                                             \
+  using EosBase<EOSDERIVED>::MinimumTemperature;                                         \
   using EosBase<EOSDERIVED>::PTofRE;                                                     \
   using EosBase<EOSDERIVED>::FillEos;
 
@@ -215,6 +218,12 @@ class EosBase {
                        output, lambdas[i]);
         });
   }
+  // Report minimum values of density and temperature
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumDensity() const { return 0; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real Minimum MinimumTemperature() const { return 0; }
+
   template <typename RealIndexer, typename LambdaIndexer>
   inline void PTofRE(RealIndexer &&rhos, RealIndexer &&sies, RealIndexer &&presses,
                      RealIndexer &&temps, RealIndexer &&dpdrs, RealIndexer &&dpdes,
@@ -251,6 +260,7 @@ class EosBase {
            de; // Would it be better to skip the calculation of Te and return 1/cv?
     return;
   }
+
   // Specialzied vector version of PTofRE maybe more suited for EOSPAC
   // }
   // template<typename RealIndexer, typename LambdaIndexer>

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -68,11 +68,11 @@ class EosBase {
                                        LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           temperatures[i] =
-              static_cast<CRTP const &>(*this).TemperatureFromDensityInternalEnergy(
-                  rhos[i], sies[i], lambdas[i]);
+              copy.TemperatureFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -82,10 +82,11 @@ class EosBase {
                                                    LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          sies[i] = static_cast<CRTP const &>(*this).InternalEnergyFromDensityTemperature(
-              rhos[i], temperatures[i], lambdas[i]);
+          sies[i] = copy.InternalEnergyFromDensityTemperature(rhos[i], temperatures[i],
+                                                              lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -95,10 +96,11 @@ class EosBase {
                                              LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          pressures[i] = static_cast<CRTP const &>(*this).PressureFromDensityTemperature(
-              rhos[i], temperatures[i], lambdas[i]);
+          pressures[i] =
+              copy.PressureFromDensityTemperature(rhos[i], temperatures[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -108,11 +110,11 @@ class EosBase {
                                                 LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           pressures[i] =
-              static_cast<CRTP const &>(*this).PressureFromDensityInternalEnergy(
-                  rhos[i], sies[i], lambdas[i]);
+              copy.PressureFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -122,10 +124,11 @@ class EosBase {
                                                  LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          cvs[i] = static_cast<CRTP const &>(*this).SpecificHeatFromDensityTemperature(
-              rhos[i], temperatures[i], lambdas[i]);
+          cvs[i] = copy.SpecificHeatFromDensityTemperature(rhos[i], temperatures[i],
+                                                           lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -135,10 +138,11 @@ class EosBase {
                                                     LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          cvs[i] = static_cast<CRTP const &>(*this).SpecificHeatFromDensityInternalEnergy(
-              rhos[i], sies[i], lambdas[i]);
+          cvs[i] =
+              copy.SpecificHeatFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -148,10 +152,11 @@ class EosBase {
                                                 LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          bmods[i] = static_cast<CRTP const &>(*this).BulkModulusFromDensityTemperature(
-              rhos[i], temperatures[i], lambdas[i]);
+          bmods[i] = copy.BulkModulusFromDensityTemperature(rhos[i], temperatures[i],
+                                                            lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -161,11 +166,11 @@ class EosBase {
                                                    LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           bmods[i] =
-              static_cast<CRTP const &>(*this).BulkModulusFromDensityInternalEnergy(
-                  rhos[i], sies[i], lambdas[i]);
+              copy.BulkModulusFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -175,10 +180,11 @@ class EosBase {
                                                    LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          gm1s[i] = static_cast<CRTP const &>(*this).GruneisenParamFromDensityTemperature(
-              rhos[i], temperatures[i], lambdas[i]);
+          gm1s[i] = copy.GruneisenParamFromDensityTemperature(rhos[i], temperatures[i],
+                                                              lambdas[i]);
         });
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -188,11 +194,11 @@ class EosBase {
                                                       LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           gm1s[i] =
-              static_cast<CRTP const &>(*this).GruneisenParamFromDensityInternalEnergy(
-                  rhos[i], sies[i], lambdas[i]);
+              copy.GruneisenParamFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
   template <typename RealIndexer, typename LambdaIndexer>
@@ -202,11 +208,11 @@ class EosBase {
                       LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          static_cast<CRTP const &>(*this).FillEos(rhos[i], temps[i], energies[i],
-                                                   presses[i], cvs[i], bmods[i], output,
-                                                   lambdas[i]);
+          copy.FillEos(rhos[i], temps[i], energies[i], presses[i], cvs[i], bmods[i],
+                       output, lambdas[i]);
         });
   }
   template <typename RealIndexer, typename LambdaIndexer>
@@ -216,11 +222,11 @@ class EosBase {
                      LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
+    CRTP copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          static_cast<CRTP const &>(*this).PTofRE(rhos[i], sies[i], lambdas[i],
-                                                  presses[i], temps[i], dpdrs[i],
-                                                  dpdes[i], dtdrs[i], dtdes[i]);
+          copy.PTofRE(rhos[i], sies[i], lambdas[i], presses[i], temps[i], dpdrs[i],
+                      dpdes[i], dtdrs[i], dtdes[i]);
         });
   }
   // Scalar version of PTofRE

--- a/singularity-eos/eos/eos_eospac.cpp
+++ b/singularity-eos/eos/eos_eospac.cpp
@@ -40,10 +40,12 @@ EOSPAC::EOSPAC(const int matid, bool invert_at_setup) : matid_(matid) {
   RofPT_table_ = tablehandle[3];
   TofRP_table_ = tablehandle[4];
 
-  // Set reference states
+  // Set reference states and table bounds
   SesameMetadata m;
   eosGetMetadata(matid, m, Verbosity::Quiet);
   rho_ref_ = m.normalDensity;
+  rho_min_ = m.rhoMin;
+  temp_min_ = m.TMin;
 
   EOS_REAL R[1] = {rho_ref_};
   EOS_REAL T[1] = {temperatureToSesame(temp_ref_)};

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -224,6 +224,16 @@ class Variant {
         eos_);
   }
 
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumDensity() const {
+    return mpark::visit([](const auto &eos) { return eos.MinimumDensity(); }, eos_);
+  }
+
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumTemperature() const {
+    return mpark::visit([](const auto &eos) { return eos.MinimumTemperature(); }, eos_);
+  }
+
   /*
   Vector versions of the member functions run on the host but the scalar
   lookups will run on the device

--- a/singularity-eos/eos/modifiers/eos_unitsystem.hpp
+++ b/singularity-eos/eos/modifiers/eos_unitsystem.hpp
@@ -43,6 +43,27 @@ static struct LengthTimeUnitsInit {
 template <typename T>
 class UnitSystem : public EosBase<UnitSystem<T>> {
  public:
+  // Generic functions provided by the base class. These contain
+  // e.g. the vector overloads that use the scalar versions declared
+  // here We explicitly list, rather than using the macro because we
+  // overload some methods.
+
+  // TODO(JMM): The modifier EOS's should probably call the specific
+  // sub-functions of the class they modify so that they can leverage,
+  // e.g., an especially performant or special version of these
+  using EosBase<UnitSystem<T>>::TemperatureFromDensityInternalEnergy;
+  using EosBase<UnitSystem<T>>::InternalEnergyFromDensityTemperature;
+  using EosBase<UnitSystem<T>>::PressureFromDensityTemperature;
+  using EosBase<UnitSystem<T>>::PressureFromDensityInternalEnergy;
+  using EosBase<UnitSystem<T>>::SpecificHeatFromDensityTemperature;
+  using EosBase<UnitSystem<T>>::SpecificHeatFromDensityInternalEnergy;
+  using EosBase<UnitSystem<T>>::BulkModulusFromDensityTemperature;
+  using EosBase<UnitSystem<T>>::BulkModulusFromDensityInternalEnergy;
+  using EosBase<UnitSystem<T>>::GruneisenParamFromDensityTemperature;
+  using EosBase<UnitSystem<T>>::GruneisenParamFromDensityInternalEnergy;
+  using EosBase<UnitSystem<T>>::PTofRE;
+  using EosBase<UnitSystem<T>>::FillEos;
+
   // move semantics ensures dynamic memory comes along for the ride
   // TODO(JMM): Entropy unit needed?
   UnitSystem(T &&t, eos_units_init::ThermalUnitsInit, const Real rho_unit,
@@ -198,8 +219,12 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
     dvdt *= inv_dvdt_unit_;
   }
 
-  // Vector functions that overload the scalar versions declared here.
-  SG_ADD_BASE_CLASS_USINGS(UnitSystem<T>)
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const {
+    return inv_rho_unit * t_.MinimumDensity();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const {
+    return inv_temp_unit_ * t_.MinimumTemperature();
+  }
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return t_.nlambda(); }

--- a/singularity-eos/eos/modifiers/relativistic_eos.hpp
+++ b/singularity-eos/eos/modifiers/relativistic_eos.hpp
@@ -35,6 +35,27 @@ using namespace eos_base;
 template <typename T>
 class RelativisticEOS : public EosBase<RelativisticEOS<T>> {
  public:
+  // Generic functions provided by the base class. These contain
+  // e.g. the vector overloads that use the scalar versions declared
+  // here We explicitly list, rather than using the macro because we
+  // overload some methods.
+
+  // TODO(JMM): The modifier EOS's should probably call the specific
+  // sub-functions of the class they modify so that they can leverage,
+  // e.g., an especially performant or special version of these
+  using EosBase<RelativisticEOS<T>>::TemperatureFromDensityInternalEnergy;
+  using EosBase<RelativisticEOS<T>>::InternalEnergyFromDensityTemperature;
+  using EosBase<RelativisticEOS<T>>::PressureFromDensityTemperature;
+  using EosBase<RelativisticEOS<T>>::PressureFromDensityInternalEnergy;
+  using EosBase<RelativisticEOS<T>>::SpecificHeatFromDensityTemperature;
+  using EosBase<RelativisticEOS<T>>::SpecificHeatFromDensityInternalEnergy;
+  using EosBase<RelativisticEOS<T>>::BulkModulusFromDensityTemperature;
+  using EosBase<RelativisticEOS<T>>::BulkModulusFromDensityInternalEnergy;
+  using EosBase<RelativisticEOS<T>>::GruneisenParamFromDensityTemperature;
+  using EosBase<RelativisticEOS<T>>::GruneisenParamFromDensityInternalEnergy;
+  using EosBase<RelativisticEOS<T>>::PTofRE;
+  using EosBase<RelativisticEOS<T>>::FillEos;
+
   // move semantics ensures dynamic memory comes along for the ride
   RelativisticEOS(T &&t, const Real cl)
       : t_(std::forward<T>(t)), cl_(cl) // speed of light, units arbitrary
@@ -112,6 +133,13 @@ class RelativisticEOS : public EosBase<RelativisticEOS<T>> {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return t_.nlambda(); }
 
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const {
+    return t_.MinimumDensity();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const {
+    return t_.MinimumTemperature();
+  }
+
   PORTABLE_FUNCTION
   unsigned long PreferredInput() const { return t_.PreferredInput(); }
 
@@ -128,9 +156,6 @@ class RelativisticEOS : public EosBase<RelativisticEOS<T>> {
                               Real *lambda = nullptr) const {
     t_.ValuesAtReferenceState(rho, temp, sie, press, cv, bmod, dpde, dvdt, lambda);
   }
-
-  // Vector functions that overload the scalar versions declared here.
-  SG_ADD_BASE_CLASS_USINGS(RelativisticEOS<T>)
 
  private:
   T t_;

--- a/singularity-eos/eos/modifiers/scaled_eos.hpp
+++ b/singularity-eos/eos/modifiers/scaled_eos.hpp
@@ -35,6 +35,27 @@ using namespace eos_base;
 template <typename T>
 class ScaledEOS : public EosBase<ScaledEOS<T>> {
  public:
+  // Generic functions provided by the base class. These contain
+  // e.g. the vector overloads that use the scalar versions declared
+  // here We explicitly list, rather than using the macro because we
+  // overload some methods.
+
+  // TODO(JMM): The modifier EOS's should probably call the specific
+  // sub-functions of the class they modify so that they can leverage,
+  // e.g., an especially performant or special version of these
+  using EosBase<ScaledEOS<T>>::TemperatureFromDensityInternalEnergy;
+  using EosBase<ScaledEOS<T>>::InternalEnergyFromDensityTemperature;
+  using EosBase<ScaledEOS<T>>::PressureFromDensityTemperature;
+  using EosBase<ScaledEOS<T>>::PressureFromDensityInternalEnergy;
+  using EosBase<ScaledEOS<T>>::SpecificHeatFromDensityTemperature;
+  using EosBase<ScaledEOS<T>>::SpecificHeatFromDensityInternalEnergy;
+  using EosBase<ScaledEOS<T>>::BulkModulusFromDensityTemperature;
+  using EosBase<ScaledEOS<T>>::BulkModulusFromDensityInternalEnergy;
+  using EosBase<ScaledEOS<T>>::GruneisenParamFromDensityTemperature;
+  using EosBase<ScaledEOS<T>>::GruneisenParamFromDensityInternalEnergy;
+  using EosBase<ScaledEOS<T>>::PTofRE;
+  using EosBase<ScaledEOS<T>>::FillEos;
+
   // move semantics ensures dynamic memory comes along for the ride
   ScaledEOS(T &&t, const Real scale)
       : t_(std::forward<T>(t)), scale_(scale), inv_scale_(1. / scale) {}
@@ -145,8 +166,12 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
     sie = sie * scale_;
   }
 
-  // Vector functions that overload the scalar versions declared here.
-  SG_ADD_BASE_CLASS_USINGS(ScaledEOS<T>)
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const {
+    return inv_scale_ * t_.MinimumDensity();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const {
+    return t_.MinimumTemperature();
+  }
 
  private:
   T t_;

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -35,6 +35,27 @@ using namespace eos_base;
 template <typename T>
 class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
  public:
+  // Generic functions provided by the base class. These contain
+  // e.g. the vector overloads that use the scalar versions declared
+  // here We explicitly list, rather than using the macro because we
+  // overload some methods.
+
+  // TODO(JMM): The modifier EOS's should probably call the specific
+  // sub-functions of the class they modify so that they can leverage,
+  // e.g., an especially performant or special version of these
+  using EosBase<ShiftedEOS<T>>::TemperatureFromDensityInternalEnergy;
+  using EosBase<ShiftedEOS<T>>::InternalEnergyFromDensityTemperature;
+  using EosBase<ShiftedEOS<T>>::PressureFromDensityTemperature;
+  using EosBase<ShiftedEOS<T>>::PressureFromDensityInternalEnergy;
+  using EosBase<ShiftedEOS<T>>::SpecificHeatFromDensityTemperature;
+  using EosBase<ShiftedEOS<T>>::SpecificHeatFromDensityInternalEnergy;
+  using EosBase<ShiftedEOS<T>>::BulkModulusFromDensityTemperature;
+  using EosBase<ShiftedEOS<T>>::BulkModulusFromDensityInternalEnergy;
+  using EosBase<ShiftedEOS<T>>::GruneisenParamFromDensityTemperature;
+  using EosBase<ShiftedEOS<T>>::GruneisenParamFromDensityInternalEnergy;
+  using EosBase<ShiftedEOS<T>>::PTofRE;
+  using EosBase<ShiftedEOS<T>>::FillEos;
+
   // move semantics ensures dynamic memory comes along for the ride
   ShiftedEOS(T &&t, const Real shift) : t_(std::forward<T>(t)), shift_(shift) {}
   ShiftedEOS() = default;
@@ -136,8 +157,12 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
     sie += shift_;
   }
 
-  // Vector functions that overload the scalar versions declared here.
-  SG_ADD_BASE_CLASS_USINGS(ShiftedEOS<T>)
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const {
+    return t_.MinimumDensity();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const {
+    return t_.MinimumTemperature();
+  }
 
  private:
   T t_;

--- a/test/eos_unit_tests.cpp
+++ b/test/eos_unit_tests.cpp
@@ -103,6 +103,9 @@ inline void compare_two_eoss(const EOS &test_e, const EOS &ref_e) {
                   ref_e.BulkModulusFromDensityTemperature(1, 1), 1.e-15));
   REQUIRE(isClose(test_e.GruneisenParamFromDensityTemperature(1, 1),
                   ref_e.GruneisenParamFromDensityTemperature(1, 1), 1.e-15));
+  REQUIRE(isClose(test_e.MinimumDensity(1, 1), ref_e.MinimumDensity(1, 1), 1.e-15));
+  REQUIRE(
+      isClose(test_e.MinimumTemperature(1, 1), ref_e.MinimumTemperature(1, 1), 1.e-15));
   return;
 }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@jdolence is currently working on solving issues with PTE solvers and reported that it would be useful to know the minimum values of the independent variables in a tabulated EOS.

This machinery provides this. We now report minimum density and temperature for all EOS's. For analytic EOS's, this is provided by a new method in the base class, which simply returns zero. (I assume here we will never be working with antimatter or the population inversions of a laser gain medium which might produce negative densities or temperatures respectively. ;) )

The tabulated EOS's and the modifiers implement their own versions as appropriate.

I believe there may be more to attack here, as far as what bounds to report. But this is a start.

As with all my pull requests as of late... Depends on #106 so that should go in first.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
