### PR TITLE
Fix bug in EOSPAC using statements

### DIFF
--- a/singularity-eos/eos/eos.hpp
+++ b/singularity-eos/eos/eos.hpp
@@ -1094,18 +1094,18 @@ class EOSPAC : public EosBase<EOSPAC> {
   // e.g. the vector overloads that use the scalar versions declared
   // here We explicitly list, rather than using the macro because we
   // overload some methods.
-  using EosBase<SpinerEOSDependsRhoSie>::TemperatureFromDensityInternalEnergy;
-  using EosBase<SpinerEOSDependsRhoSie>::InternalEnergyFromDensityTemperature;
-  using EosBase<SpinerEOSDependsRhoSie>::PressureFromDensityTemperature;
-  using EosBase<SpinerEOSDependsRhoSie>::PressureFromDensityInternalEnergy;
-  using EosBase<SpinerEOSDependsRhoSie>::SpecificHeatFromDensityTemperature;
-  using EosBase<SpinerEOSDependsRhoSie>::SpecificHeatFromDensityInternalEnergy;
-  using EosBase<SpinerEOSDependsRhoSie>::BulkModulusFromDensityTemperature;
-  using EosBase<SpinerEOSDependsRhoSie>::BulkModulusFromDensityInternalEnergy;
-  using EosBase<SpinerEOSDependsRhoSie>::GruneisenParamFromDensityTemperature;
-  using EosBase<SpinerEOSDependsRhoSie>::GruneisenParamFromDensityInternalEnergy;
-  using EosBase<SpinerEOSDependsRhoSie>::PTofRE;
-  using EosBase<SpinerEOSDependsRhoSie>::FillEos;
+  using EosBase<EOSPAC>::TemperatureFromDensityInternalEnergy;
+  using EosBase<EOSPAC>::InternalEnergyFromDensityTemperature;
+  using EosBase<EOSPAC>::PressureFromDensityTemperature;
+  using EosBase<EOSPAC>::PressureFromDensityInternalEnergy;
+  using EosBase<EOSPAC>::SpecificHeatFromDensityTemperature;
+  using EosBase<EOSPAC>::SpecificHeatFromDensityInternalEnergy;
+  using EosBase<EOSPAC>::BulkModulusFromDensityTemperature;
+  using EosBase<EOSPAC>::BulkModulusFromDensityInternalEnergy;
+  using EosBase<EOSPAC>::GruneisenParamFromDensityTemperature;
+  using EosBase<EOSPAC>::GruneisenParamFromDensityInternalEnergy;
+  using EosBase<EOSPAC>::PTofRE;
+  using EosBase<EOSPAC>::FillEos;
 
   // TODO (JHP): Change EOSPAC vector implementations to be more performant
   // template<typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Fix using statements for EOSPAC to properly use the EOSPAC class as the template parameter instead of SpinerEOSDependsRhoSie.

This bug was introduced in https://github.com/lanl/singularity-eos/pull/109

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
