### PR TITLE
changed defines to avoid collisions downstream

### DIFF
--- a/utils/root-finding-1d/root_finding.hpp
+++ b/utils/root-finding-1d/root_finding.hpp
@@ -31,9 +31,9 @@
 
 #define SINGULARITY_ROOT_DEBUG (0)
 #define SINGULARITY_ROOT_VERBOSE (0)
-//TODO: mauneyc: this isn't used here, and I can't
-//find it used elsewhere. it also doesn't get unset.
-//should it be ditched?
+// TODO: mauneyc: this isn't used here, and I can't
+// find it used elsewhere. it also doesn't get unset.
+// should it be ditched?
 #define SINGULARITY_ROOT_NAN_OK (0)
 
 #define SINGULARITY_MY_SIGN(x) (x > 0) - (x < 0)

--- a/utils/root-finding-1d/root_finding.hpp
+++ b/utils/root-finding-1d/root_finding.hpp
@@ -29,11 +29,14 @@
 #include <math.h>
 #include <stdio.h>
 
-#define ROOT_DEBUG (0)
-#define ROOT_VERBOSE (0)
-#define ROOT_NAN_OK (0)
+#define SINGULARITY_ROOT_DEBUG (0)
+#define SINGULARITY_ROOT_VERBOSE (0)
+//TODO: mauneyc: this isn't used here, and I can't
+//find it used elsewhere. it also doesn't get unset.
+//should it be ditched?
+#define SINGULARITY_ROOT_NAN_OK (0)
 
-#define MY_SIGN(x) (x > 0) - (x < 0)
+#define SINGULARITY_MY_SIGN(x) (x > 0) - (x < 0)
 
 namespace RootFinding1D {
 constexpr const int SECANT_NITER_MAX{1000};
@@ -141,14 +144,14 @@ PORTABLE_INLINE_FUNCTION Status findRoot(const T &f, const Real ytarget, Real xg
   status = secant(f, ytarget, xguess, xmin, xmax, xtol, ytol, xroot, counts);
   if (status == Status::SUCCESS) return status;
 
-#if ROOT_DEBUG
+#if SINGULARITY_ROOT_DEBUG
   if (isnan(xroot)) {
     fprintf(stderr, "xroot is nan after secant\n");
   }
 #endif
 
 // Secant failed. Try bisection.
-#if ROOT_VERBOSE
+#if SINGULARITY_ROOT_VERBOSE
   fprintf(stderr,
           "\n\nRoot finding. Secant failed. Trying bisection.\n"
           "\txguess  = %.10g\n"
@@ -161,7 +164,7 @@ PORTABLE_INLINE_FUNCTION Status findRoot(const T &f, const Real ytarget, Real xg
 
   // Check for something horrible happening
   if (isnan(xroot) || isinf(xroot)) {
-#if ROOT_DEBUG
+#if SINGULARITY_ROOT_DEBUG
     fprintf(stderr, "xroot is nan after bisection\n");
 #endif
     return Status::FAIL;
@@ -196,7 +199,7 @@ PORTABLE_INLINE_FUNCTION Status secant(const T &f, const Real ytarget, const Rea
     if (x > xmax) x = xmax;
     if (isnan(x) || isinf(x)) {
       // can't recover from this
-#if ROOT_DEBUG
+#if SINGULARITY_ROOT_DEBUG
       fprintf(stderr,
               "\n\n[secant]: NAN or out-of-bounds detected!\n"
               "\txguess  = %.10e\n"
@@ -215,7 +218,7 @@ PORTABLE_INLINE_FUNCTION Status secant(const T &f, const Real ytarget, const Rea
               "\titer    = %d\n"
               "\tsign x  = %d\n",
               xguess, ytarget, x, x_last, xmin, xmax, y, dx, yp, ym, dyNum, dyDen, dy,
-              iter, (int)MY_SIGN(x));
+              iter, (int)SINGULARITY_MY_SIGN(x));
 #endif
       counts.increment(counts.more());
       return Status::FAIL;
@@ -233,7 +236,7 @@ PORTABLE_INLINE_FUNCTION Status secant(const T &f, const Real ytarget, const Rea
 
   y = f(x);
   const Real frac_error = fabs(y - ytarget) / (fabs(y) + ytol);
-#if ROOT_DEBUG
+#if SINGULARITY_ROOT_DEBUG
   if (frac_error > ytol) {
     fprintf(stderr,
             "\n\n[secant]: Failed via too large yerror.\n"
@@ -293,7 +296,7 @@ PORTABLE_INLINE_FUNCTION Status bisect(const T &f, const Real ytarget, const Rea
     grow *= 1.1;
     if (fl * fr < 0.0 || xl < xmin || xr > xmax) break;
     if (i > BISECT_REG_MAX - 2) {
-#if ROOT_DEBUG
+#if SINGULARITY_ROOT_DEBUG
       fprintf(stderr,
               "\n\n[Bisect]: expanding region failed\n"
               "\txl   = %.10g\n"
@@ -327,7 +330,7 @@ PORTABLE_INLINE_FUNCTION Status bisect(const T &f, const Real ytarget, const Rea
       xr = xmax;
       fr = f(xr) - ytarget;
       if (fl * fr > 0) {
-#if ROOT_DEBUG
+#if SINGULARITY_ROOT_DEBUG
         Real il = f(xl);
         Real ir = f(xr);
         fprintf(stderr,
@@ -372,7 +375,7 @@ PORTABLE_INLINE_FUNCTION Status bisect(const T &f, const Real ytarget, const Rea
   xroot = 0.5 * (xl + xr);
 
   if (isnan(xroot)) {
-#if ROOT_DEBUG
+#if SINGULARITY_ROOT_DEBUG
     Real il = f(xl);
     Real ir = f(xr);
     fprintf(stderr,
@@ -398,8 +401,8 @@ PORTABLE_INLINE_FUNCTION Status bisect(const T &f, const Real ytarget, const Rea
 // ----------------------------------------------------------------------
 } // namespace RootFinding1D
 
-#undef ROOT_DEBUG
-#undef ROOT_VERBOSE
-#undef MY_SIGN
+#undef SINGULARITY_ROOT_DEBUG
+#undef SINGULARITY_ROOT_VERBOSE
+#undef SINGULARITY_MY_SIGN
 
 #endif // _SINGULARITY_EOS_UTILS_ROOT_FINDING_HPP_

--- a/utils/root-finding-1d/root_finding.hpp
+++ b/utils/root-finding-1d/root_finding.hpp
@@ -31,10 +31,6 @@
 
 #define SINGULARITY_ROOT_DEBUG (0)
 #define SINGULARITY_ROOT_VERBOSE (0)
-// TODO: mauneyc: this isn't used here, and I can't
-// find it used elsewhere. it also doesn't get unset.
-// should it be ditched?
-#define SINGULARITY_ROOT_NAN_OK (0)
 
 #define SINGULARITY_MY_SIGN(x) (x > 0) - (x < 0)
 


### PR DESCRIPTION
Change the `#define`s in `utils/root-finding-1d/root_finding.hpp` to be prefixed with `SINGULARITY_`, to avoid possible collisions with names/symbols downstream

There is also a presently in the code I'm not sure about, see Summary

## PR Summary

As I understand it, this root-find shares a common origin in GSL; it is no only possible that other codes do so, but I in fact hit an issue when integrating `singularity-eos` into a code that does something similar. The results were lots of weird errors that ended up being these preprocessor directives over-writing variables names.

To prevent this in future, this PR changes the strings of these `#define`s to try and avoid possible future collisions.

There is also a possible unnecessary `#define` (originally `utils/root-finding-1d/root_finding.hpp:34`) :
```c++
#define ROOT_NAN_OK (0)
```
This isn't referenced in the file, and further isn't unset. Is this necessary for something outside the source tree? If we don't need it anywhere else, it would be good to remove it altogether.

NB: _Ideally_ these would be declared as `constexpr` and placed in namescope, but currently without `if constexpr` functionallity, this would introduce unwanted code branching. If we do ever decide to bump the C++ standard, this would be the preferred change. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ x] Adds a test for any bugs fixed. Adds tests for new features.
- [ x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ x] Document any new features, update documentation for changes made.
- [ x] Make sure the copyright notice on any files you modified is up to date.
