### PR TITLE
Fix: spack package.py gets non-breaking version string

### DIFF
--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -61,7 +61,7 @@ class SingularityEos(CMakePackage, CudaPackage):
     depends_on("kokkos +wrapper+cuda_lambda+cuda_relocatable_device_code", when="+cuda+kokkos")
 
     # fix for older spacks
-    if spack.version.Version(spack.main.get_version()) >= spack.version.Version("0.17"):
+    if spack.version.Version(spack.spack_version) >= spack.version.Version("0.17"):
         depends_on("kokkos-kernels ~shared", when="+kokkos-kernels")
 
     for _flag in list(CudaPackage.cuda_arch_values):


### PR DESCRIPTION
This changes the version check, so that internal spack checks don't go bonkers

## PR Summary

Before, the `package.py` file used `spack.main.get_version()` to get the 'current' spack version. However, this returned the version along with the git hash appended, and later comparison checks would complain about bad characters in the version string.

This was changed to `spack.spack_version`, which simply holds the (compatible) version.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
