### PR TITLE
Removing "extra tokens" warning

### DIFF
--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -171,4 +171,4 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
 
 } // namespace singularity
 
-#endif _SINGULARITY_EOS_EOS_SHIFTED_EOS_
+#endif // _SINGULARITY_EOS_EOS_SHIFTED_EOS_


### PR DESCRIPTION
Small update to remove compiler warnings about `extra tokens at end of #endif directive`

## PR Summary

Both GNU/Clang are unhappy about stuff after `#endif`s. There was some of this in `singularity-eos/eos/modifiers/shifted_eos.hpp`. I simply commented out the string.

## PR Checklist

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
