### PR TITLE
More robust initial guess for temperature in PTE

### DIFF
--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -228,9 +228,9 @@ class PTESolverBase {
     // check for sanity.  basically checks that the input temperatures weren't garbage
     assert(Tguess < 1.0e15);
     // iteratively increase temperature guess until all rho's are above rho_at_pmin
-    const Real Tfactor = 3.0;
+    const Real Tfactor = 10.0;
     bool rho_fail;
-    for (int i = 0; i < 6; i++) {
+    for (int i = 0; i < 3; i++) {
       Real vsum = 0.0;
       // set volume fractions
       for (int m = 0; m < nmat; ++m) {

--- a/singularity-eos/eos/eos_spiner.cpp
+++ b/singularity-eos/eos/eos_spiner.cpp
@@ -457,7 +457,9 @@ void SpinerEOSDependsRhoT::setlTColdCrit_() {
     // there's no good uniquely defined solution.
     // We choose the highest-temperature crossing,
     // which results in the least code. But this may be wrong.
-    if (last_pos_crossing < 0) { // off the grid
+    // JMM: <= 0 required here so that a cold curve on the min T
+    // isotherm doesn't trigger a root find.
+    if (last_pos_crossing <= 0) { // off the grid
       lTColdCrit_(j) = lTMin_;
     } else { // at least one pos crossing. Use last one.
       const callable_interp::r_interp sieFunc(sie_, lRho);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This is a very small update that iteratively searches for an initial temperature guess such that the initial material densities are always above the density at pressure minimum at that temperature.

Also includes a tiny bug fix in the calculation of cold curves in SpinerDependsRhoT.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
