### PR TITLE
error to warning when using Kokkos and Eigen

### DIFF
--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -120,7 +120,7 @@ bool solve_Ax_b_wscr(const int n, Real *a, Real *b, Real *scr) {
   InvertR::invoke(1.0, A, B);
 #else
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-#error "Eigen should not be used with Kokkos."
+#warning "Eigen should not be used with Kokkos."
 #endif
   // Eigen VERSION
   Eigen::Map<Eigen::Matrix<Real, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> A(a, n,


### PR DESCRIPTION
This changes the preprocessor directive when compiling with `kokkos` + `Eigen` to a `#warning`, so that the code will not halt compilation in this case.

This is a temporary fix for #125  . Ideally this (and other) directives will be superseded by the build configuration stage.