### PR TITLE
remove PORTABLE_INLINE_FUNCTION on default constructor of CacheAccessor

### DIFF
--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -140,7 +140,6 @@ struct NullPtrIndexer {
 
 class CacheAccessor {
  public:
-  PORTABLE_INLINE_FUNCTION
   CacheAccessor() = default;
   PORTABLE_INLINE_FUNCTION
   explicit CacheAccessor(Real *scr) : cache_(scr) {}


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Decorating default constructors/destructors produces a warning when building for CUDA.  This just removes a PORTABLE_INLINE_FUNCTION on the default constructor for the `CacheAccessor` class used internally for the PTE solve.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
