### PR TITLE
fix docs deploy on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
             cd doc/sphinx
             make multiversion
         - name: Deploy
-          if: ${{ if: github.event.pull_request.head.repo.full_name == github.repository }}
+          if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           uses: peaceiris/actions-gh-pages@v3.7.3
           with:
             github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,7 @@ jobs:
             cd doc/sphinx
             make multiversion
         - name: Deploy
+          if: ${{ if: github.event.pull_request.head.repo.full_name == github.repository }}
           uses: peaceiris/actions-gh-pages@v3.7.3
           with:
             github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

When people on forks submit a PR, the docs test fails because the fork doesn't have permission to deploy the docs to github pages. This PR hopefully resolves the issue by disabling the deployment on PRs from forks. (Tested in Spiner.)

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
