### PR TITLE
Make Gruneisen EOS root finding tolerance a function of machine epsilon

### DIFF
--- a/singularity-eos/eos/eos_gruneisen.cpp
+++ b/singularity-eos/eos/eos_gruneisen.cpp
@@ -113,7 +113,7 @@ PORTABLE_FUNCTION Real Gruneisen::ComputeRhoMax(const Real s1, const Real s2,
       using RootFinding1D::RootCounts;
       using RootFinding1D::Status;
       RootCounts counts;
-      static constexpr Real factor = 100
+      static constexpr Real factor = 100;
       static constexpr Real xtol = factor * EPS;
       static constexpr Real ytol = factor / 10 * EPS;
       static constexpr Real eta_guess = 0.001;

--- a/singularity-eos/eos/eos_gruneisen.cpp
+++ b/singularity-eos/eos/eos_gruneisen.cpp
@@ -113,9 +113,10 @@ PORTABLE_FUNCTION Real Gruneisen::ComputeRhoMax(const Real s1, const Real s2,
       using RootFinding1D::RootCounts;
       using RootFinding1D::Status;
       RootCounts counts;
-      const Real xtol = 1.e-08;
-      const Real ytol = 1.e-08;
-      const Real eta_guess = 0.001;
+      static constexpr Real factor = 100
+      static constexpr Real xtol = factor * EPS;
+      static constexpr Real ytol = factor / 10 * EPS;
+      static constexpr Real eta_guess = 0.001;
       auto status =
           regula_falsi(poly, 0., eta_guess, minbound, maxbound, xtol, ytol, root, counts);
       if (status != Status::SUCCESS) {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Changes the root finding tolerances used in the Gruneisen EOS to be related to machine epsilon. The function where this is used computes the maximum allowable density for the EOS given a fit to the Hugoniot.

I'm using a smaller tolerance for y than x in this case because it is possible that a local extremum will be the root (or will be very close to the root), causing the dy/dx derivative at the root to be very small. Previously the tolerances had been equal, in which case the small derivative would cause a small y tolerance to become a much larger (perhaps unacceptably so) tolerance in x.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- N/A Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- N/A Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
