### PR TITLE
Replace secant method with regula_falsi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current develop
 
-### Fixed cmake code to properly install fortran module files in include path
+### Fixed (Repair bugs, etc)
 - [[PR157]](https://github.com/lanl/singularity-eos/pull/157) fix root finders in Gruneisen, Davis, and JWL
 - [[PR151]](https://github.com/lanl/singularity-eos/pull/151) fix module install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Fixed cmake code to properly install fortran module files in include path
+- [[PR157]](https://github.com/lanl/singularity-eos/pull/157) fix root finders in Gruneisen, Davis, and JWL
 - [[PR151]](https://github.com/lanl/singularity-eos/pull/151) fix module install
 
 ### Added (new features/APIs/variables/...)

--- a/singularity-eos/eos/eos_davis.cpp
+++ b/singularity-eos/eos/eos_davis.cpp
@@ -14,6 +14,7 @@
 
 #include <cmath>
 #include <singularity-eos/eos/eos.hpp>
+#include <singularity-eos/base/root-finding-1d/root_finding.hpp>
 
 namespace singularity {
 
@@ -139,28 +140,19 @@ PORTABLE_FUNCTION void DavisReactants::DensityEnergyFromPressureTemperature(
     const Real press, const Real temp, Real *lambda, Real &rho, Real &sie) const {
   // First, solve P=P(rho,T) for rho.  Note P(rho,e) has an sie-es term, which is only a
   // function of T
-  auto residual = [&](const Real r) {
-    return press - (Ps(r) + Gamma(r) * r * _Cv0 * Ts(r) / (1 + _alpha) *
-                                (std::pow(temp / Ts(r), 1 + _alpha) - 1.0));
+  auto PofRatT = [&](const Real r) {
+    return (Ps(r) + Gamma(r) * r * _Cv0 * Ts(r) / (1 + _alpha) *
+                   (std::pow(temp / Ts(r), 1 + _alpha) - 1.0));
   };
-  Real rho1 = _rho0, res1 = residual(rho1);
-  Real slope =
-      _Cv0 * _G0 *
-      ((_alpha * _G0 - 1.0) * temp * std::pow(temp / _T0, _alpha) + _T0 + _G0 * _T0) /
-      (1 + _alpha);
-  Real rho2 = rho1 + res1 / slope, res2 = residual(rho2);
-  Real rhom, resm;
-  for (int i = 1; i < 20; ++i) {
-    slope = (rho2 - rho1) / (res2 - res1);
-    rhom = rho2 - res2 * slope;
-    resm = residual(rhom);
-    if (resm / press < 1e-8) break;
-    rho1 = rho2;
-    res1 = res2;
-    rho2 = rhom;
-    res2 = resm;
+  using RootFinding1D::regula_falsi;
+  using RootFinding1D::Status;
+  RootFinding1D::RootCounts counts;
+  auto status = regula_falsi(PofRatT,press,_rho0,1.0e-5,1.0e3,1.0e-8,1.0e-8,rho,counts);
+  if (status != Status::SUCCESS) {
+    // Root finder failed even though the solution was bracketed... this is an error
+    EOS_ERROR("DavisReactants::DensityEnergyFromPressureTemperature: " 
+              "Root find failed to find a solution given P, T\n");
   }
-  rho = rhom;
   sie = InternalEnergyFromDensityTemperature(rho, temp);
 }
 PORTABLE_FUNCTION
@@ -305,24 +297,19 @@ Real DavisProducts::GruneisenParamFromDensityTemperature(const Real rho, const R
 }
 PORTABLE_FUNCTION void DavisProducts::DensityEnergyFromPressureTemperature(
     const Real press, const Real temp, Real *lambda, Real &rho, Real &sie) const {
-  auto residual = [&](const Real r) {
-    return press - (Ps(r) + Gamma(r) * r * _Cv * (temp - Ts(r)));
+  auto PofRatT = [&](const Real r) {
+    return (Ps(r) + Gamma(r) * r * _Cv * (temp - Ts(r)));
   };
-  Real rho1 = 1.0 / _vc, res1 = residual(rho1);
-  Real slope;
-  Real rho2 = rho1 * 2.0, res2 = residual(rho2);
-  Real rhom, resm;
-  for (int i = 1; i < 20; ++i) {
-    slope = (rho2 - rho1) / (res2 - res1);
-    rhom = rho2 - res2 * slope;
-    resm = residual(rhom);
-    if (resm / press < 1e-8) break;
-    rho1 = rho2;
-    res1 = res2;
-    rho2 = rhom;
-    res2 = resm;
+  using RootFinding1D::regula_falsi;
+  using RootFinding1D::Status;
+  RootFinding1D::RootCounts counts;
+  const Real rho0 = 1.0 / _vc;
+  auto status = regula_falsi(PofRatT,press,rho0,1.0e-5,1.0e3,1.0e-8,1.0e-8,rho,counts);
+  if (status != Status::SUCCESS) {
+    // Root finder failed even though the solution was bracketed... this is an error
+    EOS_ERROR("DavisProducts::DensityEnergyFromPressureTemperature: " 
+              "Root find failed to find a solution given P, T\n");
   }
-  rho = rhom;
   sie = InternalEnergyFromDensityTemperature(rho, temp);
 }
 PORTABLE_FUNCTION

--- a/singularity-eos/eos/eos_davis.cpp
+++ b/singularity-eos/eos/eos_davis.cpp
@@ -13,8 +13,8 @@
 //------------------------------------------------------------------------------
 
 #include <cmath>
-#include <singularity-eos/eos/eos.hpp>
 #include <singularity-eos/base/root-finding-1d/root_finding.hpp>
+#include <singularity-eos/eos/eos.hpp>
 
 namespace singularity {
 
@@ -142,15 +142,16 @@ PORTABLE_FUNCTION void DavisReactants::DensityEnergyFromPressureTemperature(
   // function of T
   auto PofRatT = [&](const Real r) {
     return (Ps(r) + Gamma(r) * r * _Cv0 * Ts(r) / (1 + _alpha) *
-                   (std::pow(temp / Ts(r), 1 + _alpha) - 1.0));
+                        (std::pow(temp / Ts(r), 1 + _alpha) - 1.0));
   };
   using RootFinding1D::regula_falsi;
   using RootFinding1D::Status;
   RootFinding1D::RootCounts counts;
-  auto status = regula_falsi(PofRatT,press,_rho0,1.0e-5,1.0e3,1.0e-8,1.0e-8,rho,counts);
+  auto status =
+      regula_falsi(PofRatT, press, _rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho, counts);
   if (status != Status::SUCCESS) {
     // Root finder failed even though the solution was bracketed... this is an error
-    EOS_ERROR("DavisReactants::DensityEnergyFromPressureTemperature: " 
+    EOS_ERROR("DavisReactants::DensityEnergyFromPressureTemperature: "
               "Root find failed to find a solution given P, T\n");
   }
   sie = InternalEnergyFromDensityTemperature(rho, temp);
@@ -304,10 +305,11 @@ PORTABLE_FUNCTION void DavisProducts::DensityEnergyFromPressureTemperature(
   using RootFinding1D::Status;
   RootFinding1D::RootCounts counts;
   const Real rho0 = 1.0 / _vc;
-  auto status = regula_falsi(PofRatT,press,rho0,1.0e-5,1.0e3,1.0e-8,1.0e-8,rho,counts);
+  auto status =
+      regula_falsi(PofRatT, press, rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho, counts);
   if (status != Status::SUCCESS) {
     // Root finder failed even though the solution was bracketed... this is an error
-    EOS_ERROR("DavisProducts::DensityEnergyFromPressureTemperature: " 
+    EOS_ERROR("DavisProducts::DensityEnergyFromPressureTemperature: "
               "Root find failed to find a solution given P, T\n");
   }
   sie = InternalEnergyFromDensityTemperature(rho, temp);

--- a/singularity-eos/eos/eos_gruneisen.cpp
+++ b/singularity-eos/eos/eos_gruneisen.cpp
@@ -257,10 +257,11 @@ PORTABLE_FUNCTION void Gruneisen::DensityEnergyFromPressureTemperature(
     using RootFinding1D::regula_falsi;
     using RootFinding1D::Status;
     RootFinding1D::RootCounts counts;
-    auto status = regula_falsi(PofRatE,press,_rho0,1.0e-5,1.0e3,1.0e-8,1.0e-8,rho,counts);
+    auto status =
+        regula_falsi(PofRatE, press, _rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho, counts);
     if (status != Status::SUCCESS) {
       // Root finder failed even though the solution was bracketed... this is an error
-      EOS_ERROR("Gruneisen::DensityEnergyFromPressureTemperature: " 
+      EOS_ERROR("Gruneisen::DensityEnergyFromPressureTemperature: "
                 "Root find failed to find a solution given P, T\n");
     }
   }

--- a/singularity-eos/eos/eos_jwl.cpp
+++ b/singularity-eos/eos/eos_jwl.cpp
@@ -92,16 +92,15 @@ PORTABLE_FUNCTION void JWL::DensityEnergyFromPressureTemperature(const Real pres
   // Thus P = P_r +_w*rho*cv*T ==> Invertable?
   // Turns out not to be exactly invertible
   Real rhoguess = (rho < 1e-8) ? _rho0 : rho;
-  auto PofRatT = [&](const Real r) {
-    return _Cv * temp * r * _w + ReferencePressure(r);
-  };
+  auto PofRatT = [&](const Real r) { return _Cv * temp * r * _w + ReferencePressure(r); };
   using RootFinding1D::regula_falsi;
   using RootFinding1D::Status;
   RootFinding1D::RootCounts counts;
-  auto status = regula_falsi(PofRatT,press,rhoguess,1.0e-5,1.0e3,1.0e-8,1.0e-8,rho,counts);
+  auto status =
+      regula_falsi(PofRatT, press, rhoguess, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho, counts);
   if (status != Status::SUCCESS) {
     // Root finder failed even though the solution was bracketed... this is an error
-    EOS_ERROR("JWL::DensityEnergyFromPressureTemperature: " 
+    EOS_ERROR("JWL::DensityEnergyFromPressureTemperature: "
               "Root find failed to find a solution given P, T\n");
   }
   sie = InternalEnergyFromDensityTemperature(rho, temp);


### PR DESCRIPTION
## PR Summary
Replaces the original hand-written solvers using a naive secant method (with a bug!) with the now present `regula_falsi` solver. 

The buggy versions were in the Gruneisen EOS and the two Davis EOSs, and there was a slightly less buggy version (which had the missing abs) in JWL, but it makes sense for these to be put together for consistency.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
