### PR TITLE
Add py-pybind11 as Spack dependency

### DIFF
--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -51,6 +51,7 @@ class SingularityEos(CMakePackage, CudaPackage):
     depends_on("cmake@3.14:")
     depends_on("catch2@2.13.7", when="+tests")
     depends_on("python@3:", when="+python")
+    depends_on("py-pybind11@2.9.1:", when="+python")
 #    depends_on("py-h5py", when="+tests build_extra=stellarcollapse")
     depends_on("py-sphinx", when="+doc")
     depends_on("py-sphinx-rtd-theme@0.4.3", when="+doc")


### PR DESCRIPTION
## PR Summary

Makes pybind11 a Spack dependency when building the Python bindings.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file
