### PR TITLE
Provide a function to give initial temperature guesses for PTE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [[PR151]](https://github.com/lanl/singularity-eos/pull/151) fix module install
 
 ### Added (new features/APIs/variables/...)
+- [[PR164]](https://github.com/lanl/singularity-eos/pull/164) provide facilities for an initial temperature guess for PTE
 
 ### Changed (changing behavior/API/variables/...)
 

--- a/doc/sphinx/src/using-closures.rst
+++ b/doc/sphinx/src/using-closures.rst
@@ -225,9 +225,23 @@ For an example of the PTE solver machinery in use, see the
 Initial Guesses for PTE Solvers
 ------------------------------------
 
-As is always the case when solving systems of nonlinear equations, good initial guesses are important to ensure rapid convergence to the solution.  For the PTE solvers, this means providing intial guesses for the material densities and the equilibrium temperature.  For material densities, a good initial guess is often the previous value obtained from a prior call to the solver.  ``singularity-eos`` does not provide any mechanism to cache these values from call to call, so it is up to the host code to provide these as input to the solvers.  Note that the input values for the material densities and volume fractions are assumed to be consistent with the conserved cell-averaged material densities, or in other words, the produce of the input material densities, volume fractions, and cell volume should equal the amount of mass of each material in the cell.  This consistency should be ensured for the input values or else the solvers will not provide correct answers.
+As is always the case when solving systems of nonlinear equations, good initial
+guesses are important to ensure rapid convergence to the solution.  For the PTE
+solvers, this means providing intial guesses for the material densities and the
+equilibrium temperature.  For material densities, a good initial guess is often
+the previous value obtained from a prior call to the solver. ``singularity-eos``
+does not provide any mechanism to cache these values from call to call, so it is
+up to the host code to provide these as input to the solvers.  Note that the
+input values for the material densities and volume fractions are assumed to be
+consistent with the conserved cell-averaged material densities, or in other
+words, the produce of the input material densities, volume fractions, and cell
+volume should equal the amount of mass of each material in the cell.  This
+consistency should be ensured for the input values or else the solvers will not
+provide correct answers.
 
-For the temperature initial guess, one can similarly use a previous value for the cell.  Alternatively, ``singularity-eos`` provides a function that can be used to provide an initial guess.  This function takes the form
+For the temperature initial guess, one can similarly use a previous value for
+the cell.  Alternatively, ``singularity-eos`` provides a function that can be
+used to provide an initial guess.  This function takes the form
 
 .. code-block:: cpp
 

--- a/doc/sphinx/src/using-closures.rst
+++ b/doc/sphinx/src/using-closures.rst
@@ -174,7 +174,7 @@ The constructor for the ``PTESolverRhoT`` is of the form
   template <typename EOS_t, typename Real_t, typename Lambda_t>
   PTESolverRhoT(const int nmat, EOS_t &&eos, const Real vfrac_tot, const Real sie_tot,
                 Real_t &&rho, Real_t &&vfrac, Real_t &&sie, Real_t &&temp, Real_t &&press,
-                Lambda_t &&lambda, Real *scratch);
+                Lambda_t &&lambda, Real *scratch, const Real Tguess = 0);
 
 where ``nmat`` is the number of materials, ``eos`` is an indexer over
 equation of state objects, one per material, and ``vfrac_tot`` is a
@@ -188,7 +188,9 @@ one per material. ``press`` is an indexer over pressures, one per
 material. ``lambda`` is an indexer over lambda arrays, one ``Real *``
 object per material. ``scratch`` is a pointer to pre-allocated scratch
 memory, as described above. It is assumed enough scratch has been
-allocated.
+allocated.  Finally, the optional argument ``Tguess`` allows for host
+codes to pass in an initial temperature guess for the solver.  For more
+information on initial guesses, see the section below.
 
 The constructor for the ``PTESolverRhoU`` has the same structure:
 
@@ -197,7 +199,8 @@ The constructor for the ``PTESolverRhoU`` has the same structure:
   template <typename EOS_t, typename Real_t, typename Lambda_t>
   PTESolverRhoU(const int nmat, const EOS_t &&eos, const Real vfrac_tot,
                 const Real sie_tot, Real_t &&rho, Real_t &&vfrac, Real_t &&sie,
-                Real_t &&temp, Real_t &&press, Lambda_t &&lambda, Real *scratch);
+                Real_t &&temp, Real_t &&press, Lambda_t &&lambda, Real *scratch,
+                const Real Tguess = 0);
 
 Both constructors are callable on host or device. In gerneral,
 densities and internal energies are the required inputs. However, all
@@ -218,3 +221,30 @@ example:
 
 For an example of the PTE solver machinery in use, see the
 ``test_pte.cpp`` file in the tests directory.
+
+Initial Guesses for PTE Solvers
+------------------------------------
+
+As is always the case when solving systems of nonlinear equations, good initial guesses are important to ensure rapid convergence to the solution.  For the PTE solvers, this means providing intial guesses for the material densities and the equilibrium temperature.  For material densities, a good initial guess is often the previous value obtained from a prior call to the solver.  ``singularity-eos`` does not provide any mechanism to cache these values from call to call, so it is up to the host code to provide these as input to the solvers.  Note that the input values for the material densities and volume fractions are assumed to be consistent with the conserved cell-averaged material densities, or in other words, the produce of the input material densities, volume fractions, and cell volume should equal the amount of mass of each material in the cell.  This consistency should be ensured for the input values or else the solvers will not provide correct answers.
+
+For the temperature initial guess, one can similarly use a previous value for the cell.  Alternatively, ``singularity-eos`` provides a function that can be used to provide an initial guess.  This function takes the form
+
+.. code-block:: cpp
+
+  template <typename EOSIndexer, typename RealIndexer>
+  PORTABLE_INLINE_FUNCTION Real ApproxTemperatureFromRhoMatU(
+    const int nmat, EOSIndexer &&eos, const Real u_tot, RealIndexer &&rho,
+    RealIndexer &&vfrac, const Real Tguess = 0.0);
+
+where ``nmat`` is the number of materials, ``eos`` is an indexer over
+equation of state objects, ``u_tot`` is the total material internal
+energy density (energy per unit volume), ``rho`` is an indexer over
+material density, ``vfrac`` is an indexer over material volume fractions,
+and the optional argument ``Tguess`` allows for callers to pass in a guess
+that could accelerate finding a solution.  This function does a 1-D root find
+to find the temperature at which the material internal energies sum to the
+total.  The root find does not have a tight tolerance -- instead the
+hard-coded tolerance was selected to balance performance with the accuracy
+desired for an initial guess in a PTE solve.  If a previous temperature value
+is unavailable or some other process may have significantly modified the
+temperature since it was last updated, this function can be quite effective.

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -49,6 +49,8 @@ constexpr Real line_search_alpha = 1.e-2;
 constexpr int line_search_max_iter = 6;
 constexpr Real line_search_fac = 0.5;
 constexpr Real vfrac_safety_fac = 0.95;
+constexpr Real minimum_temperature = 1.e-9;
+constexpr Real maximum_temperature = 1.e9;
 } // namespace mix_params
 
 namespace mix_impl {

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -16,6 +16,7 @@
 #define _SINGULARITY_EOS_CLOSURE_MIXED_CELL_MODELS_
 
 #include <ports-of-call/portability.hpp>
+#include <singularity-eos/base/fast-math/logs.hpp>
 #include <singularity-eos/eos/eos.hpp>
 
 #include <cmath>

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -420,12 +420,10 @@ class PTESolverBase {
 
 } // namespace mix_impl
 
-
 template <typename EOSIndexer, typename RealIndexer>
-PORTABLE_INLINE_FUNCTION
-Real ApproxTemperatureFromRhoMatU(const int nmat, EOSIndexer &&eos, const Real u_tot,
-                                  RealIndexer &&rho, RealIndexer &&vfrac,
-                                  const Real Tguess = 0.0) {
+PORTABLE_INLINE_FUNCTION Real ApproxTemperatureFromRhoMatU(
+    const int nmat, EOSIndexer &&eos, const Real u_tot, RealIndexer &&rho,
+    RealIndexer &&vfrac, const Real Tguess = 0.0) {
   // given material microphysical densities, volume fractions, and a total internal energy
   // density (rho e => erg/cm^3), solve for the temperature that gives the right sum
   // of material energies.  this should only be used for a rough guess since it has a
@@ -444,7 +442,8 @@ Real ApproxTemperatureFromRhoMatU(const int nmat, EOSIndexer &&eos, const Real u
   if (u_tot > uhi) return mix_params::maximum_temperature;
   Real lTlo = FastMath::lg(mix_params::minimum_temperature);
   Real lThi = FastMath::lg(mix_params::maximum_temperature);
-  if (Tguess > mix_params::minimum_temperature && Tguess < mix_params::maximum_temperature) {
+  if (Tguess > mix_params::minimum_temperature &&
+      Tguess < mix_params::maximum_temperature) {
     const Real ug = ufunc(Tguess);
     if (ug < u_tot) {
       lTlo = FastMath::lg(Tguess);
@@ -459,7 +458,7 @@ Real ApproxTemperatureFromRhoMatU(const int nmat, EOSIndexer &&eos, const Real u
   while (lThi - lTlo > 0.01 && iter < max_iter) {
     // apply bisection which is much better behaved
     // for materials that have a flat sie at low temperatures
-    const Real lT = 0.5*(lTlo + lThi);
+    const Real lT = 0.5 * (lTlo + lThi);
     const Real uT = ufunc(FastMath::pow2(lT));
     if (uT < u_tot) {
       lTlo = lT;
@@ -471,7 +470,7 @@ Real ApproxTemperatureFromRhoMatU(const int nmat, EOSIndexer &&eos, const Real u
     iter++;
   }
 
-  const Real alpha = (u_tot - ulo)/(uhi - ulo);
+  const Real alpha = (u_tot - ulo) / (uhi - ulo);
   return FastMath::pow2((1.0 - alpha) * lTlo + alpha * lThi);
 }
 
@@ -538,7 +537,7 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
     InitBase();
     Residual();
     // Leave this in for now, but comment out because I'm not sure it's a good idea
-    //TryIdealPTE(this);
+    // TryIdealPTE(this);
     // Set the current guess for the equilibrium temperature.  Note that this is already
     // scaled.
     Tequil = temp[0];
@@ -752,11 +751,11 @@ class PTESolverRhoU : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
  public:
   // template the ctor to get type deduction/universal references prior to c++17
   template <typename EOS_t, typename Real_t, typename Lambda_t>
-  PORTABLE_INLINE_FUNCTION
-  PTESolverRhoU(const int nmat, const EOS_t &&eos, const Real vfrac_tot,
-                const Real sie_tot, Real_t &&rho, Real_t &&vfrac, Real_t &&sie,
-                Real_t &&temp, Real_t &&press, Lambda_t &&lambda, Real *scratch,
-                const Real Tguess = 0.0)
+  PORTABLE_INLINE_FUNCTION PTESolverRhoU(const int nmat, const EOS_t &&eos,
+                                         const Real vfrac_tot, const Real sie_tot,
+                                         Real_t &&rho, Real_t &&vfrac, Real_t &&sie,
+                                         Real_t &&temp, Real_t &&press, Lambda_t &&lambda,
+                                         Real *scratch, const Real Tguess = 0.0)
       : mix_impl::PTESolverBase<EOSIndexer, RealIndexer>(nmat, 2 * nmat, eos, vfrac_tot,
                                                          sie_tot, rho, vfrac, sie, temp,
                                                          press, scratch, Tguess) {

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -190,10 +190,10 @@ class PTESolverBase {
   PTESolverBase(int nmats, int neqs, const EOSIndexer &eos_, const Real vfrac_tot,
                 const Real sie_tot, const RealIndexer &rho_, const RealIndexer &vfrac_,
                 const RealIndexer &sie_, const RealIndexer &temp_,
-                const RealIndexer &press_, Real *&scratch)
+                const RealIndexer &press_, Real *&scratch, Real Tguess)
       : nmat(nmats), neq(neqs), niter(0), eos(eos_), vfrac_total(vfrac_tot),
         sie_total(sie_tot), rho(rho_), vfrac(vfrac_), sie(sie_), temp(temp_),
-        press(press_) {
+        press(press_), Tnorm(Tguess) {
     jacobian = AssignIncrement(scratch, neq * neq);
     dx = AssignIncrement(scratch, neq);
     sol_scratch = AssignIncrement(scratch, 2 * neq);
@@ -221,9 +221,15 @@ class PTESolverBase {
     u_total = rho_total * sie_total;
 
     // guess some non-zero temperature to start
-    Real Tguess = 300.0;
-    for (int m = 0; m < nmat; ++m)
-      Tguess = std::max(Tguess, temp[m]);
+    // If a guess was passed in, it's saved in Tnorm
+    Real Tguess;
+    if (Tnorm > 0.0) {
+      Tguess = Tnorm;
+    } else {
+      Tguess = 300.0;
+      for (int m = 0; m < nmat; ++m)
+        Tguess = std::max(Tguess, temp[m]);
+    }
     // check for sanity.  basically checks that the input temperatures weren't garbage
     assert(Tguess < 1.0e15);
     // iteratively increase temperature guess until all rho's are above rho_at_pmin
@@ -412,6 +418,61 @@ class PTESolverBase {
 
 } // namespace mix_impl
 
+
+template <typename EOSIndexer, typename RealIndexer>
+PORTABLE_INLINE_FUNCTION
+Real ApproxTemperatureFromRhoMatU(const int nmat, EOSIndexer &&eos, const Real u_tot,
+                                  RealIndexer &&rho, RealIndexer &&vfrac,
+                                  const Real Tguess = 0.0) {
+  // given material microphysical densities, volume fractions, and a total internal energy
+  // density (rho e => erg/cm^3), solve for the temperature that gives the right sum
+  // of material energies.  this should only be used for a rough guess since it has a
+  // hard coded and fairly loose tolerance
+  auto ufunc = [&](const Real T) {
+    Real usum = 0.0;
+    for (int m = 0; m < nmat; m++) {
+      usum += rho[m] * vfrac[m] * eos[m].InternalEnergyFromDensityTemperature(rho[m], T);
+    }
+    return usum;
+  };
+
+  Real ulo = ufunc(mix_params::minimum_temperature);
+  if (u_tot < ulo) return mix_params::minimum_temperature;
+  Real uhi = ufunc(mix_params::maximum_temperature);
+  if (u_tot > uhi) return mix_params::maximum_temperature;
+  Real lTlo = FastMath::lg(mix_params::minimum_temperature);
+  Real lThi = FastMath::lg(mix_params::maximum_temperature);
+  if (Tguess > mix_params::minimum_temperature && Tguess < mix_params::maximum_temperature) {
+    const Real ug = ufunc(Tguess);
+    if (ug < u_tot) {
+      lTlo = FastMath::lg(Tguess);
+      ulo = ug;
+    } else {
+      lThi = FastMath::lg(Tguess);
+      uhi = ug;
+    }
+  }
+  int iter = 0;
+  constexpr int max_iter = 10;
+  while (lThi - lTlo > 0.01 && iter < max_iter) {
+    // apply bisection which is much better behaved
+    // for materials that have a flat sie at low temperatures
+    const Real lT = 0.5*(lTlo + lThi);
+    const Real uT = ufunc(FastMath::pow2(lT));
+    if (uT < u_tot) {
+      lTlo = lT;
+      ulo = uT;
+    } else {
+      lThi = lT;
+      uhi = uT;
+    }
+    iter++;
+  }
+
+  const Real alpha = (u_tot - ulo)/(uhi - ulo);
+  return FastMath::pow2((1.0 - alpha) * lTlo + alpha * lThi);
+}
+
 inline int PTESolverRhoTRequiredScratch(const int nmat) {
   int neq = nmat + 1;
   return neq * neq                 // jacobian
@@ -456,10 +517,10 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
   PORTABLE_INLINE_FUNCTION
   PTESolverRhoT(const int nmat, EOS_t &&eos, const Real vfrac_tot, const Real sie_tot,
                 Real_t &&rho, Real_t &&vfrac, Real_t &&sie, Real_t &&temp, Real_t &&press,
-                Lambda_t &&lambda, Real *scratch)
+                Lambda_t &&lambda, Real *scratch, const Real Tguess = 0.0)
       : mix_impl::PTESolverBase<EOSIndexer, RealIndexer>(nmat, nmat + 1, eos, vfrac_tot,
                                                          sie_tot, rho, vfrac, sie, temp,
-                                                         press, scratch) {
+                                                         press, scratch, Tguess) {
     dpdv = AssignIncrement(scratch, nmat);
     dedv = AssignIncrement(scratch, nmat);
     dpdT = AssignIncrement(scratch, nmat);
@@ -474,7 +535,8 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
   Real Init() {
     InitBase();
     Residual();
-    TryIdealPTE(this);
+    // Leave this in for now, but comment out because I'm not sure it's a good idea
+    //TryIdealPTE(this);
     // Set the current guess for the equilibrium temperature.  Note that this is already
     // scaled.
     Tequil = temp[0];
@@ -691,10 +753,11 @@ class PTESolverRhoU : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
   PORTABLE_INLINE_FUNCTION
   PTESolverRhoU(const int nmat, const EOS_t &&eos, const Real vfrac_tot,
                 const Real sie_tot, Real_t &&rho, Real_t &&vfrac, Real_t &&sie,
-                Real_t &&temp, Real_t &&press, Lambda_t &&lambda, Real *scratch)
+                Real_t &&temp, Real_t &&press, Lambda_t &&lambda, Real *scratch,
+                const Real Tguess = 0.0)
       : mix_impl::PTESolverBase<EOSIndexer, RealIndexer>(nmat, 2 * nmat, eos, vfrac_tot,
                                                          sie_tot, rho, vfrac, sie, temp,
-                                                         press, scratch) {
+                                                         press, scratch, Tguess) {
     dpdv = AssignIncrement(scratch, nmat);
     dtdv = AssignIncrement(scratch, nmat);
     dpde = AssignIncrement(scratch, nmat);

--- a/test/test_pte.cpp
+++ b/test/test_pte.cpp
@@ -219,10 +219,12 @@ int main(int argc, char *argv[]) {
           }
           sie_tot /= rho_tot;
 
+          const Real Tguess = ApproxTemperatureFromRhoMatU(NMAT, eos, rho_tot*sie_tot, rho, vfrac);
+
           auto method =
               PTESolverRhoT<EOSAccessor, Indexer2D<decltype(rho_d)>, decltype(lambda)>(
                   NMAT, eos, 1.0, sie_tot, rho, vfrac, sie, temp, press, lambda,
-                  &scratch_d(t * nscratch_vars));
+                  &scratch_d(t * nscratch_vars), Tguess);
           bool success = PTESolver(method);
           if (success) {
             nsuccess_d() += 1;

--- a/test/test_pte.cpp
+++ b/test/test_pte.cpp
@@ -219,7 +219,8 @@ int main(int argc, char *argv[]) {
           }
           sie_tot /= rho_tot;
 
-          const Real Tguess = ApproxTemperatureFromRhoMatU(NMAT, eos, rho_tot*sie_tot, rho, vfrac);
+          const Real Tguess =
+              ApproxTemperatureFromRhoMatU(NMAT, eos, rho_tot * sie_tot, rho, vfrac);
 
           auto method =
               PTESolverRhoT<EOSAccessor, Indexer2D<decltype(rho_d)>, decltype(lambda)>(


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
This PR introduces a function that solves $u_0 = \sum_m \rho_m \alpha_m \epsilon_m(\rho_m, T)$ for the temperature $T$, for fixed input $u_0$ (total material energy density, i.e. $erg/cm^{3}$), $\alpha_m$ (material volume fractions), and $\rho_m$ (material physical densities).  The intent of the function is to be used to provide an initial guess for the PTE solver, so the hard coded tolerance of the solver is quite loose.  Bisection is used because it's better behaved for EOSs that have only a weak dependence of $\epsilon$ on $T$ at cold temperatures.

To go along with this, the PTE solvers have been augmented to allow an initial temperature guess to be (optionally) provided.  If a guess is not provided, or the guess is zero, the solver tries to guess a temperature as before.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
