### PR TITLE
let CMake fail to infer version of Kokkos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added (new features/APIs/variables/...)
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR67]](https://github.com/lanl/singularity-eos/pull/167) allow for the possiblity Kokkos version can't be inferred
 
 ### Fixed (not changing behavior/API/variables/...)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,14 +214,18 @@ if(SINGULARITY_USE_KOKKOS)
   ####
   # TODO: Once it's oppurtune, we will
   #       not support Kokkos < 3.3
-  if(${Kokkos_VERSION_MAJOR}.${Kokkos_VERSION_MINOR} VERSION_LESS "3.3")
-    message(WARNING "`Kokkos` version [${Kokkos_VERSION_MAJOR}.${Kokkos_VERSION_MINOR}] is DEPRECATED, and `singularity-eos` will not support versions < '3.3' in the very near future.")
-    if(SINGULARITY_USE_CUDA)
-      get_filename_component(_compiler_exe ${CMAKE_CXX_COMPILER} NAME)
-      if(NOT _compiler_exe STREQUAL "nvcc_wrapper")
-        message(FATAL_ERROR "To use CUDA offloading with `Kokkos` version <= 3.2, you must use `-DCMAKE_CXX_COMPILER=/path/to/kokkos/bin/nvcc_wrapper` when invoking `cmake`. You may also need to set a Kokkos target architecture via: https://github.com/kokkos/kokkos/wiki/Compiling.")
-      endif()
-   endif() #SINGULARITY_USE_CUDA
+  if((${Kokkos_VERSION_MAJOR} MATCHES "^[0-9]+$") AND (${Kokkos_VERSION_MINOR} MATCHES "^[0-9]+$"))
+    if(${Kokkos_VERSION_MAJOR}.${Kokkos_VERSION_MINOR} VERSION_LESS "3.3")
+      message(WARNING "`Kokkos` version [${Kokkos_VERSION_MAJOR}.${Kokkos_VERSION_MINOR}] is DEPRECATED, and `singularity-eos` will not support versions < '3.3' in the very near future.")
+      if(SINGULARITY_USE_CUDA)
+        get_filename_component(_compiler_exe ${CMAKE_CXX_COMPILER} NAME)
+        if(NOT _compiler_exe STREQUAL "nvcc_wrapper")
+          message(FATAL_ERROR "To use CUDA offloading with `Kokkos` version <= 3.2, you must use `-DCMAKE_CXX_COMPILER=/path/to/kokkos/bin/nvcc_wrapper` when invoking `cmake`. You may also need to set a Kokkos target architecture via: https://github.com/kokkos/kokkos/wiki/Compiling.")
+        endif()
+     endif() #SINGULARITY_USE_CUDA
+    endif() #Kokkos_VERSION_MAJOR
+  else()
+    message(WARNING "`Kokkos` version could not be inferred. Note that versions less than `3.3` are DEPRECATED and may not work properly.")
   endif() #Kokkos_VERSION_MAJOR
   ####
 endif() #SINGULARITY_USE_KOKKOS


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

I recently tried to compile `singularity-eos` against a Kokkos release candidate, rather than a firm version, and I discovered that the version is not appropriately populated in `cmake`. This adds guard rails for this use-case, where `cmake` warns the user that it could not correctly infer `Kokkos`'s version number, but then chugs along anyway.

@mauneyc-LANL please take a look at this. It's somewhat blocking downstream.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
