### PR TITLE
fix fact tests dont build without closure

### DIFF
--- a/.github/workflows/tests_minimal.yml
+++ b/.github/workflows/tests_minimal.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-    tests minimal:
+    tests-minimal:
       name: Run minimal set of tests, to constrain minimal build
       runs-on: ubuntu-latest
 

--- a/.github/workflows/tests_minimal.yml
+++ b/.github/workflows/tests_minimal.yml
@@ -1,4 +1,4 @@
-name: Tests Full
+name: Tests Minimal
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
     branches: [ main ]
 
 jobs:
-    tests:
-      name: Run Unit and Regression Tests
+    tests minimal:
+      name: Run minimal set of tests, to constrain minimal build
       runs-on: ubuntu-latest
 
       steps:
@@ -20,9 +20,7 @@ jobs:
           run: export DEBIAN_FRONTEND=noninteractive
         - name: install dependencies
           run: |
-            sudo apt-get install -y --force-yes -qq build-essential gfortran libhdf5-serial-dev
-            pip install numpy
-            pip install h5py
+            sudo apt-get install -y --force-yes -qq build-essential
         - name: build and run tests
           run: |
             mkdir -p bin
@@ -30,11 +28,12 @@ jobs:
             mkdir -p ${HOME}/install
             cmake -DCMAKE_INSTALL_PREFIX=${HOME}/install \
                   -DSINGULARITY_BUILD_TESTS=ON \
-                  -DSINGULARITY_BUILD_PYTHON=ON \
-                  -DSINGULARITY_USE_HDF5=ON \
+                  -DSINGULARITY_BUILD_PYTHON=OFF \
+                  -DSINGULARITY_USE_HDF5=OFF \
+                  -DSINGULARITY_BUILD_CLOSURE=OFF \
                   -DSINGULARITY_TEST_SESAME=OFF \
-                  -DSINGULARITY_TEST_PYTHON=ON \
-                  -DSINGULARITY_TEST_STELLAR_COLLAPSE=ON \
+                  -DSINGULARITY_TEST_PYTHON=OFF \
+                  -DSINGULARITY_TEST_STELLAR_COLLAPSE=OFF \
                   ..
             make
             make install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Fixed (Repair bugs, etc)
+- [[PR174]](https://github.com/lanl/singularity-eos/pull/174) fix build configuration when closures are disabled
 - [[PR157]](https://github.com/lanl/singularity-eos/pull/157) fix root finders in Gruneisen, Davis, and JWL
 - [[PR151]](https://github.com/lanl/singularity-eos/pull/151) fix module install
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,9 @@ endif ()
 if (SINGULARITY_TEST_SESAME)
   list(APPEND SINGULARITY_PRIVATE_DEFINES SINGULARITY_TEST_SESAME)
 endif()
+if (SINGULARITY_BUILD_CLOSURE)
+  list(APPEND SINGULARITY_PRIVATE_DEFINES SINGULARITY_BUILD_CLOSURE)
+endif()
 
 #------------------------------------------------------------------------------#
 # singularity-eos library

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -378,7 +378,7 @@ SCENARIO("EOS Builder and Modifiers", "[EOSBuilder],[Modifiers][IdealGas]") {
                         igra.BulkModulusFromDensityTemperature(1.2 * r1, T0), 1.e-12));
       }
     }
-#endif
+#endif // SINGULARITY_BUILD_CLOSURE
   }
 }
 

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -25,7 +25,10 @@
 #include <singularity-eos/base/root-finding-1d/root_finding.hpp>
 #include <singularity-eos/eos/eos.hpp>
 #include <singularity-eos/eos/eos_builder.hpp>
+
+#ifdef SINGULARITY_BUILD_CLOSURE
 #include <singularity-eos/eos/singularity_eos.hpp>
+#endif
 
 #ifndef CATCH_CONFIG_RUNNER
 #include "catch2/catch.hpp"
@@ -273,6 +276,7 @@ SCENARIO("EOS Builder and Modifiers", "[EOSBuilder],[Modifiers][IdealGas]") {
         }
       }
     }
+#ifdef SINGULARITY_BUILD_CLOSURE
     WHEN("We construct a non-modifying modifier") {
       EOS ig = IdealGas(gm1, Cv);
       EOS igsh = ScaledEOS<IdealGas>(IdealGas(gm1, Cv), 1.0);
@@ -374,6 +378,7 @@ SCENARIO("EOS Builder and Modifiers", "[EOSBuilder],[Modifiers][IdealGas]") {
                         igra.BulkModulusFromDensityTemperature(1.2 * r1, T0), 1.e-12));
       }
     }
+#endif
   }
 }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

I discovered while debugging some issues for @ktsai7 that the tests do not build with `-DSINGULARITY_BUILD_CLOSURE=OFF` because the closure code is used in `singularity_eos.cpp`, which is called in the tests.

Long term, @dholladay00 I think decoupling closure code from the C/fortran API is probably a good idea. We can tackle that when the xrage-specific stuff moves out of `singularity-eos`. Short term, I have simply fixed the issue by adding appropriate include guards.

I also add a test in github to check that a minimal build configuration can still construct unit tests.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
