### PR TITLE
Instantiate Python classes using typelists

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -19,9 +19,9 @@ pybind11_add_module(singularity_eos
   module.cpp
   modifier_shifted.cpp
   modifier_scaled.cpp
-  modifier_bilinear_ramp.cpp
-  modifier_relativistic.cpp
   modifier_unit_system.cpp
+  modifier_relativistic.cpp
+  modifier_bilinear_ramp.cpp
 )
 target_link_libraries(singularity_eos PRIVATE singularity-eos)
 

--- a/python/modifier_unit_system.cpp
+++ b/python/modifier_unit_system.cpp
@@ -15,86 +15,40 @@
 #include "module.hpp"
 
 template<typename T>
-void unit_system_helper(py::module_ & m) {
-  m.def("UnitSystem", [](T eos, eos_units_init::ThermalUnitsInit, const Real rho_unit, const Real sie_unit, const Real temp_unit){
-    return UnitSystem<T>(std::move(eos), eos_units_init::ThermalUnitsInit(), rho_unit, sie_unit, temp_unit);
+void unit_system_eos_class(py::module_ & m) {
+  // define UnitSystem utility function
+  m.def("UnitSystem", [](typename T::BaseType eos, eos_units_init::ThermalUnitsInit, const Real rho_unit, const Real sie_unit, const Real temp_unit){
+    return T(std::move(eos), eos_units_init::ThermalUnitsInit(), rho_unit, sie_unit, temp_unit);
   }, py::arg("eos"), py::arg("units"), py::arg("rho_unit"), py::arg("sie_unit"), py::arg("temp_unit"));
-  m.def("UnitSystem", [](T eos, eos_units_init::LengthTimeUnitsInit, const Real time_unit, const Real mass_unit, const Real length_unit, const Real temp_unit){
-    return UnitSystem<T>(std::move(eos), eos_units_init::LengthTimeUnitsInit(), time_unit, mass_unit, length_unit, temp_unit);
+  m.def("UnitSystem", [](typename T::BaseType eos, eos_units_init::LengthTimeUnitsInit, const Real time_unit, const Real mass_unit, const Real length_unit, const Real temp_unit){
+    return T(std::move(eos), eos_units_init::LengthTimeUnitsInit(), time_unit, mass_unit, length_unit, temp_unit);
   }, py::arg("eos"), py::arg("units"), py::arg("time_unit"), py::arg("mass_unit"), py::arg("length_unit"), py::arg("temp_unit"));
-  m.def("UnitSystem", [](T eos, const Real rho_unit, const Real sie_unit, const Real temp_unit){
-    return UnitSystem<T>(std::move(eos), rho_unit, sie_unit, temp_unit);
+  m.def("UnitSystem", [](typename T::BaseType eos, const Real rho_unit, const Real sie_unit, const Real temp_unit){
+    return T(std::move(eos), rho_unit, sie_unit, temp_unit);
   }, py::arg("eos"), py::arg("rho_unit"), py::arg("sie_unit"), py::arg("temp_unit"));
-}
 
-template<typename T>
-void unit_system_class_helper(py::module_ & m, std::string name) {
-  eos_class<UnitSystem<T>>(m, std::string("UnitSystem") + name)
+  // define UnitSystem class
+  eos_class<T>(m, T::EosPyType())
     .def(
-      py::init<T, eos_units_init::ThermalUnitsInit, Real, Real, Real>(),
+      py::init<typename T::BaseType, eos_units_init::ThermalUnitsInit, Real, Real, Real>(),
       py::arg("eos"), py::arg("units"), py::arg("rho_unit"), py::arg("sie_unit"), py::arg("temp_unit")
     )
     .def(
-      py::init<T, eos_units_init::LengthTimeUnitsInit, Real, Real, Real, Real>(),
+      py::init<typename T::BaseType, eos_units_init::LengthTimeUnitsInit, Real, Real, Real, Real>(),
       py::arg("eos"), py::arg("units"), py::arg("time_unit"), py::arg("mass_unit"), py::arg("length_unit"), py::arg("temp_unit")
     )
     .def(
-      py::init<T, Real, Real, Real>(),
+      py::init<typename T::BaseType, Real, Real, Real>(),
       py::arg("eos"), py::arg("rho_unit"), py::arg("sie_unit"), py::arg("temp_unit")
     );
 }
 
-template<typename T>
-void unit_system_eos_class(py::module_ & m, const char * name) {
-  // define UnitSystem utility function
-  unit_system_helper<T>(m);
-  unit_system_helper<ShiftedEOS<T>>(m);
-  unit_system_helper<ScaledEOS<T>>(m);
-  unit_system_helper<ScaledEOS<ShiftedEOS<T>>>(m);
-
-  unit_system_class_helper<T>(m, name);
-  unit_system_class_helper<ShiftedEOS<T>>(m, std::string("Shifted") + name);
-  unit_system_class_helper<ScaledEOS<T>>(m, std::string("Scaled") + name);
-  unit_system_class_helper<ScaledEOS<ShiftedEOS<T>>>(m, std::string("ScaledShifted") + name);
-
-  unit_system_helper<BilinearRampEOS<T>>(m);
-  unit_system_helper<BilinearRampEOS<ShiftedEOS<T>>>(m);
-  unit_system_helper<BilinearRampEOS<ScaledEOS<T>>>(m);
-  unit_system_helper<BilinearRampEOS<ScaledEOS<ShiftedEOS<T>>>>(m);
-
-  unit_system_class_helper<BilinearRampEOS<T>>(m, std::string("BilinearRamp") + name);
-  unit_system_class_helper<BilinearRampEOS<ShiftedEOS<T>>>(m, std::string("BilinearRampShifted") + name);
-  unit_system_class_helper<BilinearRampEOS<ScaledEOS<T>>>(m, std::string("BilinearRampScaled") + name);
-  unit_system_class_helper<BilinearRampEOS<ScaledEOS<ShiftedEOS<T>>>>(m, std::string("BilinearRampScaledShifted") + name);
-
-  unit_system_helper<RelativisticEOS<T>>(m);
-  unit_system_helper<RelativisticEOS<ShiftedEOS<T>>>(m);
-  unit_system_helper<RelativisticEOS<ScaledEOS<T>>>(m);
-  unit_system_helper<RelativisticEOS<ScaledEOS<ShiftedEOS<T>>>>(m);
-
-  unit_system_class_helper<RelativisticEOS<T>>(m, std::string("Relativistic") + name);
-  unit_system_class_helper<RelativisticEOS<ShiftedEOS<T>>>(m, std::string("RelativisticShifted") + name);
-  unit_system_class_helper<RelativisticEOS<ScaledEOS<T>>>(m, std::string("RelativisticScaled") + name);
-  unit_system_class_helper<RelativisticEOS<ScaledEOS<ShiftedEOS<T>>>>(m, std::string("RelativisticScaledShifted") + name);
-
-  unit_system_helper<RelativisticEOS<BilinearRampEOS<T>>>(m);
-  unit_system_helper<RelativisticEOS<BilinearRampEOS<ShiftedEOS<T>>>>(m);
-  unit_system_helper<RelativisticEOS<BilinearRampEOS<ScaledEOS<T>>>>(m);
-  unit_system_helper<RelativisticEOS<BilinearRampEOS<ScaledEOS<ShiftedEOS<T>>>>>(m);
-
-  unit_system_class_helper<RelativisticEOS<BilinearRampEOS<T>>>(m, std::string("RelativisticBilinearRamp") + name);
-  unit_system_class_helper<RelativisticEOS<BilinearRampEOS<ShiftedEOS<T>>>>(m, std::string("RelativisticBilinearRampShifted") + name);
-  unit_system_class_helper<RelativisticEOS<BilinearRampEOS<ScaledEOS<T>>>>(m, std::string("RelativisticBilinearRampScaled") + name);
-  unit_system_class_helper<RelativisticEOS<BilinearRampEOS<ScaledEOS<ShiftedEOS<T>>>>>(m, std::string("RelativisticBilinearRampScaledShifted") + name);
+template<typename... Ts>
+void create_unit_system(py::module_ &m, tl<Ts...>) {
+  // C++14 workaround, since we don't have C++17 fold expressions
+  auto l = { (unit_system_eos_class<Ts>(m), 0)... };
 }
 
-
-void create_unit_system_eos_classes(py::module_ & m) {		       
-  unit_system_eos_class<IdealGas>(m, "IdealGas");
-
-#ifdef SPINER_USE_HDF
-  unit_system_eos_class<SpinerEOSDependsRhoT>(m, "SpinerEOSDependsRhoT");
-  unit_system_eos_class<SpinerEOSDependsRhoSie>(m, "SpinerEOSDependsRhoSie");
-  unit_system_eos_class<StellarCollapse>(m, "StellarCollapse");
-#endif
+void create_unit_system_eos_classes(py::module_ & m) {
+  create_unit_system(m, singularity::unit_system);
 }

--- a/singularity-eos/eos/eos.hpp
+++ b/singularity-eos/eos/eos.hpp
@@ -92,6 +92,12 @@ static constexpr const auto scaled =
 // variadic list of Scaled<Shifted<T>>'s
 static constexpr const auto scaled_of_shifted =
     transform_variadic_list(shifted, al<ScaledEOS>{});
+// variadic list of UnitSystem<T>'s
+static constexpr const auto unit_system =
+    transform_variadic_list(partial_eos_list, al<UnitSystem>{});
+// variadic list of Relativistic<T>'s
+static constexpr const auto relativistic =
+    transform_variadic_list(partial_eos_list, al<RelativisticEOS>{});
 // relativistic and unit system modifiers
 static constexpr const auto unit_or_rel =
     transform_variadic_list(partial_eos_list, apply_to_partial);

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -109,6 +109,7 @@ class DavisReactants : public EosBase<DavisReactants> {
   }
   void inline Finalize() {}
   static std::string EosType() { return std::string("DavisReactants"); }
+  static std::string EosPyType() { return EosType(); }
 
  private:
   static constexpr Real onethird = 1.0 / 3.0;
@@ -193,6 +194,7 @@ class DavisProducts : public EosBase<DavisProducts> {
   }
   inline void Finalize() {}
   static std::string EosType() { return std::string("DavisProducts"); }
+  static std::string EosPyType() { return EosType(); }
 
  private:
   static constexpr Real onethird = 1.0 / 3.0;

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -173,6 +173,7 @@ class EOSPAC : public EosBase<EOSPAC> {
   PORTABLE_INLINE_FUNCTION int nlambda() const noexcept { return 0; }
   inline void Finalize() {}
   static std::string EosType() { return std::string("EOSPAC"); }
+  static std::string EosPyType() { return EosType(); }
   inline void PrintParams() const { printf("EOSPAC parameters:\nmatid = %s\n", matid_); }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rho_min_; }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return temp_min_; }

--- a/singularity-eos/eos/eos_gruneisen.hpp
+++ b/singularity-eos/eos/eos_gruneisen.hpp
@@ -119,6 +119,7 @@ class Gruneisen : public EosBase<Gruneisen> {
                                        Real &rho, Real &sie) const;
   inline void Finalize() {}
   static std::string EosType() { return std::string("Gruneisen"); }
+  static std::string EosPyType() { return EosType(); }
 
  private:
   Real _C0, _s1, _s2, _s3, _G0, _b, _rho0, _T0, _P0, _Cv, _rho_max;

--- a/singularity-eos/eos/eos_ideal.hpp
+++ b/singularity-eos/eos/eos_ideal.hpp
@@ -117,6 +117,7 @@ class IdealGas : public EosBase<IdealGas> {
   }
   inline void Finalize() {}
   static std::string EosType() { return std::string("IdealGas"); }
+  static std::string EosPyType() { return EosType(); }
 
  private:
   Real _Cv, _gm1;

--- a/singularity-eos/eos/eos_jwl.hpp
+++ b/singularity-eos/eos/eos_jwl.hpp
@@ -85,6 +85,7 @@ class JWL : public EosBase<JWL> {
                                        Real &rho, Real &sie) const;
   inline void Finalize() {}
   static std::string EosType() { return std::string("JWL"); }
+  static std::string EosPyType() { return EosType(); }
 
  private:
   Real _A, _B, _R1, _R2, _w, _rho0, _Cv;

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -168,6 +168,7 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   RootFinding1D::RootCounts counts;
   inline void Finalize();
   static std::string EosType() { return std::string("SpinerEOSDependsRhoT"); }
+  static std::string EosPyType() { return EosType(); }
 
  private:
   herr_t loadDataboxes_(const std::string &matid_str, hid_t file, hid_t lTGroup,
@@ -393,6 +394,7 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   RootFinding1D::Status rootStatus() const { return status_; }
   RootFinding1D::RootCounts counts;
   static std::string EosType() { return std::string("SpinerEOSDependsRhoSie"); }
+  static std::string EosPyType() { return EosType(); }
   inline void Finalize();
 
  private:

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -166,6 +166,7 @@ class StellarCollapse : public EosBase<StellarCollapse> {
   RootFinding1D::RootCounts counts;
   inline void Finalize();
   static std::string EosType() { return std::string("StellarCollapse"); }
+  static std::string EosPyType() { return EosType(); }
 
  private:
   inline void LoadFromSP5File_(const std::string &filename);

--- a/singularity-eos/eos/modifiers/eos_unitsystem.hpp
+++ b/singularity-eos/eos/modifiers/eos_unitsystem.hpp
@@ -64,10 +64,14 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
   using EosBase<UnitSystem<T>>::PTofRE;
   using EosBase<UnitSystem<T>>::FillEos;
 
+  using BaseType = T;
+
   // give me std::format or fmt::format...
   static std::string EosType() {
     return std::string("UnitSystem<") + T::EosType() + std::string(">");
   }
+
+  static std::string EosPyType() { return std::string("UnitSystem") + T::EosPyType(); }
 
   // move semantics ensures dynamic memory comes along for the ride
   // TODO(JMM): Entropy unit needed?

--- a/singularity-eos/eos/modifiers/ramps_eos.hpp
+++ b/singularity-eos/eos/modifiers/ramps_eos.hpp
@@ -88,10 +88,14 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
   }
   BilinearRampEOS() = default;
 
+  using BaseType = T;
+
   // give me std::format or fmt::format...
   static std::string EosType() {
     return std::string("BilinearRampEOS<") + T::EosType() + std::string(">");
   }
+
+  static std::string EosPyType() { return std::string("BilinearRamp") + T::EosPyType(); }
 
   auto GetOnDevice() { return BilinearRampEOS<T>(t_.GetOnDevice(), r0_, a_, b_, c_); }
   inline void Finalize() { t_.Finalize(); }

--- a/singularity-eos/eos/modifiers/relativistic_eos.hpp
+++ b/singularity-eos/eos/modifiers/relativistic_eos.hpp
@@ -56,10 +56,14 @@ class RelativisticEOS : public EosBase<RelativisticEOS<T>> {
   using EosBase<RelativisticEOS<T>>::PTofRE;
   using EosBase<RelativisticEOS<T>>::FillEos;
 
+  using BaseType = T;
+
   // give me std::format or fmt::format...
   static std::string EosType() {
     return std::string("RelativisticEOS<") + T::EosType() + std::string(">");
   }
+
+  static std::string EosPyType() { return std::string("Relativistic") + T::EosPyType(); }
 
   // move semantics ensures dynamic memory comes along for the ride
   RelativisticEOS(T &&t, const Real cl)

--- a/singularity-eos/eos/modifiers/scaled_eos.hpp
+++ b/singularity-eos/eos/modifiers/scaled_eos.hpp
@@ -56,10 +56,14 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
   using EosBase<ScaledEOS<T>>::PTofRE;
   using EosBase<ScaledEOS<T>>::FillEos;
 
+  using BaseType = T;
+
   // give me std::format or fmt::format...
   static std::string EosType() {
     return std::string("ScaledEOS<") + T::EosType() + std::string(">");
   }
+
+  static std::string EosPyType() { return std::string("Scaled") + T::EosPyType(); }
 
   // move semantics ensures dynamic memory comes along for the ride
   ScaledEOS(T &&t, const Real scale)

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -56,10 +56,14 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
   using EosBase<ShiftedEOS<T>>::PTofRE;
   using EosBase<ShiftedEOS<T>>::FillEos;
 
+  using BaseType = T;
+
   // give me std::format or fmt::format...
   static std::string EosType() {
     return std::string("ShiftedEOS<") + T::EosType() + std::string(">");
   }
+
+  static std::string EosPyType() { return std::string("Shifted") + T::EosPyType(); }
 
   // move semantics ensures dynamic memory comes along for the ride
   ShiftedEOS(T &&t, const Real shift) : t_(std::forward<T>(t)), shift_(shift) {}


### PR DESCRIPTION
## PR Summary

This removes a lot of manual template instantiations and instead uses the available typelists to drive their creation.

@Yurlungur  please note that this **removes** a lot of instantiation that don't seem to be covered in the typelists. E.g. `unit_or_rel` does not contain the `Scaled`, `Shifted` and `ScaledShifted` combinations. I'm guessing that typlist is wrong, based on how it was explained to me previously. Another thing that is missing is `UnitSystem` of all `Relativistic` combinations.

Whatever the right set of variants is, the Python mapping is now only dependent on these typelists.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file
