### PR TITLE
Use HDF5 targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current develop
 
+### Updated `hdf5` handling in the build
+- [[PR181]](https://github.com/lanl/singularity-eos/pull/181) change from manual dependecy handling to using hdf5 interface targets
+
 ### Fixed (Repair bugs, etc)
 - [[PR174]](https://github.com/lanl/singularity-eos/pull/174) fix build configuration when closures are disabled
 - [[PR157]](https://github.com/lanl/singularity-eos/pull/157) fix root finders in Gruneisen, Davis, and JWL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ option (SINGULARITY_TEST_PYTHON "Test the Python bindings" OFF)
 option (SINGULARITY_USE_SINGLE_LOGS "Use single precision logs. Can harm accuracy." OFF)
 option (SINGULARITY_USE_TRUE_LOG_GRIDDING "Use grids that conform to log spacing." OFF)
 option (SINGULARITY_PATCH_MPARK_VARIANT "Apply GPU patch to mpark-variant submodule" ON)
-option (SINGULARITY_LINK_HDF5_FORTRAN "Include HDF5 fortran in link" OFF)
 
 # Patches variant to be compatible with cuda
 # Assumes "patch" is present on system
@@ -280,14 +279,9 @@ if (SINGULARITY_USE_HDF5)
   # hdf5, for data interopability
   # type: external
   enable_language(C)
-  if(SINGULARITY_LINK_HDF5_FORTRAN)
-    set(_hdf5_comp "C;Fortran;HL")
-  else()
-    set(_hdf5_comp "C;HL")
-  endif()
   singularity_import_dependency(
     PKG HDF5
-    COMPONENTS ${_hdf5_comp}
+    COMPONENTS "C;HL"
   )
   # For the moment, there are several versions of
   # HDF5 that are necessary to support, but they 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,22 +280,28 @@ if (SINGULARITY_USE_HDF5)
   # hdf5, for data interopability
   # type: external
   enable_language(C)
-  set(_hdf5_comp "C;HL")
-  set(_hdf5_tars "HDF5::HDF5")# hdf5::hdf5_hl")
   if(SINGULARITY_LINK_HDF5_FORTRAN)
-    set(_hdf5_comp "${_hdf5_comp};Fortran")
-    set(_hdf5_tars "HDF5::HDF5")# hdf5::hdf5_hl hdf5::hdf5_hl_fortran")
+    set(_hdf5_comp "C;Fortran;HL")
+  else()
+    set(_hdf5_comp "C;HL")
   endif()
   singularity_import_dependency(
     PKG HDF5
     COMPONENTS ${_hdf5_comp}
-    TARGET ${_hdf5_tars}
   )
-
-  # make sure we use MPI,
-  # as this requirement is not
-  # transitive in hdf5
-  #  if(HDF5_IS_PARALLEL)
+  # For the moment, there are several versions of
+  # HDF5 that are necessary to support, but they 
+  # have incompatible build targets.
+  # So, for now, we roll a custom `FindHDF5.cmake`,
+  # and then explicilty pull out the libraries.
+  # CMM: I don't love this, but trying to get things
+  # moving for now
+  #TODO: Move this into `cmake/FindHDF5.cmake`
+  get_target_property(_seosh5ll HDF5::HDF5 INTERFACE_LINK_LIBRARIES)
+  get_target_property(_seosh5ic HDF5::HDF5 INTERFACE_INCLUDE_DIRECTORIES)
+  list(APPEND SINGULARITY_PUBLIC_LIBS ${_seosh5ll})
+  list(APPEND SINGULARITY_PUBLIC_INCS ${_seosh5ic})
+  # make sure we use MPI
   if (HDF5_parallel_FOUND)
     # Message passing interface
     # type: external

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,15 +282,7 @@ if (SINGULARITY_USE_HDF5)
   singularity_import_dependency(
     PKG HDF5
     COMPONENTS C HL
-    #NB: 'newer' CMake versions, HDF5s will
-    #    do the `idiomatic` cmake setup,
-    #    and `find_package(HDF5)` will define
-    #    these targets.
-    #    however, some downstream codes
-    #    are still struggling through the
-    #    dark times, so we use the 
-    #    'standard' hack for now
-    #    TARGETS HDF5::HDF5 hdf5::hdf5_hl
+    TARGETS HDF5::HDF5 hdf5::hdf5_hl
   )
 
   # make sure we use MPI,
@@ -305,13 +297,7 @@ if (SINGULARITY_USE_HDF5)
       TARGETS MPI::MPI_CXX
     )
   endif()
-  ####
-  #TODO: when downstream is rescued,
-  #      we can discard these
-  list(APPEND SINGULARITY_PUBLIC_LIBS ${HDF5_LIBRARIES})
-  list(APPEND SINGULARITY_PUBLIC_LIBS ${HDF5_HL_LIBRARIES})
-  list(APPEND SINGULARITY_PUBLIC_INCS ${HDF5_INCLUDE_DIRS})
-  ####
+
   list(APPEND SINGULARITY_PUBLIC_DEFINES SPINER_USE_HDF)
   list(APPEND SINGULARITY_PUBLIC_DEFINES SINGULARITY_USE_HDF)
 endif() # SINGULARITY_USE_HDF5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,10 +281,10 @@ if (SINGULARITY_USE_HDF5)
   # type: external
   enable_language(C)
   set(_hdf5_comp "C;HL")
-  set(_hdf5_tars "HDF5::HDF5 hdf5::hdf5_hl")
+  set(_hdf5_tars "HDF5::HDF5")# hdf5::hdf5_hl")
   if(SINGULARITY_LINK_HDF5_FORTRAN)
     set(_hdf5_comp "${_hdf5_comp};Fortran")
-    set(_hdf5_tars "HDF5::HDF5 hdf5::hdf5_hl hdf5::hdf5_hl_fortran")
+    set(_hdf5_tars "HDF5::HDF5")# hdf5::hdf5_hl hdf5::hdf5_hl_fortran")
   endif()
   singularity_import_dependency(
     PKG HDF5
@@ -295,7 +295,8 @@ if (SINGULARITY_USE_HDF5)
   # make sure we use MPI,
   # as this requirement is not
   # transitive in hdf5
-  if(HDF5_IS_PARALLEL)
+  #  if(HDF5_IS_PARALLEL)
+  if (HDF5_parallel_FOUND)
     # Message passing interface
     # type: external
     singularity_import_dependency(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,10 +281,10 @@ if (SINGULARITY_USE_HDF5)
   # type: external
   enable_language(C)
   set(_hdf5_comp "C;HL")
-  set(_hdf5_tars "HDF5::HDF5;hdf5::hdf5_hl")
+  set(_hdf5_tars "HDF5::HDF5 hdf5::hdf5_hl")
   if(SINGULARITY_LINK_HDF5_FORTRAN)
     set(_hdf5_comp "${_hdf5_comp};Fortran")
-    set(_hdf5_tars "${_hdf5_tars};hdf5::hdf5_hl_fortran")
+    set(_hdf5_tars "HDF5::HDF5 hdf5::hdf5_hl hdf5::hdf5_hl_fortran")
   endif()
   singularity_import_dependency(
     PKG HDF5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ if (SINGULARITY_USE_HDF5)
   singularity_import_dependency(
     PKG HDF5
     COMPONENTS C HL
-    TARGETS HDF5::HDF5 hdf5::hdf5_hl
+    TARGETS HDF5::HDF5 hdf5::hdf5_hl hdf5::hdf5_hl_fortran
   )
 
   # make sure we use MPI,
@@ -360,7 +360,7 @@ if (SINGULARITY_USE_FORTRAN)
   set_target_properties(singularity-eos PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   target_include_directories(singularity-eos INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/singularity-eos/eos>
   )
 endif() # SINGULARITY_USE_FORTRAN
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,7 +289,7 @@ if (SINGULARITY_USE_HDF5)
   singularity_import_dependency(
     PKG HDF5
     COMPONENTS ${_hdf5_comp}
-    TARGETS ${_hdf5_tars}
+    TARGET ${_hdf5_tars}
   )
 
   # make sure we use MPI,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,10 +279,16 @@ if (SINGULARITY_USE_HDF5)
   # hdf5, for data interopability
   # type: external
   enable_language(C)
+  set(_hdf5_comp "C;HL")
+  set(_hdf5_tars "HDF5::HDF5;hdf5::hdf5_hl")
+  if(SINGULARITY_USE_FORTRAN)
+    set(_hdf5_comp "${_hdf5_comp};Fortran")
+    set(_hdf5_tars "${_hdf5_tars};hdf5::hdf5_hl_fortran")
+  endif()
   singularity_import_dependency(
     PKG HDF5
-    COMPONENTS C HL
-    TARGETS HDF5::HDF5 hdf5::hdf5_hl hdf5::hdf5_hl_fortran
+    COMPONENTS ${_hdf5_comp}
+    TARGETS ${_hdf5_tars}
   )
 
   # make sure we use MPI,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option (SINGULARITY_TEST_PYTHON "Test the Python bindings" OFF)
 option (SINGULARITY_USE_SINGLE_LOGS "Use single precision logs. Can harm accuracy." OFF)
 option (SINGULARITY_USE_TRUE_LOG_GRIDDING "Use grids that conform to log spacing." OFF)
 option (SINGULARITY_PATCH_MPARK_VARIANT "Apply GPU patch to mpark-variant submodule" ON)
+option (SINGULARITY_LINK_HDF5_FORTRAN "Include HDF5 fortran in link" OFF)
 
 # Patches variant to be compatible with cuda
 # Assumes "patch" is present on system
@@ -281,7 +282,7 @@ if (SINGULARITY_USE_HDF5)
   enable_language(C)
   set(_hdf5_comp "C;HL")
   set(_hdf5_tars "HDF5::HDF5;hdf5::hdf5_hl")
-  if(SINGULARITY_USE_FORTRAN)
+  if(SINGULARITY_LINK_HDF5_FORTRAN)
     set(_hdf5_comp "${_hdf5_comp};Fortran")
     set(_hdf5_tars "${_hdf5_tars};hdf5::hdf5_hl_fortran")
   endif()

--- a/cmake/FindHDF5.cmake
+++ b/cmake/FindHDF5.cmake
@@ -1,0 +1,1228 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindHDF5
+--------
+
+Find Hierarchical Data Format (HDF5), a library for reading and writing
+self describing array data.
+
+
+This module invokes the ``HDF5`` wrapper compiler that should be installed
+alongside ``HDF5``.  Depending upon the ``HDF5`` Configuration, the wrapper
+compiler is called either ``h5cc`` or ``h5pcc``.  If this succeeds, the module
+will then call the compiler with the show argument to see what flags
+are used when compiling an ``HDF5`` client application.
+
+The module will optionally accept the ``COMPONENTS`` argument.  If no
+``COMPONENTS`` are specified, then the find module will default to finding
+only the ``HDF5`` C library.  If one or more ``COMPONENTS`` are specified, the
+module will attempt to find the language bindings for the specified
+components.  The valid components are ``C``, ``CXX``, ``Fortran``, ``HL``.
+``HL`` refers to the "high-level" HDF5 functions for C and Fortran.
+If the ``COMPONENTS`` argument is not given, the module will
+attempt to find only the C bindings.
+For example, to use Fortran HDF5 and HDF5-HL functions, do:
+``find_package(HDF5 COMPONENTS Fortran HL)``.
+
+This module will read the variable
+``HDF5_USE_STATIC_LIBRARIES`` to determine whether or not to prefer a
+static link to a dynamic link for ``HDF5`` and all of it's dependencies.
+To use this feature, make sure that the ``HDF5_USE_STATIC_LIBRARIES``
+variable is set before the call to find_package.
+
+.. versionadded:: 3.10
+  Support for ``HDF5_USE_STATIC_LIBRARIES`` on Windows.
+
+Both the serial and parallel ``HDF5`` wrappers are considered and the first
+directory to contain either one will be used.  In the event that both appear
+in the same directory the serial version is preferentially selected. This
+behavior can be reversed by setting the variable ``HDF5_PREFER_PARALLEL`` to
+``TRUE``.
+
+In addition to finding the includes and libraries required to compile
+an ``HDF5`` client application, this module also makes an effort to find
+tools that come with the ``HDF5`` distribution that may be useful for
+regression testing.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project:
+
+``HDF5_FOUND``
+  HDF5 was found on the system
+``HDF5_VERSION``
+  .. versionadded:: 3.3
+    HDF5 library version
+``HDF5_INCLUDE_DIRS``
+  Location of the HDF5 header files
+``HDF5_DEFINITIONS``
+  Required compiler definitions for HDF5
+``HDF5_LIBRARIES``
+  Required libraries for all requested bindings
+``HDF5_HL_LIBRARIES``
+  Required libraries for the HDF5 high level API for all bindings,
+  if the ``HL`` component is enabled
+
+Available components are: ``C`` ``CXX`` ``Fortran`` and ``HL``.
+For each enabled language binding, a corresponding ``HDF5_${LANG}_LIBRARIES``
+variable, and potentially ``HDF5_${LANG}_DEFINITIONS``, will be defined.
+If the ``HL`` component is enabled, then an ``HDF5_${LANG}_HL_LIBRARIES`` will
+also be defined.  With all components enabled, the following variables will be defined:
+
+``HDF5_C_DEFINITIONS``
+  Required compiler definitions for HDF5 C bindings
+``HDF5_CXX_DEFINITIONS``
+  Required compiler definitions for HDF5 C++ bindings
+``HDF5_Fortran_DEFINITIONS``
+  Required compiler definitions for HDF5 Fortran bindings
+``HDF5_C_INCLUDE_DIRS``
+  Required include directories for HDF5 C bindings
+``HDF5_CXX_INCLUDE_DIRS``
+  Required include directories for HDF5 C++ bindings
+``HDF5_Fortran_INCLUDE_DIRS``
+  Required include directories for HDF5 Fortran bindings
+``HDF5_C_LIBRARIES``
+  Required libraries for the HDF5 C bindings
+``HDF5_CXX_LIBRARIES``
+  Required libraries for the HDF5 C++ bindings
+``HDF5_Fortran_LIBRARIES``
+  Required libraries for the HDF5 Fortran bindings
+``HDF5_C_HL_LIBRARIES``
+  Required libraries for the high level C bindings
+``HDF5_CXX_HL_LIBRARIES``
+  Required libraries for the high level C++ bindings
+``HDF5_Fortran_HL_LIBRARIES``
+  Required libraries for the high level Fortran bindings.
+
+``HDF5_IS_PARALLEL``
+  HDF5 library has parallel IO support
+``HDF5_C_COMPILER_EXECUTABLE``
+  path to the HDF5 C wrapper compiler
+``HDF5_CXX_COMPILER_EXECUTABLE``
+  path to the HDF5 C++ wrapper compiler
+``HDF5_Fortran_COMPILER_EXECUTABLE``
+  path to the HDF5 Fortran wrapper compiler
+``HDF5_C_COMPILER_EXECUTABLE_NO_INTERROGATE``
+  path to the primary C compiler which is also the HDF5 wrapper
+``HDF5_CXX_COMPILER_EXECUTABLE_NO_INTERROGATE``
+  path to the primary C++ compiler which is also the HDF5 wrapper
+``HDF5_Fortran_COMPILER_EXECUTABLE_NO_INTERROGATE``
+  path to the primary Fortran compiler which is also the HDF5 wrapper
+``HDF5_DIFF_EXECUTABLE``
+  path to the HDF5 dataset comparison tool
+
+With all components enabled, the following targets will be defined:
+
+``HDF5::HDF5``
+  All detected ``HDF5_LIBRARIES``.
+``hdf5::hdf5``
+  C library.
+``hdf5::hdf5_cpp``
+  C++ library.
+``hdf5::hdf5_fortran``
+  Fortran library.
+``hdf5::hdf5_hl``
+  High-level C library.
+``hdf5::hdf5_hl_cpp``
+  High-level C++ library.
+``hdf5::hdf5_hl_fortran``
+  High-level Fortran library.
+``hdf5::h5diff``
+  ``h5diff`` executable.
+
+Hints
+^^^^^
+
+The following variables can be set to guide the search for HDF5 libraries and includes:
+
+``HDF5_PREFER_PARALLEL``
+  .. versionadded:: 3.4
+
+  set ``true`` to prefer parallel HDF5 (by default, serial is preferred)
+
+``HDF5_FIND_DEBUG``
+  .. versionadded:: 3.9
+
+  Set ``true`` to get extra debugging output.
+
+``HDF5_NO_FIND_PACKAGE_CONFIG_FILE``
+  .. versionadded:: 3.8
+
+  Set ``true`` to skip trying to find ``hdf5-config.cmake``.
+#]=======================================================================]
+
+include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+
+# We haven't found HDF5 yet. Clear its state in case it is set in the parent
+# scope somewhere else. We can't rely on it because different components may
+# have been requested for this call.
+set(HDF5_FOUND OFF)
+set(HDF5_LIBRARIES)
+set(HDF5_HL_LIBRARIES)
+
+# List of the valid HDF5 components
+set(HDF5_VALID_LANGUAGE_BINDINGS C CXX Fortran)
+
+# Validate the list of find components.
+if(NOT HDF5_FIND_COMPONENTS)
+  set(HDF5_LANGUAGE_BINDINGS "C")
+else()
+  set(HDF5_LANGUAGE_BINDINGS)
+  # add the extra specified components, ensuring that they are valid.
+  set(HDF5_FIND_HL OFF)
+  foreach(_component IN LISTS HDF5_FIND_COMPONENTS)
+    list(FIND HDF5_VALID_LANGUAGE_BINDINGS ${_component} _component_location)
+    if(NOT _component_location EQUAL -1)
+      list(APPEND HDF5_LANGUAGE_BINDINGS ${_component})
+    elseif(_component STREQUAL "HL")
+      set(HDF5_FIND_HL ON)
+    elseif(_component STREQUAL "Fortran_HL") # only for compatibility
+      list(APPEND HDF5_LANGUAGE_BINDINGS Fortran)
+      set(HDF5_FIND_HL ON)
+      set(HDF5_FIND_REQUIRED_Fortran_HL FALSE)
+      set(HDF5_FIND_REQUIRED_Fortran TRUE)
+      set(HDF5_FIND_REQUIRED_HL TRUE)
+    else()
+      message(FATAL_ERROR "${_component} is not a valid HDF5 component.")
+    endif()
+  endforeach()
+  unset(_component)
+  unset(_component_location)
+  if(NOT HDF5_LANGUAGE_BINDINGS)
+    get_property(_langs GLOBAL PROPERTY ENABLED_LANGUAGES)
+    foreach(_lang IN LISTS _langs)
+      if(_lang MATCHES "^(C|CXX|Fortran)$")
+        list(APPEND HDF5_LANGUAGE_BINDINGS ${_lang})
+      endif()
+    endforeach()
+  endif()
+  list(REMOVE_ITEM HDF5_FIND_COMPONENTS Fortran_HL) # replaced by Fortran and HL
+  list(REMOVE_DUPLICATES HDF5_LANGUAGE_BINDINGS)
+endif()
+
+# Determine whether to search for serial or parallel executable first
+if(HDF5_PREFER_PARALLEL)
+  set(HDF5_C_COMPILER_NAMES h5pcc h5cc)
+  set(HDF5_CXX_COMPILER_NAMES h5pc++ h5c++)
+  set(HDF5_Fortran_COMPILER_NAMES h5pfc h5fc)
+else()
+  set(HDF5_C_COMPILER_NAMES h5cc h5pcc)
+  set(HDF5_CXX_COMPILER_NAMES h5c++ h5pc++)
+  set(HDF5_Fortran_COMPILER_NAMES h5fc h5pfc)
+endif()
+
+# Test first if the current compilers automatically wrap HDF5
+function(_HDF5_test_regular_compiler_C success version is_parallel)
+  set(scratch_directory
+    ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hdf5)
+  if(NOT ${success} OR
+     NOT EXISTS ${scratch_directory}/compiler_has_h5_c)
+    set(test_file ${scratch_directory}/cmake_hdf5_test.c)
+    file(WRITE ${test_file}
+      "#include <hdf5.h>\n"
+      "const char* info_ver = \"INFO\" \":\" H5_VERSION;\n"
+      "#ifdef H5_HAVE_PARALLEL\n"
+      "const char* info_parallel = \"INFO\" \":\" \"PARALLEL\";\n"
+      "#endif\n"
+      "int main(int argc, char **argv) {\n"
+      "  int require = 0;\n"
+      "  require += info_ver[argc];\n"
+      "#ifdef H5_HAVE_PARALLEL\n"
+      "  require += info_parallel[argc];\n"
+      "#endif\n"
+      "  hid_t fid;\n"
+      "  fid = H5Fcreate(\"foo.h5\",H5F_ACC_TRUNC,H5P_DEFAULT,H5P_DEFAULT);\n"
+      "  return 0;\n"
+      "}")
+    try_compile(${success} SOURCES ${test_file}
+      COPY_FILE ${scratch_directory}/compiler_has_h5_c
+    )
+  endif()
+  if(${success} AND EXISTS ${scratch_directory}/compiler_has_h5_c)
+    file(STRINGS ${scratch_directory}/compiler_has_h5_c INFO_STRINGS
+      REGEX "^INFO:"
+    )
+    string(REGEX MATCH "^INFO:([0-9]+\\.[0-9]+\\.[0-9]+)(-patch([0-9]+))?"
+      INFO_VER "${INFO_STRINGS}"
+    )
+    set(${version} ${CMAKE_MATCH_1})
+    if(CMAKE_MATCH_3)
+      set(${version} ${HDF5_C_VERSION}.${CMAKE_MATCH_3})
+    endif()
+    set(${version} ${${version}} PARENT_SCOPE)
+
+    if(INFO_STRINGS MATCHES "INFO:PARALLEL")
+      set(${is_parallel} TRUE PARENT_SCOPE)
+    else()
+      set(${is_parallel} FALSE PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()
+
+function(_HDF5_test_regular_compiler_CXX success version is_parallel)
+  set(scratch_directory ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hdf5)
+  if(NOT ${success} OR
+     NOT EXISTS ${scratch_directory}/compiler_has_h5_cxx)
+    set(test_file ${scratch_directory}/cmake_hdf5_test.cxx)
+    file(WRITE ${test_file}
+      "#include <H5Cpp.h>\n"
+      "#ifndef H5_NO_NAMESPACE\n"
+      "using namespace H5;\n"
+      "#endif\n"
+      "const char* info_ver = \"INFO\" \":\" H5_VERSION;\n"
+      "#ifdef H5_HAVE_PARALLEL\n"
+      "const char* info_parallel = \"INFO\" \":\" \"PARALLEL\";\n"
+      "#endif\n"
+      "int main(int argc, char **argv) {\n"
+      "  int require = 0;\n"
+      "  require += info_ver[argc];\n"
+      "#ifdef H5_HAVE_PARALLEL\n"
+      "  require += info_parallel[argc];\n"
+      "#endif\n"
+      "  H5File file(\"foo.h5\", H5F_ACC_TRUNC);\n"
+      "  return 0;\n"
+      "}")
+    try_compile(${success} SOURCES ${test_file}
+      COPY_FILE ${scratch_directory}/compiler_has_h5_cxx
+    )
+  endif()
+  if(${success} AND EXISTS ${scratch_directory}/compiler_has_h5_cxx)
+    file(STRINGS ${scratch_directory}/compiler_has_h5_cxx INFO_STRINGS
+      REGEX "^INFO:"
+    )
+    string(REGEX MATCH "^INFO:([0-9]+\\.[0-9]+\\.[0-9]+)(-patch([0-9]+))?"
+      INFO_VER "${INFO_STRINGS}"
+    )
+    set(${version} ${CMAKE_MATCH_1})
+    if(CMAKE_MATCH_3)
+      set(${version} ${HDF5_CXX_VERSION}.${CMAKE_MATCH_3})
+    endif()
+    set(${version} ${${version}} PARENT_SCOPE)
+
+    if(INFO_STRINGS MATCHES "INFO:PARALLEL")
+      set(${is_parallel} TRUE PARENT_SCOPE)
+    else()
+      set(${is_parallel} FALSE PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()
+
+function(_HDF5_test_regular_compiler_Fortran success is_parallel)
+  if(NOT ${success})
+    set(scratch_directory
+      ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hdf5)
+    set(test_file ${scratch_directory}/cmake_hdf5_test.f90)
+    file(WRITE ${test_file}
+      "program hdf5_hello\n"
+      "  use hdf5\n"
+      "  integer error\n"
+      "  call h5open_f(error)\n"
+      "  call h5close_f(error)\n"
+      "end\n")
+    try_compile(${success} SOURCES ${test_file})
+    if(${success})
+      execute_process(COMMAND ${CMAKE_Fortran_COMPILER} -showconfig
+        OUTPUT_VARIABLE config_output
+        ERROR_VARIABLE config_error
+        RESULT_VARIABLE config_result
+        )
+      if(config_output MATCHES "Parallel HDF5: yes")
+        set(${is_parallel} TRUE PARENT_SCOPE)
+      else()
+        set(${is_parallel} FALSE PARENT_SCOPE)
+      endif()
+    endif()
+  endif()
+endfunction()
+
+# Invoke the HDF5 wrapper compiler.  The compiler return value is stored to the
+# return_value argument, the text output is stored to the output variable.
+function( _HDF5_invoke_compiler language output_var return_value_var version_var is_parallel_var)
+  set(is_parallel FALSE)
+  if(HDF5_USE_STATIC_LIBRARIES)
+    set(lib_type_args -noshlib)
+  else()
+    set(lib_type_args -shlib)
+  endif()
+  set(scratch_dir ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hdf5)
+  if("${language}" STREQUAL "C")
+    set(test_file ${scratch_dir}/cmake_hdf5_test.c)
+  elseif("${language}" STREQUAL "CXX")
+    set(test_file ${scratch_dir}/cmake_hdf5_test.cxx)
+  elseif("${language}" STREQUAL "Fortran")
+    set(test_file ${scratch_dir}/cmake_hdf5_test.f90)
+  endif()
+  # Verify that the compiler wrapper can actually compile: sometimes the compiler
+  # wrapper exists, but not the compiler.  E.g. Miniconda / Anaconda Python
+  execute_process(
+    COMMAND ${HDF5_${language}_COMPILER_EXECUTABLE} ${test_file}
+    WORKING_DIRECTORY ${scratch_dir}
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE output
+    RESULT_VARIABLE return_value
+    )
+  if(return_value AND NOT HDF5_FIND_QUIETLY)
+    message(STATUS
+      "HDF5 ${language} compiler wrapper is unable to compile a minimal HDF5 program.")
+  else()
+    execute_process(
+      COMMAND ${HDF5_${language}_COMPILER_EXECUTABLE} -show ${lib_type_args} ${test_file}
+      WORKING_DIRECTORY ${scratch_dir}
+      OUTPUT_VARIABLE output
+      ERROR_VARIABLE output
+      RESULT_VARIABLE return_value
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    if(return_value AND NOT HDF5_FIND_QUIETLY)
+      message(STATUS
+        "Unable to determine HDF5 ${language} flags from HDF5 wrapper.")
+    endif()
+    execute_process(
+      COMMAND ${HDF5_${language}_COMPILER_EXECUTABLE} -showconfig
+      OUTPUT_VARIABLE config_output
+      ERROR_VARIABLE config_output
+      RESULT_VARIABLE return_value
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    if(return_value AND NOT HDF5_FIND_QUIETLY)
+      message(STATUS
+        "Unable to determine HDF5 ${language} version_var from HDF5 wrapper.")
+    endif()
+    string(REGEX MATCH "HDF5 Version: ([a-zA-Z0-9\\.\\-]*)" version "${config_output}")
+    if(version)
+      string(REPLACE "HDF5 Version: " "" version "${version}")
+      string(REPLACE "-patch" "." version "${version}")
+    endif()
+    if(config_output MATCHES "Parallel HDF5: yes")
+      set(is_parallel TRUE)
+    endif()
+  endif()
+  foreach(var output return_value version is_parallel)
+    set(${${var}_var} ${${var}} PARENT_SCOPE)
+  endforeach()
+endfunction()
+
+# Parse a compile line for definitions, includes, library paths, and libraries.
+function(_HDF5_parse_compile_line compile_line_var include_paths definitions
+    library_paths libraries libraries_hl)
+
+  separate_arguments(_compile_args NATIVE_COMMAND "${${compile_line_var}}")
+
+  foreach(_arg IN LISTS _compile_args)
+    if("${_arg}" MATCHES "^-I(.*)$")
+      # include directory
+      list(APPEND include_paths "${CMAKE_MATCH_1}")
+    elseif("${_arg}" MATCHES "^-D(.*)$")
+      # compile definition
+      list(APPEND definitions "-D${CMAKE_MATCH_1}")
+    elseif("${_arg}" MATCHES "^-L(.*)$")
+      # library search path
+      list(APPEND library_paths "${CMAKE_MATCH_1}")
+    elseif("${_arg}" MATCHES "^-l(hdf5.*hl.*)$")
+      # library name (hl)
+      list(APPEND libraries_hl "${CMAKE_MATCH_1}")
+    elseif("${_arg}" MATCHES "^-l(.*)$")
+      # library name
+      list(APPEND libraries "${CMAKE_MATCH_1}")
+    elseif("${_arg}" MATCHES "^(.:)?[/\\].*\\.(a|so|dylib|sl|lib)$")
+      # library file
+      if(NOT EXISTS "${_arg}")
+        continue()
+      endif()
+      get_filename_component(_lpath "${_arg}" DIRECTORY)
+      get_filename_component(_lname "${_arg}" NAME_WE)
+      string(REGEX REPLACE "^lib" "" _lname "${_lname}")
+      list(APPEND library_paths "${_lpath}")
+      if(_lname MATCHES "hdf5.*hl")
+        list(APPEND libraries_hl "${_lname}")
+      else()
+        list(APPEND libraries "${_lname}")
+      endif()
+    endif()
+  endforeach()
+  foreach(var include_paths definitions library_paths libraries libraries_hl)
+    set(${${var}_var} ${${var}} PARENT_SCOPE)
+  endforeach()
+endfunction()
+
+# Select a preferred imported configuration from a target
+function(_HDF5_select_imported_config target imported_conf)
+    # We will first assign the value to a local variable _imported_conf, then assign
+    # it to the function argument at the end.
+    get_target_property(_imported_conf ${target} MAP_IMPORTED_CONFIG_${CMAKE_BUILD_TYPE})
+    if (NOT _imported_conf)
+        # Get available imported configurations by examining target properties
+        get_target_property(_imported_conf ${target} IMPORTED_CONFIGURATIONS)
+        if(HDF5_FIND_DEBUG)
+            message(STATUS "Found imported configurations: ${_imported_conf}")
+        endif()
+        # Find the imported configuration that we prefer.
+        # We do this by making list of configurations in order of preference,
+        # starting with ${CMAKE_BUILD_TYPE} and ending with the first imported_conf
+        set(_preferred_confs ${CMAKE_BUILD_TYPE})
+        list(GET _imported_conf 0 _fallback_conf)
+        list(APPEND _preferred_confs RELWITHDEBINFO RELEASE DEBUG ${_fallback_conf})
+        if(HDF5_FIND_DEBUG)
+            message(STATUS "Start search through imported configurations in the following order: ${_preferred_confs}")
+        endif()
+        # Now find the first of these that is present in imported_conf
+        cmake_policy(PUSH)
+        cmake_policy(SET CMP0057 NEW) # support IN_LISTS
+        foreach (_conf IN LISTS _preferred_confs)
+            if (${_conf} IN_LIST _imported_conf)
+               set(_imported_conf ${_conf})
+               break()
+            endif()
+        endforeach()
+        cmake_policy(POP)
+    endif()
+    if(HDF5_FIND_DEBUG)
+        message(STATUS "Selected imported configuration: ${_imported_conf}")
+    endif()
+    # assign value to function argument
+    set(${imported_conf} ${_imported_conf} PARENT_SCOPE)
+endfunction()
+
+
+if(NOT HDF5_ROOT)
+    set(HDF5_ROOT $ENV{HDF5_ROOT})
+endif()
+if(HDF5_ROOT)
+    set(_HDF5_SEARCH_OPTS NO_DEFAULT_PATH)
+else()
+    set(_HDF5_SEARCH_OPTS)
+endif()
+
+# Try to find HDF5 using an installed hdf5-config.cmake
+if(NOT HDF5_FOUND AND NOT HDF5_NO_FIND_PACKAGE_CONFIG_FILE)
+    find_package(HDF5 QUIET NO_MODULE
+      HINTS ${HDF5_ROOT}
+      ${_HDF5_SEARCH_OPTS}
+      )
+    if( HDF5_FOUND)
+        if(HDF5_FIND_DEBUG)
+            message(STATUS "Found HDF5 at ${HDF5_DIR} via NO_MODULE. Now trying to extract locations etc.")
+        endif()
+        set(HDF5_IS_PARALLEL ${HDF5_ENABLE_PARALLEL})
+        set(HDF5_INCLUDE_DIRS ${HDF5_INCLUDE_DIR})
+        set(HDF5_LIBRARIES)
+        if (NOT TARGET hdf5 AND NOT TARGET hdf5-static AND NOT TARGET hdf5-shared)
+            # Some HDF5 versions (e.g. 1.8.18) used hdf5::hdf5 etc
+            set(_target_prefix "hdf5::")
+        endif()
+        set(HDF5_C_TARGET ${_target_prefix}hdf5)
+        set(HDF5_C_HL_TARGET ${_target_prefix}hdf5_hl)
+        set(HDF5_CXX_TARGET ${_target_prefix}hdf5_cpp)
+        set(HDF5_CXX_HL_TARGET ${_target_prefix}hdf5_hl_cpp)
+        set(HDF5_Fortran_TARGET ${_target_prefix}hdf5_fortran)
+        set(HDF5_Fortran_HL_TARGET ${_target_prefix}hdf5_hl_fortran)
+        set(HDF5_DEFINITIONS "")
+        if(HDF5_USE_STATIC_LIBRARIES)
+            set(_suffix "-static")
+        else()
+            set(_suffix "-shared")
+        endif()
+        foreach(_lang ${HDF5_LANGUAGE_BINDINGS})
+
+            #Older versions of hdf5 don't have a static/shared suffix so
+            #if we detect that occurrence clear the suffix
+            if(_suffix AND NOT TARGET ${HDF5_${_lang}_TARGET}${_suffix})
+              if(NOT TARGET ${HDF5_${_lang}_TARGET})
+                #can't find this component with or without the suffix
+                #so bail out, and let the following locate HDF5
+                set(HDF5_FOUND FALSE)
+                break()
+              endif()
+              set(_suffix "")
+            endif()
+
+            if(HDF5_FIND_DEBUG)
+                message(STATUS "Trying to get properties of target ${HDF5_${_lang}_TARGET}${_suffix}")
+            endif()
+            # Find library for this target. Complicated as on Windows with a DLL, we need to search for the import-lib.
+            _HDF5_select_imported_config(${HDF5_${_lang}_TARGET}${_suffix} _hdf5_imported_conf)
+            get_target_property(_hdf5_lang_location ${HDF5_${_lang}_TARGET}${_suffix} IMPORTED_IMPLIB_${_hdf5_imported_conf} )
+            if (NOT _hdf5_lang_location)
+                # no import lib, just try LOCATION
+                get_target_property(_hdf5_lang_location ${HDF5_${_lang}_TARGET}${_suffix} LOCATION_${_hdf5_imported_conf})
+                if (NOT _hdf5_lang_location)
+                    get_target_property(_hdf5_lang_location ${HDF5_${_lang}_TARGET}${_suffix} LOCATION)
+                endif()
+            endif()
+            if( _hdf5_lang_location )
+                set(HDF5_${_lang}_LIBRARY ${_hdf5_lang_location})
+                list(APPEND HDF5_LIBRARIES ${HDF5_${_lang}_TARGET}${_suffix})
+                set(HDF5_${_lang}_LIBRARIES ${HDF5_${_lang}_TARGET}${_suffix})
+                set(HDF5_${_lang}_FOUND TRUE)
+            endif()
+            if(HDF5_FIND_HL)
+                get_target_property(_hdf5_lang_hl_location ${HDF5_${_lang}_HL_TARGET}${_suffix} IMPORTED_IMPLIB_${_hdf5_imported_conf} )
+                if (NOT _hdf5_lang_hl_location)
+                    get_target_property(_hdf5_lang_hl_location ${HDF5_${_lang}_HL_TARGET}${_suffix} LOCATION_${_hdf5_imported_conf})
+                    if (NOT _hdf5_hl_lang_location)
+                        get_target_property(_hdf5_hl_lang_location ${HDF5_${_lang}_HL_TARGET}${_suffix} LOCATION)
+                    endif()
+                endif()
+                if( _hdf5_lang_hl_location )
+                    set(HDF5_${_lang}_HL_LIBRARY ${_hdf5_lang_hl_location})
+                    list(APPEND HDF5_HL_LIBRARIES ${HDF5_${_lang}_HL_TARGET}${_suffix})
+                    set(HDF5_${_lang}_HL_LIBRARIES ${HDF5_${_lang}_HL_TARGET}${_suffix})
+                    set(HDF5_HL_FOUND TRUE)
+                endif()
+                unset(_hdf5_lang_hl_location)
+            endif()
+            unset(_hdf5_imported_conf)
+            unset(_hdf5_lang_location)
+        endforeach()
+    endif()
+endif()
+
+if(NOT HDF5_FOUND)
+  set(_HDF5_NEED_TO_SEARCH FALSE)
+  set(HDF5_COMPILER_NO_INTERROGATE TRUE)
+  # Only search for languages we've enabled
+  foreach(_lang IN LISTS HDF5_LANGUAGE_BINDINGS)
+    set(HDF5_${_lang}_LIBRARIES)
+    set(HDF5_${_lang}_HL_LIBRARIES)
+
+    # First check to see if our regular compiler is one of wrappers
+    if(_lang STREQUAL "C")
+      _HDF5_test_regular_compiler_C(
+        HDF5_${_lang}_COMPILER_NO_INTERROGATE
+        HDF5_${_lang}_VERSION
+        HDF5_${_lang}_IS_PARALLEL)
+    elseif(_lang STREQUAL "CXX")
+      _HDF5_test_regular_compiler_CXX(
+        HDF5_${_lang}_COMPILER_NO_INTERROGATE
+        HDF5_${_lang}_VERSION
+        HDF5_${_lang}_IS_PARALLEL)
+    elseif(_lang STREQUAL "Fortran")
+      _HDF5_test_regular_compiler_Fortran(
+        HDF5_${_lang}_COMPILER_NO_INTERROGATE
+        HDF5_${_lang}_IS_PARALLEL)
+    else()
+      continue()
+    endif()
+    if(HDF5_${_lang}_COMPILER_NO_INTERROGATE)
+      if(HDF5_FIND_DEBUG)
+        message(STATUS "HDF5: Using hdf5 compiler wrapper for all ${_lang} compiling")
+      endif()
+      set(HDF5_${_lang}_FOUND TRUE)
+      set(HDF5_${_lang}_COMPILER_EXECUTABLE_NO_INTERROGATE
+          "${CMAKE_${_lang}_COMPILER}"
+          CACHE FILEPATH "HDF5 ${_lang} compiler wrapper")
+      set(HDF5_${_lang}_DEFINITIONS)
+      set(HDF5_${_lang}_INCLUDE_DIRS)
+      set(HDF5_${_lang}_LIBRARIES)
+      set(HDF5_${_lang}_HL_LIBRARIES)
+
+      mark_as_advanced(HDF5_${_lang}_COMPILER_EXECUTABLE_NO_INTERROGATE)
+
+      set(HDF5_${_lang}_FOUND TRUE)
+      set(HDF5_HL_FOUND TRUE)
+    else()
+      set(HDF5_COMPILER_NO_INTERROGATE FALSE)
+      # If this language isn't using the wrapper, then try to seed the
+      # search options with the wrapper
+      find_program(HDF5_${_lang}_COMPILER_EXECUTABLE
+        NAMES ${HDF5_${_lang}_COMPILER_NAMES} NAMES_PER_DIR
+        HINTS ${HDF5_ROOT}
+        PATH_SUFFIXES bin Bin
+        DOC "HDF5 ${_lang} Wrapper compiler.  Used only to detect HDF5 compile flags."
+        ${_HDF5_SEARCH_OPTS}
+      )
+      mark_as_advanced( HDF5_${_lang}_COMPILER_EXECUTABLE )
+      unset(HDF5_${_lang}_COMPILER_NAMES)
+
+      if(HDF5_${_lang}_COMPILER_EXECUTABLE)
+        _HDF5_invoke_compiler(${_lang} HDF5_${_lang}_COMPILE_LINE
+          HDF5_${_lang}_RETURN_VALUE HDF5_${_lang}_VERSION HDF5_${_lang}_IS_PARALLEL)
+        if(HDF5_${_lang}_RETURN_VALUE EQUAL 0)
+          if(HDF5_FIND_DEBUG)
+            message(STATUS "HDF5: Using hdf5 compiler wrapper to determine ${_lang} configuration")
+          endif()
+          _HDF5_parse_compile_line( HDF5_${_lang}_COMPILE_LINE
+            HDF5_${_lang}_INCLUDE_DIRS
+            HDF5_${_lang}_DEFINITIONS
+            HDF5_${_lang}_LIBRARY_DIRS
+            HDF5_${_lang}_LIBRARY_NAMES
+            HDF5_${_lang}_HL_LIBRARY_NAMES
+          )
+          set(HDF5_${_lang}_LIBRARIES)
+
+          foreach(_lib IN LISTS HDF5_${_lang}_LIBRARY_NAMES)
+            set(_HDF5_SEARCH_NAMES_LOCAL)
+            if("x${_lib}" MATCHES "hdf5")
+              # hdf5 library
+              set(_HDF5_SEARCH_OPTS_LOCAL ${_HDF5_SEARCH_OPTS})
+              if(HDF5_USE_STATIC_LIBRARIES)
+                if(WIN32)
+                  set(_HDF5_SEARCH_NAMES_LOCAL lib${_lib})
+                else()
+                  set(_HDF5_SEARCH_NAMES_LOCAL lib${_lib}.a)
+                endif()
+              endif()
+            else()
+              # external library
+              set(_HDF5_SEARCH_OPTS_LOCAL)
+            endif()
+            find_library(HDF5_${_lang}_LIBRARY_${_lib}
+              NAMES ${_HDF5_SEARCH_NAMES_LOCAL} ${_lib} NAMES_PER_DIR
+              HINTS ${HDF5_${_lang}_LIBRARY_DIRS}
+                    ${HDF5_ROOT}
+              ${_HDF5_SEARCH_OPTS_LOCAL}
+              )
+            unset(_HDF5_SEARCH_OPTS_LOCAL)
+            unset(_HDF5_SEARCH_NAMES_LOCAL)
+            if(HDF5_${_lang}_LIBRARY_${_lib})
+              list(APPEND HDF5_${_lang}_LIBRARIES ${HDF5_${_lang}_LIBRARY_${_lib}})
+            else()
+              list(APPEND HDF5_${_lang}_LIBRARIES ${_lib})
+            endif()
+          endforeach()
+          if(HDF5_FIND_HL)
+            set(HDF5_${_lang}_HL_LIBRARIES)
+            foreach(_lib IN LISTS HDF5_${_lang}_HL_LIBRARY_NAMES)
+              set(_HDF5_SEARCH_NAMES_LOCAL)
+              if("x${_lib}" MATCHES "hdf5")
+                # hdf5 library
+                set(_HDF5_SEARCH_OPTS_LOCAL ${_HDF5_SEARCH_OPTS})
+                if(HDF5_USE_STATIC_LIBRARIES)
+                  if(WIN32)
+                    set(_HDF5_SEARCH_NAMES_LOCAL lib${_lib})
+                  else()
+                    set(_HDF5_SEARCH_NAMES_LOCAL lib${_lib}.a)
+                  endif()
+                endif()
+              else()
+                # external library
+                set(_HDF5_SEARCH_OPTS_LOCAL)
+              endif()
+              find_library(HDF5_${_lang}_LIBRARY_${_lib}
+                NAMES ${_HDF5_SEARCH_NAMES_LOCAL} ${_lib} NAMES_PER_DIR
+                HINTS ${HDF5_${_lang}_LIBRARY_DIRS}
+                      ${HDF5_ROOT}
+                ${_HDF5_SEARCH_OPTS_LOCAL}
+                )
+              unset(_HDF5_SEARCH_OPTS_LOCAL)
+              unset(_HDF5_SEARCH_NAMES_LOCAL)
+              if(HDF5_${_lang}_LIBRARY_${_lib})
+                list(APPEND HDF5_${_lang}_HL_LIBRARIES ${HDF5_${_lang}_LIBRARY_${_lib}})
+              else()
+                list(APPEND HDF5_${_lang}_HL_LIBRARIES ${_lib})
+              endif()
+            endforeach()
+            set(HDF5_HL_FOUND TRUE)
+          endif()
+
+          set(HDF5_${_lang}_FOUND TRUE)
+          list(REMOVE_DUPLICATES HDF5_${_lang}_DEFINITIONS)
+          list(REMOVE_DUPLICATES HDF5_${_lang}_INCLUDE_DIRS)
+        else()
+          set(_HDF5_NEED_TO_SEARCH TRUE)
+        endif()
+      else()
+        set(_HDF5_NEED_TO_SEARCH TRUE)
+      endif()
+    endif()
+    if(HDF5_${_lang}_VERSION)
+      if(NOT HDF5_VERSION)
+        set(HDF5_VERSION ${HDF5_${_lang}_VERSION})
+      elseif(NOT HDF5_VERSION VERSION_EQUAL HDF5_${_lang}_VERSION)
+        message(WARNING "HDF5 Version found for language ${_lang}, ${HDF5_${_lang}_VERSION} is different than previously found version ${HDF5_VERSION}")
+      endif()
+    endif()
+    if(DEFINED HDF5_${_lang}_IS_PARALLEL)
+      if(NOT DEFINED HDF5_IS_PARALLEL)
+        set(HDF5_IS_PARALLEL ${HDF5_${_lang}_IS_PARALLEL})
+      elseif(NOT HDF5_IS_PARALLEL AND HDF5_${_lang}_IS_PARALLEL)
+        message(WARNING "HDF5 found for language ${_lang} is parallel but previously found language is not parallel.")
+      elseif(HDF5_IS_PARALLEL AND NOT HDF5_${_lang}_IS_PARALLEL)
+        message(WARNING "HDF5 found for language ${_lang} is not parallel but previously found language is parallel.")
+      endif()
+    endif()
+  endforeach()
+  unset(_lib)
+else()
+  set(_HDF5_NEED_TO_SEARCH TRUE)
+endif()
+
+if(NOT HDF5_FOUND AND HDF5_COMPILER_NO_INTERROGATE)
+  # No arguments necessary, all languages can use the compiler wrappers
+  set(HDF5_FOUND TRUE)
+  set(HDF5_METHOD "Included by compiler wrappers")
+  set(HDF5_REQUIRED_VARS HDF5_METHOD)
+elseif(NOT HDF5_FOUND AND NOT _HDF5_NEED_TO_SEARCH)
+  # Compiler wrappers aren't being used by the build but were found and used
+  # to determine necessary include and library flags
+  set(HDF5_INCLUDE_DIRS)
+  set(HDF5_LIBRARIES)
+  set(HDF5_HL_LIBRARIES)
+  foreach(_lang IN LISTS HDF5_LANGUAGE_BINDINGS)
+    if(HDF5_${_lang}_FOUND)
+      if(NOT HDF5_${_lang}_COMPILER_NO_INTERROGATE)
+        list(APPEND HDF5_DEFINITIONS ${HDF5_${_lang}_DEFINITIONS})
+        list(APPEND HDF5_INCLUDE_DIRS ${HDF5_${_lang}_INCLUDE_DIRS})
+        list(APPEND HDF5_LIBRARIES ${HDF5_${_lang}_LIBRARIES})
+        if(HDF5_FIND_HL)
+          list(APPEND HDF5_HL_LIBRARIES ${HDF5_${_lang}_HL_LIBRARIES})
+        endif()
+      endif()
+    endif()
+  endforeach()
+  list(REMOVE_DUPLICATES HDF5_DEFINITIONS)
+  list(REMOVE_DUPLICATES HDF5_INCLUDE_DIRS)
+  set(HDF5_FOUND TRUE)
+  set(HDF5_REQUIRED_VARS HDF5_LIBRARIES)
+  if(HDF5_FIND_HL)
+    list(APPEND HDF5_REQUIRED_VARS HDF5_HL_LIBRARIES)
+  endif()
+endif()
+
+find_program( HDF5_DIFF_EXECUTABLE
+    NAMES h5diff
+    HINTS ${HDF5_ROOT}
+    PATH_SUFFIXES bin Bin
+    ${_HDF5_SEARCH_OPTS}
+    DOC "HDF5 file differencing tool." )
+mark_as_advanced( HDF5_DIFF_EXECUTABLE )
+
+if( NOT HDF5_FOUND )
+    # seed the initial lists of libraries to find with items we know we need
+    set(HDF5_C_LIBRARY_NAMES          hdf5)
+    set(HDF5_C_HL_LIBRARY_NAMES       hdf5_hl ${HDF5_C_LIBRARY_NAMES} )
+
+    set(HDF5_CXX_LIBRARY_NAMES        hdf5_cpp    ${HDF5_C_LIBRARY_NAMES})
+    set(HDF5_CXX_HL_LIBRARY_NAMES     hdf5_hl_cpp ${HDF5_C_HL_LIBRARY_NAMES} ${HDF5_CXX_LIBRARY_NAMES})
+
+    set(HDF5_Fortran_LIBRARY_NAMES    hdf5_fortran   ${HDF5_C_LIBRARY_NAMES})
+    set(HDF5_Fortran_HL_LIBRARY_NAMES hdf5_hl_fortran hdf5hl_fortran ${HDF5_C_HL_LIBRARY_NAMES} ${HDF5_Fortran_LIBRARY_NAMES})
+
+    # suffixes as seen on Linux, MSYS2, ...
+    set(_lib_suffixes hdf5)
+    if(NOT HDF5_PREFER_PARALLEL)
+      list(APPEND _lib_suffixes hdf5/serial)
+    endif()
+    if(HDF5_USE_STATIC_LIBRARIES)
+      set(_inc_suffixes include/static)
+    else()
+      set(_inc_suffixes include/shared)
+    endif()
+
+    foreach(_lang IN LISTS HDF5_LANGUAGE_BINDINGS)
+        set(HDF5_${_lang}_LIBRARIES)
+        set(HDF5_${_lang}_HL_LIBRARIES)
+
+        # The "main" library.
+        set(_hdf5_main_library "")
+
+        # find the HDF5 libraries
+        foreach(LIB IN LISTS HDF5_${_lang}_LIBRARY_NAMES)
+            if(HDF5_USE_STATIC_LIBRARIES)
+                # According to bug 1643 on the CMake bug tracker, this is the
+                # preferred method for searching for a static library.
+                # See https://gitlab.kitware.com/cmake/cmake/-/issues/1643.  We search
+                # first for the full static library name, but fall back to a
+                # generic search on the name if the static search fails.
+                set( THIS_LIBRARY_SEARCH_DEBUG
+                    lib${LIB}d.a lib${LIB}_debug.a lib${LIB}d lib${LIB}_D lib${LIB}_debug
+                    lib${LIB}d-static.a lib${LIB}_debug-static.a ${LIB}d-static ${LIB}_D-static ${LIB}_debug-static )
+                set( THIS_LIBRARY_SEARCH_RELEASE lib${LIB}.a lib${LIB} lib${LIB}-static.a ${LIB}-static)
+            else()
+                set( THIS_LIBRARY_SEARCH_DEBUG ${LIB}d ${LIB}_D ${LIB}_debug ${LIB}d-shared ${LIB}_D-shared ${LIB}_debug-shared)
+                set( THIS_LIBRARY_SEARCH_RELEASE ${LIB} ${LIB}-shared)
+                if(WIN32)
+                  list(APPEND HDF5_DEFINITIONS "-DH5_BUILT_AS_DYNAMIC_LIB")
+                endif()
+            endif()
+            find_library(HDF5_${LIB}_LIBRARY_DEBUG
+                NAMES ${THIS_LIBRARY_SEARCH_DEBUG}
+                HINTS ${HDF5_ROOT} PATH_SUFFIXES lib Lib ${_lib_suffixes}
+                ${_HDF5_SEARCH_OPTS}
+            )
+            find_library(HDF5_${LIB}_LIBRARY_RELEASE
+                NAMES ${THIS_LIBRARY_SEARCH_RELEASE}
+                HINTS ${HDF5_ROOT} PATH_SUFFIXES lib Lib ${_lib_suffixes}
+                ${_HDF5_SEARCH_OPTS}
+            )
+
+            # Set the "main" library if not already set.
+            if (NOT _hdf5_main_library)
+              if (HDF5_${LIB}_LIBRARY_RELEASE)
+                set(_hdf5_main_library "${HDF5_${LIB}_LIBRARY_RELEASE}")
+              elseif (HDF5_${LIB}_LIBRARY_DEBUG)
+                set(_hdf5_main_library "${HDF5_${LIB}_LIBRARY_DEBUG}")
+              endif ()
+            endif ()
+
+            select_library_configurations( HDF5_${LIB} )
+            list(APPEND HDF5_${_lang}_LIBRARIES ${HDF5_${LIB}_LIBRARY})
+        endforeach()
+        if(HDF5_${_lang}_LIBRARIES)
+            set(HDF5_${_lang}_FOUND TRUE)
+        endif()
+
+        # Append the libraries for this language binding to the list of all
+        # required libraries.
+        list(APPEND HDF5_LIBRARIES ${HDF5_${_lang}_LIBRARIES})
+
+        # find the HDF5 include directories
+        set(_hdf5_inc_extra_paths)
+        set(_hdf5_inc_extra_suffixes)
+        if("${_lang}" STREQUAL "Fortran")
+            set(HDF5_INCLUDE_FILENAME hdf5.mod HDF5.mod)
+
+            # Add library-based search paths for Fortran modules.
+            if (NOT _hdf5_main_library STREQUAL "")
+              # gfortran module directory
+              if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "LCC")
+                get_filename_component(_hdf5_library_dir "${_hdf5_main_library}" DIRECTORY)
+                list(APPEND _hdf5_inc_extra_paths "${_hdf5_library_dir}")
+                unset(_hdf5_library_dir)
+                list(APPEND _hdf5_inc_extra_suffixes gfortran/modules)
+              endif ()
+            endif ()
+        elseif("${_lang}" STREQUAL "CXX")
+            set(HDF5_INCLUDE_FILENAME H5Cpp.h)
+        else()
+            set(HDF5_INCLUDE_FILENAME hdf5.h)
+        endif()
+
+        unset(_hdf5_main_library)
+
+        find_path(HDF5_${_lang}_INCLUDE_DIR ${HDF5_INCLUDE_FILENAME}
+            HINTS ${HDF5_ROOT}
+            PATHS $ENV{HOME}/.local/include ${_hdf5_inc_extra_paths}
+            PATH_SUFFIXES include Include ${_inc_suffixes} ${_lib_suffixes} ${_hdf5_inc_extra_suffixes}
+            ${_HDF5_SEARCH_OPTS}
+        )
+        mark_as_advanced(HDF5_${_lang}_INCLUDE_DIR)
+        unset(_hdf5_inc_extra_paths)
+        unset(_hdf5_inc_extra_suffixes)
+        # set the _DIRS variable as this is what the user will normally use
+        set(HDF5_${_lang}_INCLUDE_DIRS ${HDF5_${_lang}_INCLUDE_DIR})
+        list(APPEND HDF5_INCLUDE_DIRS ${HDF5_${_lang}_INCLUDE_DIR})
+
+        if(HDF5_FIND_HL)
+            foreach(LIB IN LISTS HDF5_${_lang}_HL_LIBRARY_NAMES)
+                if(HDF5_USE_STATIC_LIBRARIES)
+                    # According to bug 1643 on the CMake bug tracker, this is the
+                    # preferred method for searching for a static library.
+                    # See https://gitlab.kitware.com/cmake/cmake/-/issues/1643.  We search
+                    # first for the full static library name, but fall back to a
+                    # generic search on the name if the static search fails.
+                    set( THIS_LIBRARY_SEARCH_DEBUG
+                        lib${LIB}d.a lib${LIB}_debug.a lib${LIB}d lib${LIB}_D lib${LIB}_debug
+                        lib${LIB}d-static.a lib${LIB}_debug-static.a lib${LIB}d-static lib${LIB}_D-static lib${LIB}_debug-static )
+                    set( THIS_LIBRARY_SEARCH_RELEASE lib${LIB}.a lib${LIB} lib${LIB}-static.a lib${LIB}-static)
+                else()
+                    set( THIS_LIBRARY_SEARCH_DEBUG ${LIB}d ${LIB}_D ${LIB}_debug ${LIB}d-shared ${LIB}_D-shared ${LIB}_debug-shared)
+                    set( THIS_LIBRARY_SEARCH_RELEASE ${LIB} ${LIB}-shared)
+                endif()
+                find_library(HDF5_${LIB}_LIBRARY_DEBUG
+                    NAMES ${THIS_LIBRARY_SEARCH_DEBUG}
+                    HINTS ${HDF5_ROOT} PATH_SUFFIXES lib Lib ${_lib_suffixes}
+                    ${_HDF5_SEARCH_OPTS}
+                )
+                find_library(HDF5_${LIB}_LIBRARY_RELEASE
+                    NAMES ${THIS_LIBRARY_SEARCH_RELEASE}
+                    HINTS ${HDF5_ROOT} PATH_SUFFIXES lib Lib ${_lib_suffixes}
+                    ${_HDF5_SEARCH_OPTS}
+                )
+
+                select_library_configurations( HDF5_${LIB} )
+                list(APPEND HDF5_${_lang}_HL_LIBRARIES ${HDF5_${LIB}_LIBRARY})
+            endforeach()
+
+            # Append the libraries for this language binding to the list of all
+            # required libraries.
+            list(APPEND HDF5_HL_LIBRARIES ${HDF5_${_lang}_HL_LIBRARIES})
+        endif()
+    endforeach()
+    if(HDF5_FIND_HL AND HDF5_HL_LIBRARIES)
+        set(HDF5_HL_FOUND TRUE)
+    endif()
+
+    list(REMOVE_DUPLICATES HDF5_DEFINITIONS)
+    list(REMOVE_DUPLICATES HDF5_INCLUDE_DIRS)
+
+    # If the HDF5 include directory was found, open H5pubconf.h to determine if
+    # HDF5 was compiled with parallel IO support
+    set( HDF5_IS_PARALLEL FALSE )
+    set( HDF5_VERSION "" )
+    foreach( _dir IN LISTS HDF5_INCLUDE_DIRS )
+      foreach(_hdr "${_dir}/H5pubconf.h" "${_dir}/H5pubconf-64.h" "${_dir}/H5pubconf-32.h")
+        if( EXISTS "${_hdr}" )
+            file( STRINGS "${_hdr}"
+                HDF5_HAVE_PARALLEL_DEFINE
+                REGEX "HAVE_PARALLEL 1" )
+            if( HDF5_HAVE_PARALLEL_DEFINE )
+                set( HDF5_IS_PARALLEL TRUE )
+            endif()
+            unset(HDF5_HAVE_PARALLEL_DEFINE)
+
+            file( STRINGS "${_hdr}"
+                HDF5_VERSION_DEFINE
+                REGEX "^[ \t]*#[ \t]*define[ \t]+H5_VERSION[ \t]+" )
+            if( "${HDF5_VERSION_DEFINE}" MATCHES
+                "H5_VERSION[ \t]+\"([0-9]+\\.[0-9]+\\.[0-9]+)(-patch([0-9]+))?\"" )
+                set( HDF5_VERSION "${CMAKE_MATCH_1}" )
+                if( CMAKE_MATCH_3 )
+                  set( HDF5_VERSION ${HDF5_VERSION}.${CMAKE_MATCH_3})
+                endif()
+            endif()
+            unset(HDF5_VERSION_DEFINE)
+        endif()
+      endforeach()
+    endforeach()
+    unset(_hdr)
+    unset(_dir)
+    set( HDF5_IS_PARALLEL ${HDF5_IS_PARALLEL} CACHE BOOL
+        "HDF5 library compiled with parallel IO support" )
+    mark_as_advanced( HDF5_IS_PARALLEL )
+
+    set(HDF5_REQUIRED_VARS HDF5_LIBRARIES HDF5_INCLUDE_DIRS)
+    if(HDF5_FIND_HL)
+        list(APPEND HDF5_REQUIRED_VARS HDF5_HL_LIBRARIES)
+    endif()
+endif()
+
+# For backwards compatibility we set HDF5_INCLUDE_DIR to the value of
+# HDF5_INCLUDE_DIRS
+if( HDF5_INCLUDE_DIRS )
+  set( HDF5_INCLUDE_DIR "${HDF5_INCLUDE_DIRS}" )
+endif()
+
+# If HDF5_REQUIRED_VARS is empty at this point, then it's likely that
+# something external is trying to explicitly pass already found
+# locations
+if(NOT HDF5_REQUIRED_VARS)
+    set(HDF5_REQUIRED_VARS HDF5_LIBRARIES HDF5_INCLUDE_DIRS)
+endif()
+
+find_package_handle_standard_args(HDF5
+    REQUIRED_VARS ${HDF5_REQUIRED_VARS}
+    VERSION_VAR   HDF5_VERSION
+    HANDLE_COMPONENTS
+)
+
+unset(_HDF5_SEARCH_OPTS)
+
+if( HDF5_FOUND AND NOT HDF5_DIR)
+  # hide HDF5_DIR for the non-advanced user to avoid confusion with
+  # HDF5_DIR-NOT_FOUND while HDF5 was found.
+  mark_as_advanced(HDF5_DIR)
+endif()
+
+if (HDF5_FOUND)
+  if (NOT TARGET HDF5::HDF5)
+    add_library(HDF5::HDF5 INTERFACE IMPORTED)
+    string(REPLACE "-D" "" _hdf5_definitions "${HDF5_DEFINITIONS}")
+    set_target_properties(HDF5::HDF5 PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${HDF5_INCLUDE_DIRS}"
+      INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
+    unset(_hdf5_definitions)
+    target_link_libraries(HDF5::HDF5 INTERFACE ${HDF5_LIBRARIES})
+  endif ()
+
+  foreach (hdf5_lang IN LISTS HDF5_LANGUAGE_BINDINGS)
+    if (hdf5_lang STREQUAL "C")
+      set(hdf5_target_name "hdf5")
+    elseif (hdf5_lang STREQUAL "CXX")
+      set(hdf5_target_name "hdf5_cpp")
+    elseif (hdf5_lang STREQUAL "Fortran")
+      set(hdf5_target_name "hdf5_fortran")
+    else ()
+      continue ()
+    endif ()
+
+    if (NOT TARGET "hdf5::${hdf5_target_name}")
+      if (HDF5_COMPILER_NO_INTERROGATE)
+        add_library("hdf5::${hdf5_target_name}" INTERFACE IMPORTED)
+        string(REPLACE "-D" "" _hdf5_definitions "${HDF5_${hdf5_lang}_DEFINITIONS}")
+        set_target_properties("hdf5::${hdf5_target_name}" PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${HDF5_${hdf5_lang}_INCLUDE_DIRS}"
+          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
+      else()
+        if (DEFINED "HDF5_${hdf5_target_name}_LIBRARY")
+          set(_hdf5_location "${HDF5_${hdf5_target_name}_LIBRARY}")
+          set(_hdf5_location_release "${HDF5_${hdf5_target_name}_LIBRARY_RELEASE}")
+          set(_hdf5_location_debug "${HDF5_${hdf5_target_name}_LIBRARY_DEBUG}")
+        elseif (DEFINED "HDF5_${hdf5_lang}_LIBRARY")
+          set(_hdf5_location "${HDF5_${hdf5_lang}_LIBRARY}")
+          set(_hdf5_location_release "${HDF5_${hdf5_lang}_LIBRARY_RELEASE}")
+          set(_hdf5_location_debug "${HDF5_${hdf5_lang}_LIBRARY_DEBUG}")
+        elseif (DEFINED "HDF5_${hdf5_lang}_LIBRARY_${hdf5_target_name}")
+          set(_hdf5_location "${HDF5_${hdf5_lang}_LIBRARY_${hdf5_target_name}}")
+        else ()
+          # Error if we still don't have the location.
+          message(SEND_ERROR
+            "HDF5 was found, but a different variable was set which contains "
+            "the location of the `hdf5::${hdf5_target_name}` library.")
+        endif ()
+        add_library("hdf5::${hdf5_target_name}" UNKNOWN IMPORTED)
+        string(REPLACE "-D" "" _hdf5_definitions "${HDF5_${hdf5_lang}_DEFINITIONS}")
+        if (NOT HDF5_${hdf5_lang}_INCLUDE_DIRS)
+         set(HDF5_${hdf5_lang}_INCLUDE_DIRS ${HDF5_INCLUDE_DIRS})
+        endif ()
+        set_target_properties("hdf5::${hdf5_target_name}" PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${HDF5_${hdf5_lang}_INCLUDE_DIRS}"
+          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
+        if (_hdf5_location_release)
+          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND PROPERTY
+            IMPORTED_CONFIGURATIONS RELEASE)
+          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
+            IMPORTED_LOCATION_RELEASE "${_hdf5_location_release}")
+        endif()
+        if (_hdf5_location_debug)
+          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND PROPERTY
+            IMPORTED_CONFIGURATIONS DEBUG)
+          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
+            IMPORTED_LOCATION_DEBUG "${_hdf5_location_debug}")
+        endif()
+        if (NOT _hdf5_location_release AND NOT _hdf5_location_debug)
+          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
+            IMPORTED_LOCATION "${_hdf5_location}")
+        endif()
+        if (_hdf5_libtype STREQUAL "SHARED")
+          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND
+            PROPERTY
+              INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_DYNAMIC_LIB)
+        elseif (_hdf5_libtype STREQUAL "STATIC")
+          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND
+            PROPERTY
+              INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_STATIC_LIB)
+        endif ()
+        unset(_hdf5_definitions)
+        unset(_hdf5_libtype)
+        unset(_hdf5_location)
+        unset(_hdf5_location_release)
+        unset(_hdf5_location_debug)
+      endif ()
+    endif ()
+
+    if (NOT HDF5_FIND_HL)
+      continue ()
+    endif ()
+
+    set(hdf5_alt_target_name "")
+    if (hdf5_lang STREQUAL "C")
+      set(hdf5_target_name "hdf5_hl")
+    elseif (hdf5_lang STREQUAL "CXX")
+      set(hdf5_target_name "hdf5_hl_cpp")
+    elseif (hdf5_lang STREQUAL "Fortran")
+      set(hdf5_target_name "hdf5_hl_fortran")
+      set(hdf5_alt_target_name "hdf5hl_fortran")
+    else ()
+      continue ()
+    endif ()
+
+    if (NOT TARGET "hdf5::${hdf5_target_name}")
+      if (HDF5_COMPILER_NO_INTERROGATE)
+        add_library("hdf5::${hdf5_target_name}" INTERFACE IMPORTED)
+        string(REPLACE "-D" "" _hdf5_definitions "${HDF5_${hdf5_lang}_HL_DEFINITIONS}")
+        set_target_properties("hdf5::${hdf5_target_name}" PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${HDF5_${hdf5_lang}_HL_INCLUDE_DIRS}"
+          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
+      else()
+        if (DEFINED "HDF5_${hdf5_target_name}_LIBRARY")
+          set(_hdf5_location "${HDF5_${hdf5_target_name}_LIBRARY}")
+          set(_hdf5_location_release "${HDF5_${hdf5_target_name}_LIBRARY_RELEASE}")
+          set(_hdf5_location_debug "${HDF5_${hdf5_target_name}_LIBRARY_DEBUG}")
+        elseif (DEFINED "HDF5_${hdf5_lang}_HL_LIBRARY")
+          set(_hdf5_location "${HDF5_${hdf5_lang}_HL_LIBRARY}")
+          set(_hdf5_location_release "${HDF5_${hdf5_lang}_HL_LIBRARY_RELEASE}")
+          set(_hdf5_location_debug "${HDF5_${hdf5_lang}_HL_LIBRARY_DEBUG}")
+        elseif (DEFINED "HDF5_${hdf5_lang}_LIBRARY_${hdf5_target_name}")
+          set(_hdf5_location "${HDF5_${hdf5_lang}_LIBRARY_${hdf5_target_name}}")
+        elseif (hdf5_alt_target_name AND DEFINED "HDF5_${hdf5_lang}_LIBRARY_${hdf5_alt_target_name}")
+          set(_hdf5_location "${HDF5_${hdf5_lang}_LIBRARY_${hdf5_alt_target_name}}")
+        else ()
+          # Error if we still don't have the location.
+          message(SEND_ERROR
+            "HDF5 was found, but a different variable was set which contains "
+            "the location of the `hdf5::${hdf5_target_name}` library.")
+        endif ()
+        add_library("hdf5::${hdf5_target_name}" UNKNOWN IMPORTED)
+        string(REPLACE "-D" "" _hdf5_definitions "${HDF5_${hdf5_lang}_HL_DEFINITIONS}")
+        set_target_properties("hdf5::${hdf5_target_name}" PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${HDF5_${hdf5_lang}_HL_INCLUDE_DIRS}"
+          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
+        if (_hdf5_location_release)
+          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND PROPERTY
+            IMPORTED_CONFIGURATIONS RELEASE)
+          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
+            IMPORTED_LOCATION_RELEASE "${_hdf5_location_release}")
+        endif()
+        if (_hdf5_location_debug)
+          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND PROPERTY
+            IMPORTED_CONFIGURATIONS DEBUG)
+          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
+            IMPORTED_LOCATION_DEBUG "${_hdf5_location_debug}")
+        endif()
+        if (NOT _hdf5_location_release AND NOT _hdf5_location_debug)
+          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
+            IMPORTED_LOCATION "${_hdf5_location}")
+        endif()
+        if (_hdf5_libtype STREQUAL "SHARED")
+          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND
+            PROPERTY
+              INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_DYNAMIC_LIB)
+        elseif (_hdf5_libtype STREQUAL "STATIC")
+          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND
+            PROPERTY
+              INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_STATIC_LIB)
+        endif ()
+        unset(_hdf5_definitions)
+        unset(_hdf5_libtype)
+        unset(_hdf5_location)
+      endif ()
+    endif ()
+  endforeach ()
+  unset(hdf5_lang)
+
+  if (HDF5_DIFF_EXECUTABLE AND NOT TARGET hdf5::h5diff)
+    add_executable(hdf5::h5diff IMPORTED)
+    set_target_properties(hdf5::h5diff PROPERTIES
+      IMPORTED_LOCATION "${HDF5_DIFF_EXECUTABLE}")
+  endif ()
+endif ()
+
+if (HDF5_FIND_DEBUG)
+  message(STATUS "HDF5_DIR: ${HDF5_DIR}")
+  message(STATUS "HDF5_DEFINITIONS: ${HDF5_DEFINITIONS}")
+  message(STATUS "HDF5_INCLUDE_DIRS: ${HDF5_INCLUDE_DIRS}")
+  message(STATUS "HDF5_LIBRARIES: ${HDF5_LIBRARIES}")
+  message(STATUS "HDF5_HL_LIBRARIES: ${HDF5_HL_LIBRARIES}")
+  foreach(_lang IN LISTS HDF5_LANGUAGE_BINDINGS)
+    message(STATUS "HDF5_${_lang}_DEFINITIONS: ${HDF5_${_lang}_DEFINITIONS}")
+    message(STATUS "HDF5_${_lang}_INCLUDE_DIR: ${HDF5_${_lang}_INCLUDE_DIR}")
+    message(STATUS "HDF5_${_lang}_INCLUDE_DIRS: ${HDF5_${_lang}_INCLUDE_DIRS}")
+    message(STATUS "HDF5_${_lang}_LIBRARY: ${HDF5_${_lang}_LIBRARY}")
+    message(STATUS "HDF5_${_lang}_LIBRARIES: ${HDF5_${_lang}_LIBRARIES}")
+    message(STATUS "HDF5_${_lang}_HL_LIBRARY: ${HDF5_${_lang}_HL_LIBRARY}")
+    message(STATUS "HDF5_${_lang}_HL_LIBRARIES: ${HDF5_${_lang}_HL_LIBRARIES}")
+  endforeach()
+  message(STATUS "Defined targets (if any):")
+  foreach(_lang IN  ITEMS "" "_cpp" "_fortran")
+    foreach(_hl IN  ITEMS "" "_hl")
+      foreach(_prefix IN ITEMS "hdf5::" "")
+        foreach(_suffix IN ITEMS "-static" "-shared" "")
+          set (_target ${_prefix}hdf5${_hl}${_lang}${_suffix})
+          if (TARGET  ${_target})
+            message(STATUS "... ${_target}")
+          else()
+            #message(STATUS "... ${_target} does not exist")
+          endif()
+        endforeach()
+      endforeach()
+    endforeach()
+  endforeach()
+endif()
+unset(_lang)
+unset(_HDF5_NEED_TO_SEARCH)
+

--- a/cmake/FindHDF5.cmake
+++ b/cmake/FindHDF5.cmake
@@ -154,8 +154,8 @@ The following variables can be set to guide the search for HDF5 libraries and in
   Set ``true`` to skip trying to find ``hdf5-config.cmake``.
 #]=======================================================================]
 
-include(SelectLibraryConfigurations.cmake)
-include(FindPackageHandleStandardArgs.cmake)
+include(SelectLibraryConfigurations)
+include(FindPackageHandleStandardArgs)
 
 # We haven't found HDF5 yet. Clear its state in case it is set in the parent
 # scope somewhere else. We can't rely on it because different components may

--- a/cmake/FindHDF5.cmake
+++ b/cmake/FindHDF5.cmake
@@ -1,3 +1,66 @@
+# From https://github.com/geospace-code/h5fortran/blob/main/cmake/FindHDF5.cmake
+
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+
+FindHDF5
+---------
+
+by Michael Hirsch www.scivision.dev
+
+Finds HDF5 library for C, CXX, Fortran. Serial or parallel HDF5.
+
+Environment variable ``HDF5MPI_ROOT`` or CMake variable HDF5MPI_ROOT can
+specify the location of the HDF5-MPI parallel library.
+
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+``HDF5_FOUND``
+  HDF5 libraries were found
+
+``HDF5_INCLUDE_DIRS``
+  HDF5 include directory
+
+``HDF5_LIBRARIES``
+  HDF5 library files
+
+``HDF5_<lang>_COMPILER_EXECUTABLE``
+  wrapper compiler for HDF5
+
+``HDF5_HAVE_PARALLEL``
+  HDF5 links the MPI library (thus user program must link MPI as well)
+
+Components
+==========
+
+``C``
+  C is normally available for all HDF5 library installs
+
+``CXX``
+  C++ is an optional feature that not all HDF5 library installs are built with
+
+``Fortran``
+  Fortran is an optional feature that not all HDF5 library installs are built with
+
+``parallel``
+  checks that the optional MPI parallel HDF5 layer is enabled. NOTE: if HDF5_parallel_FOUND is true,
+  the user program MUST link MPI::MPI_C and/or MPI::MPI_Fortran.
+
+``HL``
+  always implied and silently accepted to keep compatibility with factory FindHDF5.cmake
+
+
+Targets
+^^^^^^^
+
+``HDF5::HDF5``
+  HDF5 Imported Target
+#]=======================================================================]
+
 include(CheckSymbolExists)
 include(CheckCSourceCompiles)
 include(CheckFortranSourceCompiles)

--- a/cmake/FindHDF5.cmake
+++ b/cmake/FindHDF5.cmake
@@ -1,1228 +1,856 @@
-# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
-# file Copyright.txt or https://cmake.org/licensing for details.
-
-#[=======================================================================[.rst:
-FindHDF5
---------
-
-Find Hierarchical Data Format (HDF5), a library for reading and writing
-self describing array data.
-
-
-This module invokes the ``HDF5`` wrapper compiler that should be installed
-alongside ``HDF5``.  Depending upon the ``HDF5`` Configuration, the wrapper
-compiler is called either ``h5cc`` or ``h5pcc``.  If this succeeds, the module
-will then call the compiler with the show argument to see what flags
-are used when compiling an ``HDF5`` client application.
-
-The module will optionally accept the ``COMPONENTS`` argument.  If no
-``COMPONENTS`` are specified, then the find module will default to finding
-only the ``HDF5`` C library.  If one or more ``COMPONENTS`` are specified, the
-module will attempt to find the language bindings for the specified
-components.  The valid components are ``C``, ``CXX``, ``Fortran``, ``HL``.
-``HL`` refers to the "high-level" HDF5 functions for C and Fortran.
-If the ``COMPONENTS`` argument is not given, the module will
-attempt to find only the C bindings.
-For example, to use Fortran HDF5 and HDF5-HL functions, do:
-``find_package(HDF5 COMPONENTS Fortran HL)``.
-
-This module will read the variable
-``HDF5_USE_STATIC_LIBRARIES`` to determine whether or not to prefer a
-static link to a dynamic link for ``HDF5`` and all of it's dependencies.
-To use this feature, make sure that the ``HDF5_USE_STATIC_LIBRARIES``
-variable is set before the call to find_package.
-
-.. versionadded:: 3.10
-  Support for ``HDF5_USE_STATIC_LIBRARIES`` on Windows.
-
-Both the serial and parallel ``HDF5`` wrappers are considered and the first
-directory to contain either one will be used.  In the event that both appear
-in the same directory the serial version is preferentially selected. This
-behavior can be reversed by setting the variable ``HDF5_PREFER_PARALLEL`` to
-``TRUE``.
-
-In addition to finding the includes and libraries required to compile
-an ``HDF5`` client application, this module also makes an effort to find
-tools that come with the ``HDF5`` distribution that may be useful for
-regression testing.
-
-Result Variables
-^^^^^^^^^^^^^^^^
-
-This module will set the following variables in your project:
-
-``HDF5_FOUND``
-  HDF5 was found on the system
-``HDF5_VERSION``
-  .. versionadded:: 3.3
-    HDF5 library version
-``HDF5_INCLUDE_DIRS``
-  Location of the HDF5 header files
-``HDF5_DEFINITIONS``
-  Required compiler definitions for HDF5
-``HDF5_LIBRARIES``
-  Required libraries for all requested bindings
-``HDF5_HL_LIBRARIES``
-  Required libraries for the HDF5 high level API for all bindings,
-  if the ``HL`` component is enabled
-
-Available components are: ``C`` ``CXX`` ``Fortran`` and ``HL``.
-For each enabled language binding, a corresponding ``HDF5_${LANG}_LIBRARIES``
-variable, and potentially ``HDF5_${LANG}_DEFINITIONS``, will be defined.
-If the ``HL`` component is enabled, then an ``HDF5_${LANG}_HL_LIBRARIES`` will
-also be defined.  With all components enabled, the following variables will be defined:
-
-``HDF5_C_DEFINITIONS``
-  Required compiler definitions for HDF5 C bindings
-``HDF5_CXX_DEFINITIONS``
-  Required compiler definitions for HDF5 C++ bindings
-``HDF5_Fortran_DEFINITIONS``
-  Required compiler definitions for HDF5 Fortran bindings
-``HDF5_C_INCLUDE_DIRS``
-  Required include directories for HDF5 C bindings
-``HDF5_CXX_INCLUDE_DIRS``
-  Required include directories for HDF5 C++ bindings
-``HDF5_Fortran_INCLUDE_DIRS``
-  Required include directories for HDF5 Fortran bindings
-``HDF5_C_LIBRARIES``
-  Required libraries for the HDF5 C bindings
-``HDF5_CXX_LIBRARIES``
-  Required libraries for the HDF5 C++ bindings
-``HDF5_Fortran_LIBRARIES``
-  Required libraries for the HDF5 Fortran bindings
-``HDF5_C_HL_LIBRARIES``
-  Required libraries for the high level C bindings
-``HDF5_CXX_HL_LIBRARIES``
-  Required libraries for the high level C++ bindings
-``HDF5_Fortran_HL_LIBRARIES``
-  Required libraries for the high level Fortran bindings.
-
-``HDF5_IS_PARALLEL``
-  HDF5 library has parallel IO support
-``HDF5_C_COMPILER_EXECUTABLE``
-  path to the HDF5 C wrapper compiler
-``HDF5_CXX_COMPILER_EXECUTABLE``
-  path to the HDF5 C++ wrapper compiler
-``HDF5_Fortran_COMPILER_EXECUTABLE``
-  path to the HDF5 Fortran wrapper compiler
-``HDF5_C_COMPILER_EXECUTABLE_NO_INTERROGATE``
-  path to the primary C compiler which is also the HDF5 wrapper
-``HDF5_CXX_COMPILER_EXECUTABLE_NO_INTERROGATE``
-  path to the primary C++ compiler which is also the HDF5 wrapper
-``HDF5_Fortran_COMPILER_EXECUTABLE_NO_INTERROGATE``
-  path to the primary Fortran compiler which is also the HDF5 wrapper
-``HDF5_DIFF_EXECUTABLE``
-  path to the HDF5 dataset comparison tool
-
-With all components enabled, the following targets will be defined:
-
-``HDF5::HDF5``
-  All detected ``HDF5_LIBRARIES``.
-``hdf5::hdf5``
-  C library.
-``hdf5::hdf5_cpp``
-  C++ library.
-``hdf5::hdf5_fortran``
-  Fortran library.
-``hdf5::hdf5_hl``
-  High-level C library.
-``hdf5::hdf5_hl_cpp``
-  High-level C++ library.
-``hdf5::hdf5_hl_fortran``
-  High-level Fortran library.
-``hdf5::h5diff``
-  ``h5diff`` executable.
-
-Hints
-^^^^^
-
-The following variables can be set to guide the search for HDF5 libraries and includes:
-
-``HDF5_PREFER_PARALLEL``
-  .. versionadded:: 3.4
-
-  set ``true`` to prefer parallel HDF5 (by default, serial is preferred)
-
-``HDF5_FIND_DEBUG``
-  .. versionadded:: 3.9
-
-  Set ``true`` to get extra debugging output.
-
-``HDF5_NO_FIND_PACKAGE_CONFIG_FILE``
-  .. versionadded:: 3.8
-
-  Set ``true`` to skip trying to find ``hdf5-config.cmake``.
-#]=======================================================================]
-
-include(SelectLibraryConfigurations)
-include(FindPackageHandleStandardArgs)
-
-# We haven't found HDF5 yet. Clear its state in case it is set in the parent
-# scope somewhere else. We can't rely on it because different components may
-# have been requested for this call.
-set(HDF5_FOUND OFF)
-set(HDF5_LIBRARIES)
-set(HDF5_HL_LIBRARIES)
-
-# List of the valid HDF5 components
-set(HDF5_VALID_LANGUAGE_BINDINGS C CXX Fortran)
-
-# Validate the list of find components.
-if(NOT HDF5_FIND_COMPONENTS)
-  set(HDF5_LANGUAGE_BINDINGS "C")
-else()
-  set(HDF5_LANGUAGE_BINDINGS)
-  # add the extra specified components, ensuring that they are valid.
-  set(HDF5_FIND_HL OFF)
-  foreach(_component IN LISTS HDF5_FIND_COMPONENTS)
-    list(FIND HDF5_VALID_LANGUAGE_BINDINGS ${_component} _component_location)
-    if(NOT _component_location EQUAL -1)
-      list(APPEND HDF5_LANGUAGE_BINDINGS ${_component})
-    elseif(_component STREQUAL "HL")
-      set(HDF5_FIND_HL ON)
-    elseif(_component STREQUAL "Fortran_HL") # only for compatibility
-      list(APPEND HDF5_LANGUAGE_BINDINGS Fortran)
-      set(HDF5_FIND_HL ON)
-      set(HDF5_FIND_REQUIRED_Fortran_HL FALSE)
-      set(HDF5_FIND_REQUIRED_Fortran TRUE)
-      set(HDF5_FIND_REQUIRED_HL TRUE)
-    else()
-      message(FATAL_ERROR "${_component} is not a valid HDF5 component.")
-    endif()
-  endforeach()
-  unset(_component)
-  unset(_component_location)
-  if(NOT HDF5_LANGUAGE_BINDINGS)
-    get_property(_langs GLOBAL PROPERTY ENABLED_LANGUAGES)
-    foreach(_lang IN LISTS _langs)
-      if(_lang MATCHES "^(C|CXX|Fortran)$")
-        list(APPEND HDF5_LANGUAGE_BINDINGS ${_lang})
-      endif()
-    endforeach()
-  endif()
-  list(REMOVE_ITEM HDF5_FIND_COMPONENTS Fortran_HL) # replaced by Fortran and HL
-  list(REMOVE_DUPLICATES HDF5_LANGUAGE_BINDINGS)
-endif()
-
-# Determine whether to search for serial or parallel executable first
-if(HDF5_PREFER_PARALLEL)
-  set(HDF5_C_COMPILER_NAMES h5pcc h5cc)
-  set(HDF5_CXX_COMPILER_NAMES h5pc++ h5c++)
-  set(HDF5_Fortran_COMPILER_NAMES h5pfc h5fc)
-else()
-  set(HDF5_C_COMPILER_NAMES h5cc h5pcc)
-  set(HDF5_CXX_COMPILER_NAMES h5c++ h5pc++)
-  set(HDF5_Fortran_COMPILER_NAMES h5fc h5pfc)
-endif()
-
-# Test first if the current compilers automatically wrap HDF5
-function(_HDF5_test_regular_compiler_C success version is_parallel)
-  set(scratch_directory
-    ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hdf5)
-  if(NOT ${success} OR
-     NOT EXISTS ${scratch_directory}/compiler_has_h5_c)
-    set(test_file ${scratch_directory}/cmake_hdf5_test.c)
-    file(WRITE ${test_file}
-      "#include <hdf5.h>\n"
-      "const char* info_ver = \"INFO\" \":\" H5_VERSION;\n"
-      "#ifdef H5_HAVE_PARALLEL\n"
-      "const char* info_parallel = \"INFO\" \":\" \"PARALLEL\";\n"
-      "#endif\n"
-      "int main(int argc, char **argv) {\n"
-      "  int require = 0;\n"
-      "  require += info_ver[argc];\n"
-      "#ifdef H5_HAVE_PARALLEL\n"
-      "  require += info_parallel[argc];\n"
-      "#endif\n"
-      "  hid_t fid;\n"
-      "  fid = H5Fcreate(\"foo.h5\",H5F_ACC_TRUNC,H5P_DEFAULT,H5P_DEFAULT);\n"
-      "  return 0;\n"
-      "}")
-    try_compile(${success} SOURCES ${test_file}
-      COPY_FILE ${scratch_directory}/compiler_has_h5_c
-    )
-  endif()
-  if(${success} AND EXISTS ${scratch_directory}/compiler_has_h5_c)
-    file(STRINGS ${scratch_directory}/compiler_has_h5_c INFO_STRINGS
-      REGEX "^INFO:"
-    )
-    string(REGEX MATCH "^INFO:([0-9]+\\.[0-9]+\\.[0-9]+)(-patch([0-9]+))?"
-      INFO_VER "${INFO_STRINGS}"
-    )
-    set(${version} ${CMAKE_MATCH_1})
-    if(CMAKE_MATCH_3)
-      set(${version} ${HDF5_C_VERSION}.${CMAKE_MATCH_3})
-    endif()
-    set(${version} ${${version}} PARENT_SCOPE)
-
-    if(INFO_STRINGS MATCHES "INFO:PARALLEL")
-      set(${is_parallel} TRUE PARENT_SCOPE)
-    else()
-      set(${is_parallel} FALSE PARENT_SCOPE)
-    endif()
-  endif()
-endfunction()
-
-function(_HDF5_test_regular_compiler_CXX success version is_parallel)
-  set(scratch_directory ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hdf5)
-  if(NOT ${success} OR
-     NOT EXISTS ${scratch_directory}/compiler_has_h5_cxx)
-    set(test_file ${scratch_directory}/cmake_hdf5_test.cxx)
-    file(WRITE ${test_file}
-      "#include <H5Cpp.h>\n"
-      "#ifndef H5_NO_NAMESPACE\n"
-      "using namespace H5;\n"
-      "#endif\n"
-      "const char* info_ver = \"INFO\" \":\" H5_VERSION;\n"
-      "#ifdef H5_HAVE_PARALLEL\n"
-      "const char* info_parallel = \"INFO\" \":\" \"PARALLEL\";\n"
-      "#endif\n"
-      "int main(int argc, char **argv) {\n"
-      "  int require = 0;\n"
-      "  require += info_ver[argc];\n"
-      "#ifdef H5_HAVE_PARALLEL\n"
-      "  require += info_parallel[argc];\n"
-      "#endif\n"
-      "  H5File file(\"foo.h5\", H5F_ACC_TRUNC);\n"
-      "  return 0;\n"
-      "}")
-    try_compile(${success} SOURCES ${test_file}
-      COPY_FILE ${scratch_directory}/compiler_has_h5_cxx
-    )
-  endif()
-  if(${success} AND EXISTS ${scratch_directory}/compiler_has_h5_cxx)
-    file(STRINGS ${scratch_directory}/compiler_has_h5_cxx INFO_STRINGS
-      REGEX "^INFO:"
-    )
-    string(REGEX MATCH "^INFO:([0-9]+\\.[0-9]+\\.[0-9]+)(-patch([0-9]+))?"
-      INFO_VER "${INFO_STRINGS}"
-    )
-    set(${version} ${CMAKE_MATCH_1})
-    if(CMAKE_MATCH_3)
-      set(${version} ${HDF5_CXX_VERSION}.${CMAKE_MATCH_3})
-    endif()
-    set(${version} ${${version}} PARENT_SCOPE)
-
-    if(INFO_STRINGS MATCHES "INFO:PARALLEL")
-      set(${is_parallel} TRUE PARENT_SCOPE)
-    else()
-      set(${is_parallel} FALSE PARENT_SCOPE)
-    endif()
-  endif()
-endfunction()
-
-function(_HDF5_test_regular_compiler_Fortran success is_parallel)
-  if(NOT ${success})
-    set(scratch_directory
-      ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hdf5)
-    set(test_file ${scratch_directory}/cmake_hdf5_test.f90)
-    file(WRITE ${test_file}
-      "program hdf5_hello\n"
-      "  use hdf5\n"
-      "  integer error\n"
-      "  call h5open_f(error)\n"
-      "  call h5close_f(error)\n"
-      "end\n")
-    try_compile(${success} SOURCES ${test_file})
-    if(${success})
-      execute_process(COMMAND ${CMAKE_Fortran_COMPILER} -showconfig
-        OUTPUT_VARIABLE config_output
-        ERROR_VARIABLE config_error
-        RESULT_VARIABLE config_result
-        )
-      if(config_output MATCHES "Parallel HDF5: yes")
-        set(${is_parallel} TRUE PARENT_SCOPE)
-      else()
-        set(${is_parallel} FALSE PARENT_SCOPE)
-      endif()
-    endif()
-  endif()
-endfunction()
-
-# Invoke the HDF5 wrapper compiler.  The compiler return value is stored to the
-# return_value argument, the text output is stored to the output variable.
-function( _HDF5_invoke_compiler language output_var return_value_var version_var is_parallel_var)
-  set(is_parallel FALSE)
-  if(HDF5_USE_STATIC_LIBRARIES)
-    set(lib_type_args -noshlib)
-  else()
-    set(lib_type_args -shlib)
-  endif()
-  set(scratch_dir ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hdf5)
-  if("${language}" STREQUAL "C")
-    set(test_file ${scratch_dir}/cmake_hdf5_test.c)
-  elseif("${language}" STREQUAL "CXX")
-    set(test_file ${scratch_dir}/cmake_hdf5_test.cxx)
-  elseif("${language}" STREQUAL "Fortran")
-    set(test_file ${scratch_dir}/cmake_hdf5_test.f90)
-  endif()
-  # Verify that the compiler wrapper can actually compile: sometimes the compiler
-  # wrapper exists, but not the compiler.  E.g. Miniconda / Anaconda Python
-  execute_process(
-    COMMAND ${HDF5_${language}_COMPILER_EXECUTABLE} ${test_file}
-    WORKING_DIRECTORY ${scratch_dir}
-    OUTPUT_VARIABLE output
-    ERROR_VARIABLE output
-    RESULT_VARIABLE return_value
-    )
-  if(return_value AND NOT HDF5_FIND_QUIETLY)
-    message(STATUS
-      "HDF5 ${language} compiler wrapper is unable to compile a minimal HDF5 program.")
-  else()
-    execute_process(
-      COMMAND ${HDF5_${language}_COMPILER_EXECUTABLE} -show ${lib_type_args} ${test_file}
-      WORKING_DIRECTORY ${scratch_dir}
-      OUTPUT_VARIABLE output
-      ERROR_VARIABLE output
-      RESULT_VARIABLE return_value
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      )
-    if(return_value AND NOT HDF5_FIND_QUIETLY)
-      message(STATUS
-        "Unable to determine HDF5 ${language} flags from HDF5 wrapper.")
-    endif()
-    execute_process(
-      COMMAND ${HDF5_${language}_COMPILER_EXECUTABLE} -showconfig
-      OUTPUT_VARIABLE config_output
-      ERROR_VARIABLE config_output
-      RESULT_VARIABLE return_value
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      )
-    if(return_value AND NOT HDF5_FIND_QUIETLY)
-      message(STATUS
-        "Unable to determine HDF5 ${language} version_var from HDF5 wrapper.")
-    endif()
-    string(REGEX MATCH "HDF5 Version: ([a-zA-Z0-9\\.\\-]*)" version "${config_output}")
-    if(version)
-      string(REPLACE "HDF5 Version: " "" version "${version}")
-      string(REPLACE "-patch" "." version "${version}")
-    endif()
-    if(config_output MATCHES "Parallel HDF5: yes")
-      set(is_parallel TRUE)
-    endif()
-  endif()
-  foreach(var output return_value version is_parallel)
-    set(${${var}_var} ${${var}} PARENT_SCOPE)
-  endforeach()
-endfunction()
-
-# Parse a compile line for definitions, includes, library paths, and libraries.
-function(_HDF5_parse_compile_line compile_line_var include_paths definitions
-    library_paths libraries libraries_hl)
-
-  separate_arguments(_compile_args NATIVE_COMMAND "${${compile_line_var}}")
-
-  foreach(_arg IN LISTS _compile_args)
-    if("${_arg}" MATCHES "^-I(.*)$")
-      # include directory
-      list(APPEND include_paths "${CMAKE_MATCH_1}")
-    elseif("${_arg}" MATCHES "^-D(.*)$")
-      # compile definition
-      list(APPEND definitions "-D${CMAKE_MATCH_1}")
-    elseif("${_arg}" MATCHES "^-L(.*)$")
-      # library search path
-      list(APPEND library_paths "${CMAKE_MATCH_1}")
-    elseif("${_arg}" MATCHES "^-l(hdf5.*hl.*)$")
-      # library name (hl)
-      list(APPEND libraries_hl "${CMAKE_MATCH_1}")
-    elseif("${_arg}" MATCHES "^-l(.*)$")
-      # library name
-      list(APPEND libraries "${CMAKE_MATCH_1}")
-    elseif("${_arg}" MATCHES "^(.:)?[/\\].*\\.(a|so|dylib|sl|lib)$")
-      # library file
-      if(NOT EXISTS "${_arg}")
-        continue()
-      endif()
-      get_filename_component(_lpath "${_arg}" DIRECTORY)
-      get_filename_component(_lname "${_arg}" NAME_WE)
-      string(REGEX REPLACE "^lib" "" _lname "${_lname}")
-      list(APPEND library_paths "${_lpath}")
-      if(_lname MATCHES "hdf5.*hl")
-        list(APPEND libraries_hl "${_lname}")
-      else()
-        list(APPEND libraries "${_lname}")
-      endif()
-    endif()
-  endforeach()
-  foreach(var include_paths definitions library_paths libraries libraries_hl)
-    set(${${var}_var} ${${var}} PARENT_SCOPE)
-  endforeach()
-endfunction()
-
-# Select a preferred imported configuration from a target
-function(_HDF5_select_imported_config target imported_conf)
-    # We will first assign the value to a local variable _imported_conf, then assign
-    # it to the function argument at the end.
-    get_target_property(_imported_conf ${target} MAP_IMPORTED_CONFIG_${CMAKE_BUILD_TYPE})
-    if (NOT _imported_conf)
-        # Get available imported configurations by examining target properties
-        get_target_property(_imported_conf ${target} IMPORTED_CONFIGURATIONS)
-        if(HDF5_FIND_DEBUG)
-            message(STATUS "Found imported configurations: ${_imported_conf}")
-        endif()
-        # Find the imported configuration that we prefer.
-        # We do this by making list of configurations in order of preference,
-        # starting with ${CMAKE_BUILD_TYPE} and ending with the first imported_conf
-        set(_preferred_confs ${CMAKE_BUILD_TYPE})
-        list(GET _imported_conf 0 _fallback_conf)
-        list(APPEND _preferred_confs RELWITHDEBINFO RELEASE DEBUG ${_fallback_conf})
-        if(HDF5_FIND_DEBUG)
-            message(STATUS "Start search through imported configurations in the following order: ${_preferred_confs}")
-        endif()
-        # Now find the first of these that is present in imported_conf
-        cmake_policy(PUSH)
-        cmake_policy(SET CMP0057 NEW) # support IN_LISTS
-        foreach (_conf IN LISTS _preferred_confs)
-            if (${_conf} IN_LIST _imported_conf)
-               set(_imported_conf ${_conf})
-               break()
-            endif()
-        endforeach()
-        cmake_policy(POP)
-    endif()
-    if(HDF5_FIND_DEBUG)
-        message(STATUS "Selected imported configuration: ${_imported_conf}")
-    endif()
-    # assign value to function argument
-    set(${imported_conf} ${_imported_conf} PARENT_SCOPE)
-endfunction()
-
-
-if(NOT HDF5_ROOT)
-    set(HDF5_ROOT $ENV{HDF5_ROOT})
-endif()
-if(HDF5_ROOT)
-    set(_HDF5_SEARCH_OPTS NO_DEFAULT_PATH)
-else()
-    set(_HDF5_SEARCH_OPTS)
-endif()
-
-# Try to find HDF5 using an installed hdf5-config.cmake
-if(NOT HDF5_FOUND AND NOT HDF5_NO_FIND_PACKAGE_CONFIG_FILE)
-    find_package(HDF5 QUIET NO_MODULE
-      HINTS ${HDF5_ROOT}
-      ${_HDF5_SEARCH_OPTS}
-      )
-    if( HDF5_FOUND)
-        if(HDF5_FIND_DEBUG)
-            message(STATUS "Found HDF5 at ${HDF5_DIR} via NO_MODULE. Now trying to extract locations etc.")
-        endif()
-        set(HDF5_IS_PARALLEL ${HDF5_ENABLE_PARALLEL})
-        set(HDF5_INCLUDE_DIRS ${HDF5_INCLUDE_DIR})
-        set(HDF5_LIBRARIES)
-        if (NOT TARGET hdf5 AND NOT TARGET hdf5-static AND NOT TARGET hdf5-shared)
-            # Some HDF5 versions (e.g. 1.8.18) used hdf5::hdf5 etc
-            set(_target_prefix "hdf5::")
-        endif()
-        set(HDF5_C_TARGET ${_target_prefix}hdf5)
-        set(HDF5_C_HL_TARGET ${_target_prefix}hdf5_hl)
-        set(HDF5_CXX_TARGET ${_target_prefix}hdf5_cpp)
-        set(HDF5_CXX_HL_TARGET ${_target_prefix}hdf5_hl_cpp)
-        set(HDF5_Fortran_TARGET ${_target_prefix}hdf5_fortran)
-        set(HDF5_Fortran_HL_TARGET ${_target_prefix}hdf5_hl_fortran)
-        set(HDF5_DEFINITIONS "")
-        if(HDF5_USE_STATIC_LIBRARIES)
-            set(_suffix "-static")
-        else()
-            set(_suffix "-shared")
-        endif()
-        foreach(_lang ${HDF5_LANGUAGE_BINDINGS})
-
-            #Older versions of hdf5 don't have a static/shared suffix so
-            #if we detect that occurrence clear the suffix
-            if(_suffix AND NOT TARGET ${HDF5_${_lang}_TARGET}${_suffix})
-              if(NOT TARGET ${HDF5_${_lang}_TARGET})
-                #can't find this component with or without the suffix
-                #so bail out, and let the following locate HDF5
-                set(HDF5_FOUND FALSE)
-                break()
-              endif()
-              set(_suffix "")
-            endif()
-
-            if(HDF5_FIND_DEBUG)
-                message(STATUS "Trying to get properties of target ${HDF5_${_lang}_TARGET}${_suffix}")
-            endif()
-            # Find library for this target. Complicated as on Windows with a DLL, we need to search for the import-lib.
-            _HDF5_select_imported_config(${HDF5_${_lang}_TARGET}${_suffix} _hdf5_imported_conf)
-            get_target_property(_hdf5_lang_location ${HDF5_${_lang}_TARGET}${_suffix} IMPORTED_IMPLIB_${_hdf5_imported_conf} )
-            if (NOT _hdf5_lang_location)
-                # no import lib, just try LOCATION
-                get_target_property(_hdf5_lang_location ${HDF5_${_lang}_TARGET}${_suffix} LOCATION_${_hdf5_imported_conf})
-                if (NOT _hdf5_lang_location)
-                    get_target_property(_hdf5_lang_location ${HDF5_${_lang}_TARGET}${_suffix} LOCATION)
-                endif()
-            endif()
-            if( _hdf5_lang_location )
-                set(HDF5_${_lang}_LIBRARY ${_hdf5_lang_location})
-                list(APPEND HDF5_LIBRARIES ${HDF5_${_lang}_TARGET}${_suffix})
-                set(HDF5_${_lang}_LIBRARIES ${HDF5_${_lang}_TARGET}${_suffix})
-                set(HDF5_${_lang}_FOUND TRUE)
-            endif()
-            if(HDF5_FIND_HL)
-                get_target_property(_hdf5_lang_hl_location ${HDF5_${_lang}_HL_TARGET}${_suffix} IMPORTED_IMPLIB_${_hdf5_imported_conf} )
-                if (NOT _hdf5_lang_hl_location)
-                    get_target_property(_hdf5_lang_hl_location ${HDF5_${_lang}_HL_TARGET}${_suffix} LOCATION_${_hdf5_imported_conf})
-                    if (NOT _hdf5_hl_lang_location)
-                        get_target_property(_hdf5_hl_lang_location ${HDF5_${_lang}_HL_TARGET}${_suffix} LOCATION)
-                    endif()
-                endif()
-                if( _hdf5_lang_hl_location )
-                    set(HDF5_${_lang}_HL_LIBRARY ${_hdf5_lang_hl_location})
-                    list(APPEND HDF5_HL_LIBRARIES ${HDF5_${_lang}_HL_TARGET}${_suffix})
-                    set(HDF5_${_lang}_HL_LIBRARIES ${HDF5_${_lang}_HL_TARGET}${_suffix})
-                    set(HDF5_HL_FOUND TRUE)
-                endif()
-                unset(_hdf5_lang_hl_location)
-            endif()
-            unset(_hdf5_imported_conf)
-            unset(_hdf5_lang_location)
-        endforeach()
-    endif()
-endif()
-
-if(NOT HDF5_FOUND)
-  set(_HDF5_NEED_TO_SEARCH FALSE)
-  set(HDF5_COMPILER_NO_INTERROGATE TRUE)
-  # Only search for languages we've enabled
-  foreach(_lang IN LISTS HDF5_LANGUAGE_BINDINGS)
-    set(HDF5_${_lang}_LIBRARIES)
-    set(HDF5_${_lang}_HL_LIBRARIES)
-
-    # First check to see if our regular compiler is one of wrappers
-    if(_lang STREQUAL "C")
-      _HDF5_test_regular_compiler_C(
-        HDF5_${_lang}_COMPILER_NO_INTERROGATE
-        HDF5_${_lang}_VERSION
-        HDF5_${_lang}_IS_PARALLEL)
-    elseif(_lang STREQUAL "CXX")
-      _HDF5_test_regular_compiler_CXX(
-        HDF5_${_lang}_COMPILER_NO_INTERROGATE
-        HDF5_${_lang}_VERSION
-        HDF5_${_lang}_IS_PARALLEL)
-    elseif(_lang STREQUAL "Fortran")
-      _HDF5_test_regular_compiler_Fortran(
-        HDF5_${_lang}_COMPILER_NO_INTERROGATE
-        HDF5_${_lang}_IS_PARALLEL)
-    else()
-      continue()
-    endif()
-    if(HDF5_${_lang}_COMPILER_NO_INTERROGATE)
-      if(HDF5_FIND_DEBUG)
-        message(STATUS "HDF5: Using hdf5 compiler wrapper for all ${_lang} compiling")
-      endif()
-      set(HDF5_${_lang}_FOUND TRUE)
-      set(HDF5_${_lang}_COMPILER_EXECUTABLE_NO_INTERROGATE
-          "${CMAKE_${_lang}_COMPILER}"
-          CACHE FILEPATH "HDF5 ${_lang} compiler wrapper")
-      set(HDF5_${_lang}_DEFINITIONS)
-      set(HDF5_${_lang}_INCLUDE_DIRS)
-      set(HDF5_${_lang}_LIBRARIES)
-      set(HDF5_${_lang}_HL_LIBRARIES)
-
-      mark_as_advanced(HDF5_${_lang}_COMPILER_EXECUTABLE_NO_INTERROGATE)
-
-      set(HDF5_${_lang}_FOUND TRUE)
-      set(HDF5_HL_FOUND TRUE)
-    else()
-      set(HDF5_COMPILER_NO_INTERROGATE FALSE)
-      # If this language isn't using the wrapper, then try to seed the
-      # search options with the wrapper
-      find_program(HDF5_${_lang}_COMPILER_EXECUTABLE
-        NAMES ${HDF5_${_lang}_COMPILER_NAMES} NAMES_PER_DIR
-        HINTS ${HDF5_ROOT}
-        PATH_SUFFIXES bin Bin
-        DOC "HDF5 ${_lang} Wrapper compiler.  Used only to detect HDF5 compile flags."
-        ${_HDF5_SEARCH_OPTS}
-      )
-      mark_as_advanced( HDF5_${_lang}_COMPILER_EXECUTABLE )
-      unset(HDF5_${_lang}_COMPILER_NAMES)
-
-      if(HDF5_${_lang}_COMPILER_EXECUTABLE)
-        _HDF5_invoke_compiler(${_lang} HDF5_${_lang}_COMPILE_LINE
-          HDF5_${_lang}_RETURN_VALUE HDF5_${_lang}_VERSION HDF5_${_lang}_IS_PARALLEL)
-        if(HDF5_${_lang}_RETURN_VALUE EQUAL 0)
-          if(HDF5_FIND_DEBUG)
-            message(STATUS "HDF5: Using hdf5 compiler wrapper to determine ${_lang} configuration")
-          endif()
-          _HDF5_parse_compile_line( HDF5_${_lang}_COMPILE_LINE
-            HDF5_${_lang}_INCLUDE_DIRS
-            HDF5_${_lang}_DEFINITIONS
-            HDF5_${_lang}_LIBRARY_DIRS
-            HDF5_${_lang}_LIBRARY_NAMES
-            HDF5_${_lang}_HL_LIBRARY_NAMES
-          )
-          set(HDF5_${_lang}_LIBRARIES)
-
-          foreach(_lib IN LISTS HDF5_${_lang}_LIBRARY_NAMES)
-            set(_HDF5_SEARCH_NAMES_LOCAL)
-            if("x${_lib}" MATCHES "hdf5")
-              # hdf5 library
-              set(_HDF5_SEARCH_OPTS_LOCAL ${_HDF5_SEARCH_OPTS})
-              if(HDF5_USE_STATIC_LIBRARIES)
-                if(WIN32)
-                  set(_HDF5_SEARCH_NAMES_LOCAL lib${_lib})
-                else()
-                  set(_HDF5_SEARCH_NAMES_LOCAL lib${_lib}.a)
-                endif()
-              endif()
-            else()
-              # external library
-              set(_HDF5_SEARCH_OPTS_LOCAL)
-            endif()
-            find_library(HDF5_${_lang}_LIBRARY_${_lib}
-              NAMES ${_HDF5_SEARCH_NAMES_LOCAL} ${_lib} NAMES_PER_DIR
-              HINTS ${HDF5_${_lang}_LIBRARY_DIRS}
-                    ${HDF5_ROOT}
-              ${_HDF5_SEARCH_OPTS_LOCAL}
-              )
-            unset(_HDF5_SEARCH_OPTS_LOCAL)
-            unset(_HDF5_SEARCH_NAMES_LOCAL)
-            if(HDF5_${_lang}_LIBRARY_${_lib})
-              list(APPEND HDF5_${_lang}_LIBRARIES ${HDF5_${_lang}_LIBRARY_${_lib}})
-            else()
-              list(APPEND HDF5_${_lang}_LIBRARIES ${_lib})
-            endif()
-          endforeach()
-          if(HDF5_FIND_HL)
-            set(HDF5_${_lang}_HL_LIBRARIES)
-            foreach(_lib IN LISTS HDF5_${_lang}_HL_LIBRARY_NAMES)
-              set(_HDF5_SEARCH_NAMES_LOCAL)
-              if("x${_lib}" MATCHES "hdf5")
-                # hdf5 library
-                set(_HDF5_SEARCH_OPTS_LOCAL ${_HDF5_SEARCH_OPTS})
-                if(HDF5_USE_STATIC_LIBRARIES)
-                  if(WIN32)
-                    set(_HDF5_SEARCH_NAMES_LOCAL lib${_lib})
-                  else()
-                    set(_HDF5_SEARCH_NAMES_LOCAL lib${_lib}.a)
-                  endif()
-                endif()
-              else()
-                # external library
-                set(_HDF5_SEARCH_OPTS_LOCAL)
-              endif()
-              find_library(HDF5_${_lang}_LIBRARY_${_lib}
-                NAMES ${_HDF5_SEARCH_NAMES_LOCAL} ${_lib} NAMES_PER_DIR
-                HINTS ${HDF5_${_lang}_LIBRARY_DIRS}
-                      ${HDF5_ROOT}
-                ${_HDF5_SEARCH_OPTS_LOCAL}
-                )
-              unset(_HDF5_SEARCH_OPTS_LOCAL)
-              unset(_HDF5_SEARCH_NAMES_LOCAL)
-              if(HDF5_${_lang}_LIBRARY_${_lib})
-                list(APPEND HDF5_${_lang}_HL_LIBRARIES ${HDF5_${_lang}_LIBRARY_${_lib}})
-              else()
-                list(APPEND HDF5_${_lang}_HL_LIBRARIES ${_lib})
-              endif()
-            endforeach()
-            set(HDF5_HL_FOUND TRUE)
-          endif()
-
-          set(HDF5_${_lang}_FOUND TRUE)
-          list(REMOVE_DUPLICATES HDF5_${_lang}_DEFINITIONS)
-          list(REMOVE_DUPLICATES HDF5_${_lang}_INCLUDE_DIRS)
-        else()
-          set(_HDF5_NEED_TO_SEARCH TRUE)
-        endif()
-      else()
-        set(_HDF5_NEED_TO_SEARCH TRUE)
-      endif()
-    endif()
-    if(HDF5_${_lang}_VERSION)
-      if(NOT HDF5_VERSION)
-        set(HDF5_VERSION ${HDF5_${_lang}_VERSION})
-      elseif(NOT HDF5_VERSION VERSION_EQUAL HDF5_${_lang}_VERSION)
-        message(WARNING "HDF5 Version found for language ${_lang}, ${HDF5_${_lang}_VERSION} is different than previously found version ${HDF5_VERSION}")
-      endif()
-    endif()
-    if(DEFINED HDF5_${_lang}_IS_PARALLEL)
-      if(NOT DEFINED HDF5_IS_PARALLEL)
-        set(HDF5_IS_PARALLEL ${HDF5_${_lang}_IS_PARALLEL})
-      elseif(NOT HDF5_IS_PARALLEL AND HDF5_${_lang}_IS_PARALLEL)
-        message(WARNING "HDF5 found for language ${_lang} is parallel but previously found language is not parallel.")
-      elseif(HDF5_IS_PARALLEL AND NOT HDF5_${_lang}_IS_PARALLEL)
-        message(WARNING "HDF5 found for language ${_lang} is not parallel but previously found language is parallel.")
-      endif()
-    endif()
-  endforeach()
-  unset(_lib)
-else()
-  set(_HDF5_NEED_TO_SEARCH TRUE)
-endif()
-
-if(NOT HDF5_FOUND AND HDF5_COMPILER_NO_INTERROGATE)
-  # No arguments necessary, all languages can use the compiler wrappers
-  set(HDF5_FOUND TRUE)
-  set(HDF5_METHOD "Included by compiler wrappers")
-  set(HDF5_REQUIRED_VARS HDF5_METHOD)
-elseif(NOT HDF5_FOUND AND NOT _HDF5_NEED_TO_SEARCH)
-  # Compiler wrappers aren't being used by the build but were found and used
-  # to determine necessary include and library flags
-  set(HDF5_INCLUDE_DIRS)
-  set(HDF5_LIBRARIES)
-  set(HDF5_HL_LIBRARIES)
-  foreach(_lang IN LISTS HDF5_LANGUAGE_BINDINGS)
-    if(HDF5_${_lang}_FOUND)
-      if(NOT HDF5_${_lang}_COMPILER_NO_INTERROGATE)
-        list(APPEND HDF5_DEFINITIONS ${HDF5_${_lang}_DEFINITIONS})
-        list(APPEND HDF5_INCLUDE_DIRS ${HDF5_${_lang}_INCLUDE_DIRS})
-        list(APPEND HDF5_LIBRARIES ${HDF5_${_lang}_LIBRARIES})
-        if(HDF5_FIND_HL)
-          list(APPEND HDF5_HL_LIBRARIES ${HDF5_${_lang}_HL_LIBRARIES})
-        endif()
-      endif()
-    endif()
-  endforeach()
-  list(REMOVE_DUPLICATES HDF5_DEFINITIONS)
-  list(REMOVE_DUPLICATES HDF5_INCLUDE_DIRS)
-  set(HDF5_FOUND TRUE)
-  set(HDF5_REQUIRED_VARS HDF5_LIBRARIES)
-  if(HDF5_FIND_HL)
-    list(APPEND HDF5_REQUIRED_VARS HDF5_HL_LIBRARIES)
-  endif()
-endif()
-
-find_program( HDF5_DIFF_EXECUTABLE
-    NAMES h5diff
-    HINTS ${HDF5_ROOT}
-    PATH_SUFFIXES bin Bin
-    ${_HDF5_SEARCH_OPTS}
-    DOC "HDF5 file differencing tool." )
-mark_as_advanced( HDF5_DIFF_EXECUTABLE )
-
-if( NOT HDF5_FOUND )
-    # seed the initial lists of libraries to find with items we know we need
-    set(HDF5_C_LIBRARY_NAMES          hdf5)
-    set(HDF5_C_HL_LIBRARY_NAMES       hdf5_hl ${HDF5_C_LIBRARY_NAMES} )
-
-    set(HDF5_CXX_LIBRARY_NAMES        hdf5_cpp    ${HDF5_C_LIBRARY_NAMES})
-    set(HDF5_CXX_HL_LIBRARY_NAMES     hdf5_hl_cpp ${HDF5_C_HL_LIBRARY_NAMES} ${HDF5_CXX_LIBRARY_NAMES})
-
-    set(HDF5_Fortran_LIBRARY_NAMES    hdf5_fortran   ${HDF5_C_LIBRARY_NAMES})
-    set(HDF5_Fortran_HL_LIBRARY_NAMES hdf5_hl_fortran hdf5hl_fortran ${HDF5_C_HL_LIBRARY_NAMES} ${HDF5_Fortran_LIBRARY_NAMES})
-
-    # suffixes as seen on Linux, MSYS2, ...
-    set(_lib_suffixes hdf5)
-    if(NOT HDF5_PREFER_PARALLEL)
-      list(APPEND _lib_suffixes hdf5/serial)
-    endif()
-    if(HDF5_USE_STATIC_LIBRARIES)
-      set(_inc_suffixes include/static)
-    else()
-      set(_inc_suffixes include/shared)
-    endif()
-
-    foreach(_lang IN LISTS HDF5_LANGUAGE_BINDINGS)
-        set(HDF5_${_lang}_LIBRARIES)
-        set(HDF5_${_lang}_HL_LIBRARIES)
-
-        # The "main" library.
-        set(_hdf5_main_library "")
-
-        # find the HDF5 libraries
-        foreach(LIB IN LISTS HDF5_${_lang}_LIBRARY_NAMES)
-            if(HDF5_USE_STATIC_LIBRARIES)
-                # According to bug 1643 on the CMake bug tracker, this is the
-                # preferred method for searching for a static library.
-                # See https://gitlab.kitware.com/cmake/cmake/-/issues/1643.  We search
-                # first for the full static library name, but fall back to a
-                # generic search on the name if the static search fails.
-                set( THIS_LIBRARY_SEARCH_DEBUG
-                    lib${LIB}d.a lib${LIB}_debug.a lib${LIB}d lib${LIB}_D lib${LIB}_debug
-                    lib${LIB}d-static.a lib${LIB}_debug-static.a ${LIB}d-static ${LIB}_D-static ${LIB}_debug-static )
-                set( THIS_LIBRARY_SEARCH_RELEASE lib${LIB}.a lib${LIB} lib${LIB}-static.a ${LIB}-static)
-            else()
-                set( THIS_LIBRARY_SEARCH_DEBUG ${LIB}d ${LIB}_D ${LIB}_debug ${LIB}d-shared ${LIB}_D-shared ${LIB}_debug-shared)
-                set( THIS_LIBRARY_SEARCH_RELEASE ${LIB} ${LIB}-shared)
-                if(WIN32)
-                  list(APPEND HDF5_DEFINITIONS "-DH5_BUILT_AS_DYNAMIC_LIB")
-                endif()
-            endif()
-            find_library(HDF5_${LIB}_LIBRARY_DEBUG
-                NAMES ${THIS_LIBRARY_SEARCH_DEBUG}
-                HINTS ${HDF5_ROOT} PATH_SUFFIXES lib Lib ${_lib_suffixes}
-                ${_HDF5_SEARCH_OPTS}
-            )
-            find_library(HDF5_${LIB}_LIBRARY_RELEASE
-                NAMES ${THIS_LIBRARY_SEARCH_RELEASE}
-                HINTS ${HDF5_ROOT} PATH_SUFFIXES lib Lib ${_lib_suffixes}
-                ${_HDF5_SEARCH_OPTS}
-            )
-
-            # Set the "main" library if not already set.
-            if (NOT _hdf5_main_library)
-              if (HDF5_${LIB}_LIBRARY_RELEASE)
-                set(_hdf5_main_library "${HDF5_${LIB}_LIBRARY_RELEASE}")
-              elseif (HDF5_${LIB}_LIBRARY_DEBUG)
-                set(_hdf5_main_library "${HDF5_${LIB}_LIBRARY_DEBUG}")
-              endif ()
-            endif ()
-
-            select_library_configurations( HDF5_${LIB} )
-            list(APPEND HDF5_${_lang}_LIBRARIES ${HDF5_${LIB}_LIBRARY})
-        endforeach()
-        if(HDF5_${_lang}_LIBRARIES)
-            set(HDF5_${_lang}_FOUND TRUE)
-        endif()
-
-        # Append the libraries for this language binding to the list of all
-        # required libraries.
-        list(APPEND HDF5_LIBRARIES ${HDF5_${_lang}_LIBRARIES})
-
-        # find the HDF5 include directories
-        set(_hdf5_inc_extra_paths)
-        set(_hdf5_inc_extra_suffixes)
-        if("${_lang}" STREQUAL "Fortran")
-            set(HDF5_INCLUDE_FILENAME hdf5.mod HDF5.mod)
-
-            # Add library-based search paths for Fortran modules.
-            if (NOT _hdf5_main_library STREQUAL "")
-              # gfortran module directory
-              if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "LCC")
-                get_filename_component(_hdf5_library_dir "${_hdf5_main_library}" DIRECTORY)
-                list(APPEND _hdf5_inc_extra_paths "${_hdf5_library_dir}")
-                unset(_hdf5_library_dir)
-                list(APPEND _hdf5_inc_extra_suffixes gfortran/modules)
-              endif ()
-            endif ()
-        elseif("${_lang}" STREQUAL "CXX")
-            set(HDF5_INCLUDE_FILENAME H5Cpp.h)
-        else()
-            set(HDF5_INCLUDE_FILENAME hdf5.h)
-        endif()
-
-        unset(_hdf5_main_library)
-
-        find_path(HDF5_${_lang}_INCLUDE_DIR ${HDF5_INCLUDE_FILENAME}
-            HINTS ${HDF5_ROOT}
-            PATHS $ENV{HOME}/.local/include ${_hdf5_inc_extra_paths}
-            PATH_SUFFIXES include Include ${_inc_suffixes} ${_lib_suffixes} ${_hdf5_inc_extra_suffixes}
-            ${_HDF5_SEARCH_OPTS}
-        )
-        mark_as_advanced(HDF5_${_lang}_INCLUDE_DIR)
-        unset(_hdf5_inc_extra_paths)
-        unset(_hdf5_inc_extra_suffixes)
-        # set the _DIRS variable as this is what the user will normally use
-        set(HDF5_${_lang}_INCLUDE_DIRS ${HDF5_${_lang}_INCLUDE_DIR})
-        list(APPEND HDF5_INCLUDE_DIRS ${HDF5_${_lang}_INCLUDE_DIR})
-
-        if(HDF5_FIND_HL)
-            foreach(LIB IN LISTS HDF5_${_lang}_HL_LIBRARY_NAMES)
-                if(HDF5_USE_STATIC_LIBRARIES)
-                    # According to bug 1643 on the CMake bug tracker, this is the
-                    # preferred method for searching for a static library.
-                    # See https://gitlab.kitware.com/cmake/cmake/-/issues/1643.  We search
-                    # first for the full static library name, but fall back to a
-                    # generic search on the name if the static search fails.
-                    set( THIS_LIBRARY_SEARCH_DEBUG
-                        lib${LIB}d.a lib${LIB}_debug.a lib${LIB}d lib${LIB}_D lib${LIB}_debug
-                        lib${LIB}d-static.a lib${LIB}_debug-static.a lib${LIB}d-static lib${LIB}_D-static lib${LIB}_debug-static )
-                    set( THIS_LIBRARY_SEARCH_RELEASE lib${LIB}.a lib${LIB} lib${LIB}-static.a lib${LIB}-static)
-                else()
-                    set( THIS_LIBRARY_SEARCH_DEBUG ${LIB}d ${LIB}_D ${LIB}_debug ${LIB}d-shared ${LIB}_D-shared ${LIB}_debug-shared)
-                    set( THIS_LIBRARY_SEARCH_RELEASE ${LIB} ${LIB}-shared)
-                endif()
-                find_library(HDF5_${LIB}_LIBRARY_DEBUG
-                    NAMES ${THIS_LIBRARY_SEARCH_DEBUG}
-                    HINTS ${HDF5_ROOT} PATH_SUFFIXES lib Lib ${_lib_suffixes}
-                    ${_HDF5_SEARCH_OPTS}
-                )
-                find_library(HDF5_${LIB}_LIBRARY_RELEASE
-                    NAMES ${THIS_LIBRARY_SEARCH_RELEASE}
-                    HINTS ${HDF5_ROOT} PATH_SUFFIXES lib Lib ${_lib_suffixes}
-                    ${_HDF5_SEARCH_OPTS}
-                )
-
-                select_library_configurations( HDF5_${LIB} )
-                list(APPEND HDF5_${_lang}_HL_LIBRARIES ${HDF5_${LIB}_LIBRARY})
-            endforeach()
-
-            # Append the libraries for this language binding to the list of all
-            # required libraries.
-            list(APPEND HDF5_HL_LIBRARIES ${HDF5_${_lang}_HL_LIBRARIES})
-        endif()
-    endforeach()
-    if(HDF5_FIND_HL AND HDF5_HL_LIBRARIES)
-        set(HDF5_HL_FOUND TRUE)
-    endif()
-
-    list(REMOVE_DUPLICATES HDF5_DEFINITIONS)
-    list(REMOVE_DUPLICATES HDF5_INCLUDE_DIRS)
-
-    # If the HDF5 include directory was found, open H5pubconf.h to determine if
-    # HDF5 was compiled with parallel IO support
-    set( HDF5_IS_PARALLEL FALSE )
-    set( HDF5_VERSION "" )
-    foreach( _dir IN LISTS HDF5_INCLUDE_DIRS )
-      foreach(_hdr "${_dir}/H5pubconf.h" "${_dir}/H5pubconf-64.h" "${_dir}/H5pubconf-32.h")
-        if( EXISTS "${_hdr}" )
-            file( STRINGS "${_hdr}"
-                HDF5_HAVE_PARALLEL_DEFINE
-                REGEX "HAVE_PARALLEL 1" )
-            if( HDF5_HAVE_PARALLEL_DEFINE )
-                set( HDF5_IS_PARALLEL TRUE )
-            endif()
-            unset(HDF5_HAVE_PARALLEL_DEFINE)
-
-            file( STRINGS "${_hdr}"
-                HDF5_VERSION_DEFINE
-                REGEX "^[ \t]*#[ \t]*define[ \t]+H5_VERSION[ \t]+" )
-            if( "${HDF5_VERSION_DEFINE}" MATCHES
-                "H5_VERSION[ \t]+\"([0-9]+\\.[0-9]+\\.[0-9]+)(-patch([0-9]+))?\"" )
-                set( HDF5_VERSION "${CMAKE_MATCH_1}" )
-                if( CMAKE_MATCH_3 )
-                  set( HDF5_VERSION ${HDF5_VERSION}.${CMAKE_MATCH_3})
-                endif()
-            endif()
-            unset(HDF5_VERSION_DEFINE)
-        endif()
-      endforeach()
-    endforeach()
-    unset(_hdr)
-    unset(_dir)
-    set( HDF5_IS_PARALLEL ${HDF5_IS_PARALLEL} CACHE BOOL
-        "HDF5 library compiled with parallel IO support" )
-    mark_as_advanced( HDF5_IS_PARALLEL )
-
-    set(HDF5_REQUIRED_VARS HDF5_LIBRARIES HDF5_INCLUDE_DIRS)
-    if(HDF5_FIND_HL)
-        list(APPEND HDF5_REQUIRED_VARS HDF5_HL_LIBRARIES)
-    endif()
-endif()
-
-# For backwards compatibility we set HDF5_INCLUDE_DIR to the value of
-# HDF5_INCLUDE_DIRS
-if( HDF5_INCLUDE_DIRS )
-  set( HDF5_INCLUDE_DIR "${HDF5_INCLUDE_DIRS}" )
-endif()
-
-# If HDF5_REQUIRED_VARS is empty at this point, then it's likely that
-# something external is trying to explicitly pass already found
-# locations
-if(NOT HDF5_REQUIRED_VARS)
-    set(HDF5_REQUIRED_VARS HDF5_LIBRARIES HDF5_INCLUDE_DIRS)
-endif()
-
-find_package_handle_standard_args(HDF5
-    REQUIRED_VARS ${HDF5_REQUIRED_VARS}
-    VERSION_VAR   HDF5_VERSION
-    HANDLE_COMPONENTS
+include(CheckSymbolExists)
+include(CheckCSourceCompiles)
+include(CheckFortranSourceCompiles)
+
+function(get_flags exec outvar)
+
+execute_process(COMMAND ${exec} -show
+OUTPUT_STRIP_TRAILING_WHITESPACE
+OUTPUT_VARIABLE ret
+RESULT_VARIABLE code
+TIMEOUT 10
+ERROR_QUIET
 )
 
-unset(_HDF5_SEARCH_OPTS)
-
-if( HDF5_FOUND AND NOT HDF5_DIR)
-  # hide HDF5_DIR for the non-advanced user to avoid confusion with
-  # HDF5_DIR-NOT_FOUND while HDF5 was found.
-  mark_as_advanced(HDF5_DIR)
+if(code EQUAL 0)
+  set(${outvar} ${ret} PARENT_SCOPE)
 endif()
 
-if (HDF5_FOUND)
-  if (NOT TARGET HDF5::HDF5)
-    add_library(HDF5::HDF5 INTERFACE IMPORTED)
-    string(REPLACE "-D" "" _hdf5_definitions "${HDF5_DEFINITIONS}")
-    set_target_properties(HDF5::HDF5 PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${HDF5_INCLUDE_DIRS}"
-      INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
-    unset(_hdf5_definitions)
-    target_link_libraries(HDF5::HDF5 INTERFACE ${HDF5_LIBRARIES})
-  endif ()
+endfunction(get_flags)
 
-  foreach (hdf5_lang IN LISTS HDF5_LANGUAGE_BINDINGS)
-    if (hdf5_lang STREQUAL "C")
-      set(hdf5_target_name "hdf5")
-    elseif (hdf5_lang STREQUAL "CXX")
-      set(hdf5_target_name "hdf5_cpp")
-    elseif (hdf5_lang STREQUAL "Fortran")
-      set(hdf5_target_name "hdf5_fortran")
-    else ()
-      continue ()
-    endif ()
 
-    if (NOT TARGET "hdf5::${hdf5_target_name}")
-      if (HDF5_COMPILER_NO_INTERROGATE)
-        add_library("hdf5::${hdf5_target_name}" INTERFACE IMPORTED)
-        string(REPLACE "-D" "" _hdf5_definitions "${HDF5_${hdf5_lang}_DEFINITIONS}")
-        set_target_properties("hdf5::${hdf5_target_name}" PROPERTIES
-          INTERFACE_INCLUDE_DIRECTORIES "${HDF5_${hdf5_lang}_INCLUDE_DIRS}"
-          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
-      else()
-        if (DEFINED "HDF5_${hdf5_target_name}_LIBRARY")
-          set(_hdf5_location "${HDF5_${hdf5_target_name}_LIBRARY}")
-          set(_hdf5_location_release "${HDF5_${hdf5_target_name}_LIBRARY_RELEASE}")
-          set(_hdf5_location_debug "${HDF5_${hdf5_target_name}_LIBRARY_DEBUG}")
-        elseif (DEFINED "HDF5_${hdf5_lang}_LIBRARY")
-          set(_hdf5_location "${HDF5_${hdf5_lang}_LIBRARY}")
-          set(_hdf5_location_release "${HDF5_${hdf5_lang}_LIBRARY_RELEASE}")
-          set(_hdf5_location_debug "${HDF5_${hdf5_lang}_LIBRARY_DEBUG}")
-        elseif (DEFINED "HDF5_${hdf5_lang}_LIBRARY_${hdf5_target_name}")
-          set(_hdf5_location "${HDF5_${hdf5_lang}_LIBRARY_${hdf5_target_name}}")
-        else ()
-          # Error if we still don't have the location.
-          message(SEND_ERROR
-            "HDF5 was found, but a different variable was set which contains "
-            "the location of the `hdf5::${hdf5_target_name}` library.")
-        endif ()
-        add_library("hdf5::${hdf5_target_name}" UNKNOWN IMPORTED)
-        string(REPLACE "-D" "" _hdf5_definitions "${HDF5_${hdf5_lang}_DEFINITIONS}")
-        if (NOT HDF5_${hdf5_lang}_INCLUDE_DIRS)
-         set(HDF5_${hdf5_lang}_INCLUDE_DIRS ${HDF5_INCLUDE_DIRS})
-        endif ()
-        set_target_properties("hdf5::${hdf5_target_name}" PROPERTIES
-          INTERFACE_INCLUDE_DIRECTORIES "${HDF5_${hdf5_lang}_INCLUDE_DIRS}"
-          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
-        if (_hdf5_location_release)
-          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND PROPERTY
-            IMPORTED_CONFIGURATIONS RELEASE)
-          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
-            IMPORTED_LOCATION_RELEASE "${_hdf5_location_release}")
-        endif()
-        if (_hdf5_location_debug)
-          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND PROPERTY
-            IMPORTED_CONFIGURATIONS DEBUG)
-          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
-            IMPORTED_LOCATION_DEBUG "${_hdf5_location_debug}")
-        endif()
-        if (NOT _hdf5_location_release AND NOT _hdf5_location_debug)
-          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
-            IMPORTED_LOCATION "${_hdf5_location}")
-        endif()
-        if (_hdf5_libtype STREQUAL "SHARED")
-          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND
-            PROPERTY
-              INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_DYNAMIC_LIB)
-        elseif (_hdf5_libtype STREQUAL "STATIC")
-          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND
-            PROPERTY
-              INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_STATIC_LIB)
-        endif ()
-        unset(_hdf5_definitions)
-        unset(_hdf5_libtype)
-        unset(_hdf5_location)
-        unset(_hdf5_location_release)
-        unset(_hdf5_location_debug)
-      endif ()
-    endif ()
+function(pop_flag raw flag outvar)
+# this gives the argument to flags to get their paths like -I or -l or -L
 
-    if (NOT HDF5_FIND_HL)
-      continue ()
-    endif ()
+set(_v)
+string(REGEX MATCHALL "(^| )${flag} *([^\" ]+|\"[^\"]+\")" _vars "${raw}")
+foreach(_p IN LISTS _vars)
+  string(REGEX REPLACE "(^| )${flag} *" "" _p "${_p}")
+  list(APPEND _v "${_p}")
+endforeach()
 
-    set(hdf5_alt_target_name "")
-    if (hdf5_lang STREQUAL "C")
-      set(hdf5_target_name "hdf5_hl")
-    elseif (hdf5_lang STREQUAL "CXX")
-      set(hdf5_target_name "hdf5_hl_cpp")
-    elseif (hdf5_lang STREQUAL "Fortran")
-      set(hdf5_target_name "hdf5_hl_fortran")
-      set(hdf5_alt_target_name "hdf5hl_fortran")
-    else ()
-      continue ()
-    endif ()
+set(${outvar} ${_v} PARENT_SCOPE)
 
-    if (NOT TARGET "hdf5::${hdf5_target_name}")
-      if (HDF5_COMPILER_NO_INTERROGATE)
-        add_library("hdf5::${hdf5_target_name}" INTERFACE IMPORTED)
-        string(REPLACE "-D" "" _hdf5_definitions "${HDF5_${hdf5_lang}_HL_DEFINITIONS}")
-        set_target_properties("hdf5::${hdf5_target_name}" PROPERTIES
-          INTERFACE_INCLUDE_DIRECTORIES "${HDF5_${hdf5_lang}_HL_INCLUDE_DIRS}"
-          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
-      else()
-        if (DEFINED "HDF5_${hdf5_target_name}_LIBRARY")
-          set(_hdf5_location "${HDF5_${hdf5_target_name}_LIBRARY}")
-          set(_hdf5_location_release "${HDF5_${hdf5_target_name}_LIBRARY_RELEASE}")
-          set(_hdf5_location_debug "${HDF5_${hdf5_target_name}_LIBRARY_DEBUG}")
-        elseif (DEFINED "HDF5_${hdf5_lang}_HL_LIBRARY")
-          set(_hdf5_location "${HDF5_${hdf5_lang}_HL_LIBRARY}")
-          set(_hdf5_location_release "${HDF5_${hdf5_lang}_HL_LIBRARY_RELEASE}")
-          set(_hdf5_location_debug "${HDF5_${hdf5_lang}_HL_LIBRARY_DEBUG}")
-        elseif (DEFINED "HDF5_${hdf5_lang}_LIBRARY_${hdf5_target_name}")
-          set(_hdf5_location "${HDF5_${hdf5_lang}_LIBRARY_${hdf5_target_name}}")
-        elseif (hdf5_alt_target_name AND DEFINED "HDF5_${hdf5_lang}_LIBRARY_${hdf5_alt_target_name}")
-          set(_hdf5_location "${HDF5_${hdf5_lang}_LIBRARY_${hdf5_alt_target_name}}")
-        else ()
-          # Error if we still don't have the location.
-          message(SEND_ERROR
-            "HDF5 was found, but a different variable was set which contains "
-            "the location of the `hdf5::${hdf5_target_name}` library.")
-        endif ()
-        add_library("hdf5::${hdf5_target_name}" UNKNOWN IMPORTED)
-        string(REPLACE "-D" "" _hdf5_definitions "${HDF5_${hdf5_lang}_HL_DEFINITIONS}")
-        set_target_properties("hdf5::${hdf5_target_name}" PROPERTIES
-          INTERFACE_INCLUDE_DIRECTORIES "${HDF5_${hdf5_lang}_HL_INCLUDE_DIRS}"
-          INTERFACE_COMPILE_DEFINITIONS "${_hdf5_definitions}")
-        if (_hdf5_location_release)
-          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND PROPERTY
-            IMPORTED_CONFIGURATIONS RELEASE)
-          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
-            IMPORTED_LOCATION_RELEASE "${_hdf5_location_release}")
-        endif()
-        if (_hdf5_location_debug)
-          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND PROPERTY
-            IMPORTED_CONFIGURATIONS DEBUG)
-          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
-            IMPORTED_LOCATION_DEBUG "${_hdf5_location_debug}")
-        endif()
-        if (NOT _hdf5_location_release AND NOT _hdf5_location_debug)
-          set_property(TARGET "hdf5::${hdf5_target_name}" PROPERTY
-            IMPORTED_LOCATION "${_hdf5_location}")
-        endif()
-        if (_hdf5_libtype STREQUAL "SHARED")
-          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND
-            PROPERTY
-              INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_DYNAMIC_LIB)
-        elseif (_hdf5_libtype STREQUAL "STATIC")
-          set_property(TARGET "hdf5::${hdf5_target_name}" APPEND
-            PROPERTY
-              INTERFACE_COMPILE_DEFINITIONS H5_BUILT_AS_STATIC_LIB)
-        endif ()
-        unset(_hdf5_definitions)
-        unset(_hdf5_libtype)
-        unset(_hdf5_location)
-      endif ()
-    endif ()
-  endforeach ()
-  unset(hdf5_lang)
+endfunction(pop_flag)
 
-  if (HDF5_DIFF_EXECUTABLE AND NOT TARGET hdf5::h5diff)
-    add_executable(hdf5::h5diff IMPORTED)
-    set_target_properties(hdf5::h5diff PROPERTIES
-      IMPORTED_LOCATION "${HDF5_DIFF_EXECUTABLE}")
-  endif ()
-endif ()
+macro(find_mpi)
+# non-cache set by FindMPI are not visible outside function -- need macro just to see within that function
+set(mpi_comp C)
+if(Fortran IN_LIST HDF5_FIND_COMPONENTS)
+  list(APPEND mpi_comp Fortran)
+endif()
+if(HDF5_FIND_REQUIRED)
+  find_package(MPI COMPONENTS ${mpi_comp} REQUIRED)
+else()
+  find_package(MPI COMPONENTS ${mpi_comp})
+endif()
 
-if (HDF5_FIND_DEBUG)
-  message(STATUS "HDF5_DIR: ${HDF5_DIR}")
-  message(STATUS "HDF5_DEFINITIONS: ${HDF5_DEFINITIONS}")
-  message(STATUS "HDF5_INCLUDE_DIRS: ${HDF5_INCLUDE_DIRS}")
-  message(STATUS "HDF5_LIBRARIES: ${HDF5_LIBRARIES}")
-  message(STATUS "HDF5_HL_LIBRARIES: ${HDF5_HL_LIBRARIES}")
-  foreach(_lang IN LISTS HDF5_LANGUAGE_BINDINGS)
-    message(STATUS "HDF5_${_lang}_DEFINITIONS: ${HDF5_${_lang}_DEFINITIONS}")
-    message(STATUS "HDF5_${_lang}_INCLUDE_DIR: ${HDF5_${_lang}_INCLUDE_DIR}")
-    message(STATUS "HDF5_${_lang}_INCLUDE_DIRS: ${HDF5_${_lang}_INCLUDE_DIRS}")
-    message(STATUS "HDF5_${_lang}_LIBRARY: ${HDF5_${_lang}_LIBRARY}")
-    message(STATUS "HDF5_${_lang}_LIBRARIES: ${HDF5_${_lang}_LIBRARIES}")
-    message(STATUS "HDF5_${_lang}_HL_LIBRARY: ${HDF5_${_lang}_HL_LIBRARY}")
-    message(STATUS "HDF5_${_lang}_HL_LIBRARIES: ${HDF5_${_lang}_HL_LIBRARIES}")
-  endforeach()
-  message(STATUS "Defined targets (if any):")
-  foreach(_lang IN  ITEMS "" "_cpp" "_fortran")
-    foreach(_hl IN  ITEMS "" "_hl")
-      foreach(_prefix IN ITEMS "hdf5::" "")
-        foreach(_suffix IN ITEMS "-static" "-shared" "")
-          set (_target ${_prefix}hdf5${_hl}${_lang}${_suffix})
-          if (TARGET  ${_target})
-            message(STATUS "... ${_target}")
+endmacro(find_mpi)
+
+
+macro(detect_config)
+
+set(CMAKE_REQUIRED_INCLUDES ${HDF5_C_INCLUDE_DIR})
+
+find_file(h5_conf
+NAMES H5pubconf.h H5pubconf-64.h
+HINTS ${HDF5_C_INCLUDE_DIR}
+NO_DEFAULT_PATH
+)
+
+if(NOT h5_conf)
+  set(HDF5_C_FOUND false)
+  return()
+endif()
+
+# check HDF5 features that require link of external libraries.
+check_symbol_exists(H5_HAVE_FILTER_SZIP ${h5_conf} hdf5_have_szip)
+check_symbol_exists(H5_HAVE_FILTER_DEFLATE ${h5_conf} hdf5_have_zlib)
+
+# Always check for HDF5 MPI support because HDF5 link fails if MPI is linked into HDF5.
+check_symbol_exists(H5_HAVE_PARALLEL ${h5_conf} HDF5_HAVE_PARALLEL)
+
+set(HDF5_parallel_FOUND false)
+
+if(HDF5_HAVE_PARALLEL)
+  find_mpi()
+  if(NOT MPI_FOUND)
+    return()
+  endif()
+
+  set(HDF5_parallel_FOUND true)
+endif()
+
+# get version
+# from CMake/Modules/FindHDF5.cmake
+file(STRINGS ${h5_conf} _def
+REGEX "^[ \t]*#[ \t]*define[ \t]+H5_VERSION[ \t]+" )
+if("${_def}" MATCHES
+"H5_VERSION[ \t]+\"([0-9]+\\.[0-9]+\\.[0-9]+)(-patch([0-9]+))?\"" )
+  set(HDF5_VERSION "${CMAKE_MATCH_1}" )
+  if(CMAKE_MATCH_3)
+    set(HDF5_VERSION ${HDF5_VERSION}.${CMAKE_MATCH_3})
+  endif()
+endif()
+
+# avoid picking up incompatible zlib over the desired zlib
+if(CMAKE_VERSION VERSION_LESS 3.20)
+  get_filename_component(zlib_dir ${HDF5_C_INCLUDE_DIR} DIRECTORY)
+else()
+  cmake_path(GET HDF5_C_INCLUDE_DIR PARENT_PATH zlib_dir)
+endif()
+if(NOT ZLIB_ROOT)
+  set(ZLIB_ROOT "${HDF5_ROOT};${zlib_dir}")
+endif()
+
+
+if(hdf5_have_zlib)
+
+  if(HDF5_FIND_REQUIRED)
+    find_package(ZLIB REQUIRED)
+  else()
+    find_package(ZLIB)
+  endif()
+  if(NOT ZLIB_FOUND)
+    return()
+  endif()
+
+  if(hdf5_have_szip)
+    # Szip even though not used by default.
+    # If system HDF5 dynamically links libhdf5 with szip, our builds will fail if we don't also link szip.
+    # however, we don't require SZIP for this case as other HDF5 libraries may statically link SZIP.
+
+    find_library(SZIP_LIBRARY
+    NAMES szip sz
+    NAMES_PER_DIR
+    HINTS ${SZIP_ROOT} ${ZLIB_ROOT}
+    DOC "SZIP API"
+    )
+
+    find_path(SZIP_INCLUDE_DIR
+    NAMES szlib.h
+    HINTS ${SZIP_ROOT} ${ZLIB_ROOT}
+    DOC "SZIP header"
+    )
+
+    if(NOT SZIP_LIBRARY AND SZIP_INCLUDE_DIR)
+      return()
+    endif()
+
+    list(APPEND CMAKE_REQUIRED_INCLUDES ${SZIP_INCLUDE_DIR})
+    list(APPEND CMAKE_REQUIRED_LIBRARIES ${SZIP_LIBRARY})
+  endif()
+
+  list(APPEND CMAKE_REQUIRED_INCLUDES ${ZLIB_INCLUDE_DIRS})
+  list(APPEND CMAKE_REQUIRED_LIBRARIES ${ZLIB_LIBRARIES})
+endif()
+
+list(APPEND CMAKE_REQUIRED_LIBRARIES ${CMAKE_DL_LIBS})
+
+find_package(Threads)
+list(APPEND CMAKE_REQUIRED_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+
+if(UNIX)
+  list(APPEND CMAKE_REQUIRED_LIBRARIES m)
+endif()
+
+endmacro(detect_config)
+
+
+function(find_hdf5_fortran)
+# NOTE: the "lib*" are for Windows Intel compiler, even for self-built HDF5.
+# CMake won't look for lib prefix automatically.
+
+if(parallel IN_LIST HDF5_FIND_COMPONENTS AND NOT HDF5_parallel_FOUND)
+  # this avoids expensive Fortran find when MPI isn't linked properly
+  return()
+endif()
+
+hdf5_fortran_wrap(hdf5_lib_dirs hdf5_inc_dirs)
+
+if(MSVC)
+  set(CMAKE_FIND_LIBRARY_PREFIXES lib)
+endif()
+
+set(_names hdf5_fortran)
+set(_hl_names hdf5_hl_fortran hdf5hl_fortran)
+set(_hl_stub_names hdf5_hl_f90cstub)
+set(_stub_names hdf5_f90cstub)
+
+# distro names (Ubuntu)
+if(parallel IN_LIST HDF5_FIND_COMPONENTS)
+  list(APPEND _names hdf5_openmpi_fortran hdf5_mpich_fortran)
+  list(APPEND _hl_names hdf5_openmpihl_fortran hdf5_mpichhl_fortran)
+else()
+  list(APPEND _names hdf5_serial_fortran)
+  list(APPEND _hl_names hdf5_serialhl_fortran)
+endif()
+
+# Debug names
+if(MSVC)
+  list(APPEND _names hdf5_fortran_D)
+  list(APPEND _hl_names hdf5_hl_fortran_D)
+  list(APPEND _hl_stub_names hdf5_hl_f90cstub_D)
+  list(APPEND _stub_names hdf5_f90cstub_D)
+else()
+  list(APPEND _names hdf5_fortran_debug)
+  list(APPEND _hl_names hdf5_hl_fortran_debug)
+  list(APPEND _hl_stub_names hdf5_hl_f90cstub_debug)
+  list(APPEND _stub_names hdf5_f90cstub_debug)
+endif()
+
+find_library(HDF5_Fortran_LIBRARY
+NAMES ${_names}
+HINTS ${HDF5_ROOT} ${hdf5_lib_dirs}
+PATH_SUFFIXES ${hdf5_lsuf}
+NAMES_PER_DIR
+DOC "HDF5 Fortran API"
+)
+
+find_library(HDF5_Fortran_HL_LIBRARY
+NAMES ${_hl_names}
+HINTS ${HDF5_ROOT} ${hdf5_lib_dirs}
+PATH_SUFFIXES ${hdf5_lsuf}
+NAMES_PER_DIR
+DOC "HDF5 Fortran HL high-level API"
+)
+
+# not all platforms have this stub
+find_library(HDF5_Fortran_HL_stub
+NAMES ${_hl_stub_names}
+HINTS ${HDF5_ROOT} ${hdf5_lib_dirs}
+PATH_SUFFIXES ${hdf5_lsuf}
+NAMES_PER_DIR
+DOC "Fortran C HL interface, not all HDF5 implementations have/need this"
+)
+
+find_library(HDF5_Fortran_stub
+NAMES ${_stub_names}
+HINTS ${HDF5_ROOT} ${hdf5_lib_dirs}
+PATH_SUFFIXES ${hdf5_lsuf}
+NAMES_PER_DIR
+DOC "Fortran C interface, not all HDF5 implementations have/need this"
+)
+
+set(HDF5_Fortran_LIBRARIES ${HDF5_Fortran_HL_LIBRARY} ${HDF5_Fortran_LIBRARY})
+if(HDF5_Fortran_HL_stub AND HDF5_Fortran_stub)
+  list(APPEND HDF5_Fortran_LIBRARIES ${HDF5_Fortran_HL_stub} ${HDF5_Fortran_stub})
+endif()
+
+if(HDF5_ROOT)
+  find_path(HDF5_Fortran_INCLUDE_DIR
+  NAMES hdf5.mod
+  NO_DEFAULT_PATH
+  HINTS ${HDF5_C_INCLUDE_DIR} ${HDF5_ROOT}
+  DOC "HDF5 Fortran module path"
+  )
+else()
+  if(parallel IN_LIST HDF5_FIND_COMPONENTS)
+    # HDF5-MPI system library presents a unique challenge, as when non-MPI HDF5 is
+    # also installed, which is typically necessary for other system libraries, the
+    # HDF5-MPI compiler wrapper often includes that wrong non-MPI include dir first.
+    # The most general approach seemed to be the following:
+    # search in a for loop and do a link check.
+    if(NOT HDF5_Fortran_INCLUDE_DIR)
+      foreach(i IN LISTS HDF5_C_INCLUDE_DIR hdf5_inc_dirs)
+        find_path(HDF5_Fortran_INCLUDE_DIR
+        NAMES hdf5.mod
+        NO_DEFAULT_PATH
+        HINTS ${i}
+        DOC "HDF5 Fortran module path"
+        )
+        message(VERBOSE "FindHDF5: trying hdf5.mod in ${i} - got: ${HDF5_Fortran_INCLUDE_DIR}")
+        if(HDF5_Fortran_INCLUDE_DIR)
+          check_fortran_links()
+          if(HDF5_Fortran_links)
+            break()
           else()
-            #message(STATUS "... ${_target} does not exist")
+            unset(HDF5_Fortran_INCLUDE_DIR CACHE)
+            unset(HDF5_Fortran_links CACHE)
           endif()
-        endforeach()
+        endif()
       endforeach()
-    endforeach()
-  endforeach()
-endif()
-unset(_lang)
-unset(_HDF5_NEED_TO_SEARCH)
+    endif()
 
+    if(NOT HDF5_Fortran_INCLUDE_DIR)
+      # last resort, might give incompatible non-MPI hdf5.mod
+      find_path(HDF5_Fortran_INCLUDE_DIR
+      NAMES hdf5.mod
+      HINTS ${HDF5_C_INCLUDE_DIR} ${hdf5_inc_dirs}
+      PATHS ${hdf5_binpref}
+      PATH_SUFFIXES ${hdf5_msuf}
+      DOC "HDF5 Fortran module path"
+      )
+    endif()
+  else()
+    find_path(HDF5_Fortran_INCLUDE_DIR
+    NAMES hdf5.mod
+    HINTS ${HDF5_C_INCLUDE_DIR} ${hdf5_inc_dirs}
+    PATHS ${hdf5_binpref}
+    PATH_SUFFIXES ${hdf5_msuf}
+    DOC "HDF5 Fortran module path"
+    )
+  endif()
+endif()
+
+if(HDF5_Fortran_LIBRARY AND HDF5_Fortran_HL_LIBRARY AND HDF5_Fortran_INCLUDE_DIR)
+  set(HDF5_Fortran_LIBRARIES ${HDF5_Fortran_LIBRARIES} PARENT_SCOPE)
+  set(HDF5_Fortran_FOUND true PARENT_SCOPE)
+  set(HDF5_HL_FOUND true PARENT_SCOPE)
+endif()
+
+endfunction(find_hdf5_fortran)
+
+
+function(find_hdf5_cxx)
+
+hdf5_cxx_wrap(hdf5_lib_dirs hdf5_inc_dirs)
+
+if(MSVC)
+  set(CMAKE_FIND_LIBRARY_PREFIXES lib)
+endif()
+
+set(_names hdf5_cpp)
+set(_hl_names hdf5_hl_cpp)
+
+# distro names (Ubuntu)
+if(parallel IN_LIST HDF5_FIND_COMPONENTS)
+  list(APPEND _names hdf5_openmpi_cpp hdf5_mpich_cpp)
+  list(APPEND _hl_names hdf5_openmpi_hl_cpp hdf5_mpich_hl_cpp)
+else()
+  list(APPEND _names hdf5_serial_cpp)
+  list(APPEND _hl_names hdf5_serial_hl_cpp)
+endif()
+
+# Debug names
+if(MSVC)
+  list(APPEND _names hdf5_cpp_D)
+  list(APPEND _hl_names hdf5_hl_cpp_D)
+else()
+  list(APPEND _names hdf5_cpp_debug)
+  list(APPEND _hl_names hdf5_hl_cpp_debug)
+endif()
+
+find_library(HDF5_CXX_LIBRARY
+NAMES ${_names}
+HINTS ${HDF5_ROOT} ${hdf5_lib_dirs}
+PATH_SUFFIXES ${hdf5_lsuf}
+NAMES_PER_DIR
+DOC "HDF5 C++ API"
+)
+
+find_library(HDF5_CXX_HL_LIBRARY
+NAMES ${_hl_names}
+HINTS ${HDF5_ROOT} ${hdf5_lib_dirs}
+PATH_SUFFIXES ${hdf5_lsuf}
+NAMES_PER_DIR
+DOC "HDF5 C++ high-level API"
+)
+
+find_path(HDF5_CXX_INCLUDE_DIR
+NAMES hdf5.h
+HINTS ${HDF5_C_INCLUDE_DIR} ${HDF5_ROOT} ${hdf5_inc_dirs}
+PATH_SUFFIXES ${hdf5_isuf}
+DOC "HDF5 C header"
+)
+
+if(HDF5_CXX_LIBRARY AND HDF5_CXX_HL_LIBRARY AND HDF5_CXX_INCLUDE_DIR)
+  set(HDF5_CXX_LIBRARIES ${HDF5_CXX_HL_LIBRARY} ${HDF5_CXX_LIBRARY} PARENT_SCOPE)
+  set(HDF5_CXX_FOUND true PARENT_SCOPE)
+  set(HDF5_HL_FOUND true PARENT_SCOPE)
+endif()
+
+endfunction(find_hdf5_cxx)
+
+
+function(find_hdf5_c)
+
+hdf5_c_wrap(hdf5_lib_dirs hdf5_inc_dirs)
+
+if(MSVC)
+  set(CMAKE_FIND_LIBRARY_PREFIXES lib)
+endif()
+
+set(_names hdf5)
+set(_hl_names hdf5_hl)
+
+# distro names (Ubuntu)
+if(parallel IN_LIST HDF5_FIND_COMPONENTS)
+  list(APPEND _names hdf5_openmpi hdf5_mpich)
+  list(APPEND _hl_names hdf5_openmpi_hl hdf5_mpich_hl)
+else()
+  list(APPEND _names hdf5_serial)
+  list(APPEND _hl_names hdf5_serial_hl)
+endif()
+
+# debug names
+if(MSVC)
+  list(APPEND _names hdf5_D)
+  list(APPEND _hl_names hdf5_hl_D)
+else()
+  list(APPEND _names hdf5_debug)
+  list(APPEND _hl_names hdf5_hl_debug)
+endif()
+
+# MUST have HDF5_ROOT in HINTS here since it was set in this script
+find_library(HDF5_C_LIBRARY
+NAMES ${_names}
+HINTS ${HDF5_ROOT} ${hdf5_lib_dirs}
+PATH_SUFFIXES ${hdf5_lsuf}
+NAMES_PER_DIR
+DOC "HDF5 C library (necessary for all languages)"
+)
+
+find_library(HDF5_C_HL_LIBRARY
+NAMES ${_hl_names}
+HINTS ${HDF5_ROOT} ${hdf5_lib_dirs}
+PATH_SUFFIXES ${hdf5_lsuf}
+NAMES_PER_DIR
+DOC "HDF5 C high level interface"
+)
+
+find_path(HDF5_C_INCLUDE_DIR
+NAMES hdf5.h
+HINTS ${HDF5_ROOT} ${hdf5_inc_dirs}
+PATH_SUFFIXES ${hdf5_isuf}
+DOC "HDF5 C header"
+)
+
+if(HDF5_C_HL_LIBRARY AND HDF5_C_LIBRARY AND HDF5_C_INCLUDE_DIR)
+  set(HDF5_C_LIBRARIES ${HDF5_C_HL_LIBRARY} ${HDF5_C_LIBRARY} PARENT_SCOPE)
+  set(HDF5_C_FOUND true PARENT_SCOPE)
+  set(HDF5_HL_FOUND true PARENT_SCOPE)
+endif()
+
+endfunction(find_hdf5_c)
+
+
+function(hdf5_fortran_wrap lib_var inc_var)
+
+set(lib_dirs)
+set(inc_dirs)
+
+if(parallel IN_LIST HDF5_FIND_COMPONENTS)
+  set(wrapper_names h5pfc h5pfc.openmpi h5pfc.mpich)
+else()
+  set(wrapper_names h5fc)
+endif()
+
+if(HDF5_ROOT)
+  find_program(HDF5_Fortran_COMPILER_EXECUTABLE
+  NAMES ${wrapper_names}
+  NAMES_PER_DIR
+  NO_DEFAULT_PATH
+  HINTS ${HDF5_ROOT}
+  PATH_SUFFIXES ${hdf5_binsuf}
+  )
+else()
+  find_program(HDF5_Fortran_COMPILER_EXECUTABLE
+  NAMES ${wrapper_names}
+  NAMES_PER_DIR
+  PATHS ${hdf5_binpref}
+  PATH_SUFFIXES ${hdf5_binsuf}
+  )
+endif()
+
+if(NOT HDF5_Fortran_COMPILER_EXECUTABLE)
+  return()
+endif()
+
+get_flags(${HDF5_Fortran_COMPILER_EXECUTABLE} f_raw)
+if(f_raw)
+  pop_flag(${f_raw} -L lib_dirs)
+  pop_flag(${f_raw} -I inc_dirs)
+  if(NOT inc_dirs AND parallel IN_LIST HDF5_FIND_COMPONENTS)
+    get_flags(${MPI_Fortran_COMPILER} f_raw)
+    if(f_raw)
+      pop_flag(${f_raw} -I inc_dirs)
+    endif(f_raw)
+  endif()
+endif(f_raw)
+
+if(inc_dirs)
+  set(${inc_var} ${inc_dirs} PARENT_SCOPE)
+endif()
+
+if(lib_dirs)
+  set(${lib_var} ${lib_dirs} PARENT_SCOPE)
+endif()
+
+endfunction(hdf5_fortran_wrap)
+
+
+function(hdf5_cxx_wrap lib_var inc_var)
+
+set(lib_dirs)
+set(inc_dirs)
+
+if(parallel IN_LIST HDF5_FIND_COMPONENTS)
+ set(wrapper_names h5c++.openmpi h5c++.mpich)
+else()
+  set(wrapper_names h5c++)
+endif()
+
+if(HDF5_ROOT)
+  find_program(HDF5_CXX_COMPILER_EXECUTABLE
+  NAMES ${wrapper_names}
+  NAMES_PER_DIR
+  NO_DEFAULT_PATH
+  HINTS ${HDF5_ROOT}
+  PATH_SUFFIXES ${hdf5_binsuf}
+  )
+else()
+  find_program(HDF5_CXX_COMPILER_EXECUTABLE
+  NAMES ${wrapper_names}
+  NAMES_PER_DIR
+  PATHS ${hdf5_binpref}
+  PATH_SUFFIXES ${hdf5_binsuf}
+  )
+endif()
+
+if(NOT HDF5_CXX_COMPILER_EXECUTABLE)
+  return()
+endif()
+
+get_flags(${HDF5_CXX_COMPILER_EXECUTABLE} cxx_raw)
+if(cxx_raw)
+  pop_flag(${cxx_raw} -L lib_dirs)
+  pop_flag(${cxx_raw} -I inc_dirs)
+endif(cxx_raw)
+
+if(inc_dirs)
+  set(${inc_var} ${inc_dirs} PARENT_SCOPE)
+endif()
+
+if(lib_dirs)
+  set(${lib_var} ${lib_dirs} PARENT_SCOPE)
+endif()
+
+endfunction(hdf5_cxx_wrap)
+
+
+function(hdf5_c_wrap lib_var inc_var)
+
+set(lib_dirs)
+set(inc_dirs)
+
+if(parallel IN_LIST HDF5_FIND_COMPONENTS)
+  set(wrapper_names h5pcc h5pcc.openmpi h5pcc.mpich)
+else()
+  set(wrapper_names h5cc)
+endif()
+
+if(HDF5_ROOT)
+  find_program(HDF5_C_COMPILER_EXECUTABLE
+  NAMES ${wrapper_names}
+  NAMES_PER_DIR
+  NO_DEFAULT_PATH
+  HINTS ${HDF5_ROOT}
+  PATH_SUFFIXES ${hdf5_binsuf}
+  )
+else()
+  find_program(HDF5_C_COMPILER_EXECUTABLE
+  NAMES ${wrapper_names}
+  NAMES_PER_DIR
+  PATHS ${hdf5_binpref}
+  PATH_SUFFIXES ${hdf5_binsuf}
+  )
+endif()
+
+if(NOT HDF5_C_COMPILER_EXECUTABLE)
+  return()
+endif()
+
+get_flags(${HDF5_C_COMPILER_EXECUTABLE} c_raw)
+if(c_raw)
+  pop_flag(${c_raw} -L lib_dirs)
+  pop_flag(${c_raw} -I inc_dirs)
+  if(NOT inc_dirs AND parallel IN_LIST HDF5_FIND_COMPONENTS)
+    get_flags(${MPI_C_COMPILER} c_raw)
+    if(c_raw)
+      pop_flag(${c_raw} -I inc_dirs)
+    endif(c_raw)
+  endif()
+endif(c_raw)
+
+
+if(inc_dirs)
+  set(${inc_var} ${inc_dirs} PARENT_SCOPE)
+endif()
+
+if(lib_dirs)
+  set(${lib_var} ${lib_dirs} PARENT_SCOPE)
+endif()
+
+
+endfunction(hdf5_c_wrap)
+
+
+function(check_c_links)
+
+list(INSERT CMAKE_REQUIRED_LIBRARIES 0 ${HDF5_C_LIBRARIES})
+set(CMAKE_REQUIRED_INCLUDES ${HDF5_C_INCLUDE_DIR})
+
+if(HDF5_parallel_FOUND)
+  find_mpi()
+
+  list(APPEND CMAKE_REQUIRED_INCLUDES ${MPI_C_INCLUDE_DIRS})
+  list(APPEND CMAKE_REQUIRED_LIBRARIES ${MPI_C_LIBRARIES})
+
+  check_symbol_exists(H5Pset_fapl_mpio hdf5.h HAVE_H5Pset_fapl_mpio)
+  if(NOT HAVE_H5Pset_fapl_mpio)
+    return()
+  endif()
+
+  set(src [=[
+  #include "hdf5.h"
+  #include "mpi.h"
+
+  int main(void){
+  MPI_Init(NULL, NULL);
+
+  hid_t plist_id = H5Pcreate(H5P_FILE_ACCESS);
+  H5Pset_fapl_mpio(plist_id, MPI_COMM_WORLD, MPI_INFO_NULL);
+
+  H5Pclose(plist_id);
+
+  MPI_Finalize();
+
+  return 0;
+  }
+  ]=])
+
+else()
+  set(src [=[
+  #include "hdf5.h"
+
+  int main(void){
+  hid_t f = H5Fcreate("junk.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  herr_t status = H5Fclose (f);
+  return 0;}
+  ]=])
+endif(HDF5_parallel_FOUND)
+
+check_c_source_compiles("${src}" HDF5_C_links)
+
+endfunction(check_c_links)
+
+
+function(check_fortran_links)
+
+list(INSERT CMAKE_REQUIRED_LIBRARIES 0 ${HDF5_Fortran_LIBRARIES} ${HDF5_C_LIBRARIES})
+set(CMAKE_REQUIRED_INCLUDES ${HDF5_Fortran_INCLUDE_DIR} ${HDF5_C_INCLUDE_DIR})
+
+if(HDF5_parallel_FOUND)
+  find_mpi()
+
+  list(APPEND CMAKE_REQUIRED_INCLUDES ${MPI_Fortran_INCLUDE_DIRS})
+  list(APPEND CMAKE_REQUIRED_LIBRARIES ${MPI_Fortran_LIBRARIES})
+
+  set(src "program test
+  use hdf5
+  use mpi
+  implicit none
+  integer :: ierr, mpi_id
+  integer(HID_T) :: fapl, xfer_id
+  call mpi_init(ierr)
+  call h5open_f(ierr)
+  call h5pcreate_f(H5P_FILE_ACCESS_F, fapl, ierr)
+  call h5pset_fapl_mpio_f(fapl, MPI_COMM_WORLD, MPI_INFO_NULL, ierr)
+  call h5pcreate_f(H5P_DATASET_XFER_F, xfer_id, ierr)
+  call h5pset_dxpl_mpio_f(xfer_id, H5FD_MPIO_COLLECTIVE_F, ierr)
+  call mpi_finalize(ierr)
+  end program")
+else()
+  set(src "program test_minimal
+  use hdf5, only : h5open_f, h5close_f
+  use h5lt, only : h5ltmake_dataset_f
+  implicit none
+  integer :: i
+  call h5open_f(i)
+  call h5close_f(i)
+  end program")
+endif()
+
+check_fortran_source_compiles(${src} HDF5_Fortran_links SRC_EXT f90)
+
+endfunction(check_fortran_links)
+
+
+function(check_hdf5_link)
+
+if(NOT HDF5_C_FOUND)
+  return()
+endif()
+
+if(parallel IN_LIST HDF5_FIND_COMPONENTS AND NOT HDF5_parallel_FOUND)
+  return()
+endif()
+
+check_c_links()
+
+if(NOT HDF5_C_links)
+  return()
+endif()
+
+if(HDF5_Fortran_FOUND)
+  check_fortran_links()
+
+  if(NOT HDF5_Fortran_links)
+    return()
+  endif()
+endif()
+
+set(HDF5_links true PARENT_SCOPE)
+
+endfunction(check_hdf5_link)
+
+# === main program
+
+set(CMAKE_REQUIRED_LIBRARIES)
+
+if(NOT HDF5MPI_ROOT AND DEFINED ENV{HDF5MPI_ROOT})
+  set(HDF5MPI_ROOT $ENV{HDF5MPI_ROOT})
+endif()
+
+if(NOT HDF5_ROOT)
+  if(HDF5MPI_ROOT AND parallel IN_LIST HDF5_FIND_COMPONENTS)
+    set(HDF5_ROOT ${HDF5MPI_ROOT})
+  elseif(DEFINED ENV{HDF5_ROOT})
+    set(HDF5_ROOT $ENV{HDF5_ROOT})
+  endif()
+endif()
+
+# Conda causes numerous problems with finding HDF5, so exclude from search
+if(DEFINED ENV{CONDA_PREFIX})
+  set(h5_ignore_path
+    $ENV{CONDA_PREFIX}/bin $ENV{CONDA_PREFIX}/lib $ENV{CONDA_PREFIX}/include
+    $ENV{CONDA_PREFIX}/Library/bin $ENV{CONDA_PREFIX}/Library/lib $ENV{CONDA_PREFIX}/Library/include
+  )
+  list(APPEND CMAKE_IGNORE_PATH ${h5_ignore_path})
+endif()
+
+# --- library suffixes
+
+set(hdf5_lsuf lib hdf5/lib)  # need explicit "lib" for self-built HDF5
+if(NOT HDF5_ROOT)
+  if(parallel IN_LIST HDF5_FIND_COMPONENTS)
+    list(INSERT hdf5_lsuf 0 hdf5/openmpi hdf5/mpich)  # Ubuntu
+    list(INSERT hdf5_lsuf 0 openmpi/lib mpich/lib)  # CentOS
+  else()
+    list(INSERT hdf5_lsuf 0 hdf5/serial)  # Ubuntu
+  endif()
+endif()
+
+# --- include and modules suffixes
+
+if(BUILD_SHARED_LIBS)
+  set(hdf5_isuf shared include)
+  set(hdf5_msuf shared include)
+else()
+  set(hdf5_isuf static include)
+  set(hdf5_msuf static include)
+endif()
+
+if(parallel IN_LIST HDF5_FIND_COMPONENTS)
+  list(APPEND hdf5_isuf hdf5/openmpi hdf5/mpich)  # Ubuntu
+  list(APPEND hdf5_msuf hdf5/openmpi hdf5/mpich)  # Ubuntu
+else()
+  list(APPEND hdf5_isuf hdf5/serial)  # Ubuntu
+  list(APPEND hdf5_msuf hdf5/serial)  # Ubuntu
+endif()
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|AMD64)")
+  list(APPEND hdf5_isuf openmpi-x86_64 mpich-x86_64)  # CentOS
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64|arm64)")
+  list(APPEND hdf5_isuf openmpi-aarch64 mpich-aarch64)  # CentOS
+endif()
+
+if(NOT HDF5_ROOT AND CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+  # CentOS paths
+  if(parallel IN_LIST HDF5_FIND_COMPONENTS)
+    list(INSERT hdf5_msuf 0 gfortran/modules/openmpi gfortran/modules/mpich)
+  else()
+    list(APPEND hdf5_msuf gfortran/modules)
+  endif()
+endif()
+
+# --- binary prefix / suffix
+set(hdf5_binpref)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(hdf5_binpref /usr/lib64)
+endif()
+
+set(hdf5_binsuf bin)
+if(NOT HDF5_ROOT AND parallel IN_LIST HDF5_FIND_COMPONENTS)
+  # CentOS paths
+  list(APPEND hdf5_binsuf openmpi/bin mpich/bin)
+endif()
+
+# ----
+# May not help, as we'd have to foreach() a priori names, like we already do with find_library()
+# find_package(hdf5 CONFIG)
+# ----
+
+# C is always needed
+find_hdf5_c()
+
+# required libraries
+if(HDF5_C_FOUND)
+  detect_config()
+endif(HDF5_C_FOUND)
+
+if(HDF5_C_FOUND AND CXX IN_LIST HDF5_FIND_COMPONENTS)
+  find_hdf5_cxx()
+endif()
+
+if(HDF5_C_FOUND AND Fortran IN_LIST HDF5_FIND_COMPONENTS)
+  find_hdf5_fortran()
+endif()
+
+# --- configure time checks
+# these checks avoid messy, confusing errors at build time
+check_hdf5_link()
+
+set(CMAKE_REQUIRED_LIBRARIES)
+set(CMAKE_REQUIRED_INCLUDES)
+
+# pop off ignored paths so rest of script can find Python
+if(DEFINED CMAKE_IGNORE_PATH)
+  list(REMOVE_ITEM CMAKE_IGNORE_PATH "${h5_ignore_path}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HDF5
+REQUIRED_VARS HDF5_C_LIBRARIES HDF5_links
+VERSION_VAR HDF5_VERSION
+HANDLE_COMPONENTS
+)
+
+if(HDF5_FOUND)
+  set(HDF5_INCLUDE_DIRS ${HDF5_Fortran_INCLUDE_DIR} ${HDF5_CXX_INCLUDE_DIR} ${HDF5_C_INCLUDE_DIR})
+  set(HDF5_LIBRARIES ${HDF5_Fortran_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_C_LIBRARIES})
+
+  if(NOT TARGET HDF5::HDF5)
+    add_library(HDF5::HDF5 INTERFACE IMPORTED)
+    set_property(TARGET HDF5::HDF5 PROPERTY INTERFACE_LINK_LIBRARIES "${HDF5_LIBRARIES}")
+    set_property(TARGET HDF5::HDF5 PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${HDF5_INCLUDE_DIRS}")
+
+    target_include_directories(HDF5::HDF5 INTERFACE
+    $<$<BOOL:${hdf5_have_szip}>:${SZIP_INCLUDE_DIR}>
+    )
+    target_link_libraries(HDF5::HDF5 INTERFACE
+    $<$<BOOL:${hdf5_have_zlib}>:ZLIB::ZLIB>
+    $<$<BOOL:${hdf5_have_szip}>:${SZIP_LIBRARY}>
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CMAKE_DL_LIBS}
+    $<$<BOOL:${UNIX}>:m>
+    )
+
+  endif()
+endif(HDF5_FOUND)
+
+mark_as_advanced(HDF5_Fortran_LIBRARY HDF5_Fortran_HL_LIBRARY
+HDF5_C_LIBRARY HDF5_C_HL_LIBRARY
+HDF5_CXX_LIBRARY HDF5_CXX_HL_LIBRARY
+HDF5_C_INCLUDE_DIR HDF5_CXX_INCLUDE_DIR HDF5_Fortran_INCLUDE_DIR)

--- a/cmake/FindHDF5.cmake
+++ b/cmake/FindHDF5.cmake
@@ -154,8 +154,8 @@ The following variables can be set to guide the search for HDF5 libraries and in
   Set ``true`` to skip trying to find ``hdf5-config.cmake``.
 #]=======================================================================]
 
-include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+include(SelectLibraryConfigurations.cmake)
+include(FindPackageHandleStandardArgs.cmake)
 
 # We haven't found HDF5 yet. Clear its state in case it is set in the parent
 # scope somewhere else. We can't rely on it because different components may

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -41,7 +41,7 @@ foreach(_depName ${SINGULARITY_DEP_PKGS})
     set(_components "COMPONENTS ${SINGULARITY_DEP_PKGS_${_depName}}")
   endif()
   set(SINGULARITY_CONFIG_DEPENDENCIES
-    "${SINGULARITY_CONFIG_DEPENDENCIES}\nfind_package(${_depName} ${_components} REQUIRED)")
+    "${SINGULARITY_CONFIG_DEPENDENCIES}\nif(NOT ${_depName}_FOUND)\n\tfind_package(${_depName} ${_components} REQUIRED)\nendif()")
 endforeach()
 
 # generate the configuration file

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -47,6 +47,8 @@ class SingularityEos(CMakePackage, CudaPackage):
 
     variant("eospac", default=True, description="Pull in EOSPAC")
 
+    variant("hdf5_fortran", default=False, description="Use +fortran variant for HDF5")
+
     # building/testing/docs
     depends_on("cmake@3.14:")
     depends_on("catch2@2.13.7", when="+tests")
@@ -107,7 +109,8 @@ class SingularityEos(CMakePackage, CudaPackage):
         depends_on("py-h5py" + _flag, when=_flag)
         depends_on("kokkos-nvcc-wrapper" + _flag, when="+cuda+kokkos" + _flag)
 
-    depends_on("hdf5+fortran", when="+fortran")
+    depends_on("hdf5+fortran", when="+hdf5_fortran")
+    conflicts("+hdf5_fortran", when="~fortran")
 
     def cmake_args(self):
         args = [
@@ -119,6 +122,7 @@ class SingularityEos(CMakePackage, CudaPackage):
             self.define_from_variant("SINGULARITY_BUILD_CLOSURE", "fortran"),
             self.define_from_variant("SINGULARITY_BUILD_PYTHON", "python"),
             self.define_from_variant("SINGULARITY_BUILD_TESTS", "tests"),
+            self.define_from_variant("SINGULARITY_LINK_HDF5_FORTRAN", "hdf5_fortran"),
             self.define("SINGULARITY_BUILD_SESAME2SPINER",
                         "sesame" in self.spec.variants["build_extra"]),
             self.define("SINGULARITY_TEST_SESAME",

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -47,8 +47,6 @@ class SingularityEos(CMakePackage, CudaPackage):
 
     variant("eospac", default=True, description="Pull in EOSPAC")
 
-    variant("hdf5_fortran", default=False, description="Use +fortran variant for HDF5")
-
     # building/testing/docs
     depends_on("cmake@3.14:")
     depends_on("catch2@2.13.7", when="+tests")
@@ -109,9 +107,6 @@ class SingularityEos(CMakePackage, CudaPackage):
         depends_on("py-h5py" + _flag, when=_flag)
         depends_on("kokkos-nvcc-wrapper" + _flag, when="+cuda+kokkos" + _flag)
 
-    depends_on("hdf5+fortran", when="+hdf5_fortran")
-    conflicts("+hdf5_fortran", when="~fortran")
-
     def cmake_args(self):
         args = [
             self.define("SINGULARITY_PATCH_MPARK_VARIANT", False),
@@ -122,7 +117,6 @@ class SingularityEos(CMakePackage, CudaPackage):
             self.define_from_variant("SINGULARITY_BUILD_CLOSURE", "fortran"),
             self.define_from_variant("SINGULARITY_BUILD_PYTHON", "python"),
             self.define_from_variant("SINGULARITY_BUILD_TESTS", "tests"),
-            self.define_from_variant("SINGULARITY_LINK_HDF5_FORTRAN", "hdf5_fortran"),
             self.define("SINGULARITY_BUILD_SESAME2SPINER",
                         "sesame" in self.spec.variants["build_extra"]),
             self.define("SINGULARITY_TEST_SESAME",

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -107,6 +107,8 @@ class SingularityEos(CMakePackage, CudaPackage):
         depends_on("py-h5py" + _flag, when=_flag)
         depends_on("kokkos-nvcc-wrapper" + _flag, when="+cuda+kokkos" + _flag)
 
+    depends_on("hdf5+fortran", when="+fortran")
+
     def cmake_args(self):
         args = [
             self.define("SINGULARITY_PATCH_MPARK_VARIANT", False),

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,7 +62,7 @@ if (SINGULARITY_USE_HDF5 AND SINGULARITY_TEST_STELLAR_COLLAPSE)
 
   message(STATUS "Generating stellar collapse table for tests using Python script")
   find_package(Python COMPONENTS Interpreter REQUIRED)
-  if (HDF5_IS_PARALLEL)
+  if (HDF5_parallel_FOUND)
     execute_process(COMMAND mpirun -n 1 ${Python_EXECUTABLE}
       ${CMAKE_SOURCE_DIR}/utils/scripts/make_tabulated_ideal_sc.py
       -o ${PROJECT_BINARY_DIR}/stellar_collapse_ideal.h5)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Before, we used `cmake` variables that held the `hdf5` configuration data. This PR updates to use `hdf5` interface targets, `HDF5::HDF5; HDF5::hdf5_hl`.

This addresses some CI issues, and makes using HDF5 cleaner.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] After creating a pull request, note it in the CHANGELOG.md file
