### PR TITLE
Checks for found and target in singularity-eosConfig.cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [[PR181]](https://github.com/lanl/singularity-eos/pull/181) change from manual dependecy handling to using hdf5 interface targets
 
 ### Fixed (Repair bugs, etc)
+- [[PR183]](https://github.com/lanl/singularity-eos/pull/183) fortify cmake export config to always have interface targets of dependencies that need them
 - [[PR174]](https://github.com/lanl/singularity-eos/pull/174) fix build configuration when closures are disabled
 - [[PR157]](https://github.com/lanl/singularity-eos/pull/157) fix root finders in Gruneisen, Davis, and JWL
 - [[PR151]](https://github.com/lanl/singularity-eos/pull/151) fix module install

--- a/cmake/dependency.cmake
+++ b/cmake/dependency.cmake
@@ -131,6 +131,9 @@ macro(singularity_import_dependency)
   if(dep_COMPONENTS)
     list(APPEND SINGULARITY_DEP_PKGS_${dep_PKG} "${dep_COMPONENTS}")
   endif()
+  if(dep_TARGET)
+    set(SINGULARITY_DEP_TARGET_${dep_PKG} ${dep_TARGET})
+  endif()
   unset(_SMSG_PREFIX)
 endmacro() # singularity_import_dependency
 

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -18,6 +18,8 @@ include(GNUInstallDirs)
 # Generate config file
 #----------------------------------------------------------------------------#
 
+#TODO: Try to use the built-in cmake procedure for this
+
 # get all available `SINGULARITY_` cmake variables set during configuration
 get_cmake_property(_variableNames VARIABLES)
 string (REGEX MATCHALL "(^|;)SINGULARITY_[A-Za-z0-9_]*"
@@ -37,11 +39,21 @@ endforeach()
 # package install path
 foreach(_depName ${SINGULARITY_DEP_PKGS})
   set(_components "")
+  set(_target "")
   if(SINGULARITY_DEP_PKGS_${_depName})
     set(_components "COMPONENTS ${SINGULARITY_DEP_PKGS_${_depName}}")
   endif()
+  if(SINGULARITY_DEP_TARGET_${_depName})
+    set(_target "${SINGULARITY_DEP_TARGET_${_depName}}")
+  endif()
   set(SINGULARITY_CONFIG_DEPENDENCIES
-    "${SINGULARITY_CONFIG_DEPENDENCIES}\nif(NOT ${_depName}_FOUND)\n\tfind_package(${_depName} ${_components} REQUIRED)\nendif()")
+    "${SINGULARITY_CONFIG_DEPENDENCIES}\nif(NOT ${_depName}_FOUND")
+  if(NOT "${_target}" STREQUAL "")
+    set(SINGULARITY_CONFIG_DEPENDENCIES
+      "${SINGULARITY_CONFIG_DEPENDENCIES} OR NOT TARGET ${_target}")
+  endif()
+  set(SINGULARITY_CONFIG_DEPENDENCIES
+    "${SINGULARITY_CONFIG_DEPENDENCIES})\n\tfind_package(${_depName} ${_components} REQUIRED)\nendif()")
 endforeach()
 
 # generate the configuration file


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

The exported configuration checked for `Eigen3_FOUND` and passed, but the concurrent processing wasn't able to find the interface target `Eigen3::Eigen`. This updates the configuration check to check both.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->



## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
