### PR TITLE
remove h5py from spack and from tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added (new features/APIs/variables/...)
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR192]](https://github.com/lanl/singularity-eos/pull/192) remove h5py and start using gold files
 
 ### Fixed (not changing behavior/API/variables/...)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ project(singularity-eos VERSION 1.6.2 LANGUAGES NONE)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 set(SINGULARITY_GOLDFILES_VERSION "goldfiles-1.6.2")
+set(SINGULARITY_GOLDFILE_HASH
+  33ef74b29937cc1347b525f72662933dd2b0556550f6541f97fc1de8a01c3c2a)
 
 #------------------------------------------------------------------------------#
 # Use better messages
@@ -479,7 +481,6 @@ include(cmake/install.cmake)
 # to enable tests. It creates a "BUILD_TESTING" option, and runs
 # `enable_testing()`. See https://cmake.org/cmake/help/latest/module/CTest.html
 if(SINGULARITY_BUILD_TESTS)
-  include(ExternalProject) # for downloading files
   enable_testing()
   add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ project(singularity-eos VERSION 1.6.2 LANGUAGES NONE)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+set(SINGULARITY_GOLDFILES_VERSION "goldfiles-1.6.2")
+
 #------------------------------------------------------------------------------#
 # Use better messages
 #------------------------------------------------------------------------------#
@@ -477,6 +479,7 @@ include(cmake/install.cmake)
 # to enable tests. It creates a "BUILD_TESTING" option, and runs
 # `enable_testing()`. See https://cmake.org/cmake/help/latest/module/CTest.html
 if(SINGULARITY_BUILD_TESTS)
+  include(ExternalProject) # for downloading files
   enable_testing()
   add_subdirectory(test)
 endif()

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -52,7 +52,6 @@ class SingularityEos(CMakePackage, CudaPackage):
     depends_on("catch2@2.13.7", when="+tests")
     depends_on("python@3:", when="+python")
     depends_on("py-pybind11@2.9.1:", when="+python")
-#    depends_on("py-h5py", when="+tests build_extra=stellarcollapse")
     depends_on("py-sphinx", when="+doc")
     depends_on("py-sphinx-rtd-theme@0.4.3", when="+doc")
     depends_on("py-sphinx-multiversion", when="+doc")
@@ -102,9 +101,7 @@ class SingularityEos(CMakePackage, CudaPackage):
     # common MPI dependence
     for _flag in ("~mpi", "+mpi"):
         depends_on("hdf5~cxx+hl" + _flag, when=_flag)
-        depends_on("py-h5py" + _flag, when="+tests build_extra=stellarcollapse " + _flag)
 #        depends_on("hdf5+hl" + _flag, when=_flag)
-        depends_on("py-h5py" + _flag, when=_flag)
         depends_on("kokkos-nvcc-wrapper" + _flag, when="+cuda+kokkos" + _flag)
 
     def cmake_args(self):

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -101,7 +101,6 @@ class SingularityEos(CMakePackage, CudaPackage):
     # common MPI dependence
     for _flag in ("~mpi", "+mpi"):
         depends_on("hdf5~cxx+hl" + _flag, when=_flag)
-#        depends_on("hdf5+hl" + _flag, when=_flag)
         depends_on("kokkos-nvcc-wrapper" + _flag, when="+cuda+kokkos" + _flag)
 
     def cmake_args(self):

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,7 +56,7 @@ if (SINGULARITY_BUILD_CLOSURE)
 endif()
 
 if (SINGULARITY_USE_HDF5 AND SINGULARITY_TEST_STELLAR_COLLAPSE)
-   set(SINGULARITY_GOLDFILE_URL
+  set(SINGULARITY_GOLDFILE_URL
     https://github.com/lanl/singularity-eos/releases/download/${SINGULARITY_GOLDFILES_VERSION}/goldfiles.tar.gz)
   message(STATUS "Attempting to download gold files for regression tests. "
     "File is located at ${SINGULARITY_GOLDFILE_URL} "

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,16 +60,17 @@ if (SINGULARITY_USE_HDF5 AND SINGULARITY_TEST_STELLAR_COLLAPSE)
                  profile_stellar_collapse.cpp)
   target_link_libraries(profile_stellar_collapse singularity-eos::singularity-eos)
 
-  message(STATUS "Generating stellar collapse table for tests using Python script")
-  find_package(Python COMPONENTS Interpreter REQUIRED)
-  if (HDF5_parallel_FOUND)
-    execute_process(COMMAND mpirun -n 1 ${Python_EXECUTABLE}
-      ${CMAKE_SOURCE_DIR}/utils/scripts/make_tabulated_ideal_sc.py
-      -o ${PROJECT_BINARY_DIR}/stellar_collapse_ideal.h5)
-  else()
-    execute_process(COMMAND ${Python_EXECUTABLE}
-      ${CMAKE_SOURCE_DIR}/utils/scripts/make_tabulated_ideal_sc.py
-      -o ${PROJECT_BINARY_DIR}/stellar_collapse_ideal.h5)
+  if (NOT EXISTS ${PROJECT_BINARY_DIR}/stellar_collapse_ideal.h5)
+    message(STATUS "Attempting to download the stellar collapse gold file for regression tests. "
+      "You can also download this file manually, and save it in the build directory. "
+      "File is located at https://github.com/lanl/singularity-eos/releases/download/${SINGULARITY_GOLDFILES_VERSION}/stellar_collapse_ideal.h5 "
+      "If you do not want to use the gold file, you can set -DSINGULARITY_TEST_STELLAR_COLLAPSE=OFF."
+      )
+    file(
+      DOWNLOAD
+      https://github.com/lanl/singularity-eos/releases/download/${SINGULARITY_GOLDFILES_VERSION}/stellar_collapse_ideal.h5
+      ${CMAKE_BINARY_DIR}/stellar_collapse_ideal.h5
+      )
   endif()
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,7 +65,7 @@ if (SINGULARITY_USE_HDF5 AND SINGULARITY_TEST_STELLAR_COLLAPSE)
   include(FetchContent)
   FetchContent_Declare(goldfiles
     URL ${SINGULARITY_GOLDFILE_URL}
-    URL_HASH SHA256=${SIGNULARITY_GOLDFILE_HASH}
+    URL_HASH SHA256=${SINGULARITY_GOLDFILE_HASH}
     SOURCE_DIR goldfiles
     )
   FetchContent_MakeAvailable(goldfiles)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,22 +56,23 @@ if (SINGULARITY_BUILD_CLOSURE)
 endif()
 
 if (SINGULARITY_USE_HDF5 AND SINGULARITY_TEST_STELLAR_COLLAPSE)
+   set(SINGULARITY_GOLDFILE_URL
+    https://github.com/lanl/singularity-eos/releases/download/${SINGULARITY_GOLDFILES_VERSION}/goldfiles.tar.gz)
+  message(STATUS "Attempting to download gold files for regression tests. "
+    "File is located at ${SINGULARITY_GOLDFILE_URL} "
+    "If you do not want to use the gold file, you can set -DSINGULARITY_TEST_STELLAR_COLLAPSE=OFF."
+    )
+  include(FetchContent)
+  FetchContent_Declare(goldfiles
+    URL ${SINGULARITY_GOLDFILE_URL}
+    URL_HASH SHA256=${SIGNULARITY_GOLDFILE_HASH}
+    SOURCE_DIR goldfiles
+    )
+  FetchContent_MakeAvailable(goldfiles)
+
   add_executable(profile_stellar_collapse
                  profile_stellar_collapse.cpp)
   target_link_libraries(profile_stellar_collapse singularity-eos::singularity-eos)
-
-  if (NOT EXISTS ${PROJECT_BINARY_DIR}/stellar_collapse_ideal.h5)
-    message(STATUS "Attempting to download the stellar collapse gold file for regression tests. "
-      "You can also download this file manually, and save it in the build directory. "
-      "File is located at https://github.com/lanl/singularity-eos/releases/download/${SINGULARITY_GOLDFILES_VERSION}/stellar_collapse_ideal.h5 "
-      "If you do not want to use the gold file, you can set -DSINGULARITY_TEST_STELLAR_COLLAPSE=OFF."
-      )
-    file(
-      DOWNLOAD
-      https://github.com/lanl/singularity-eos/releases/download/${SINGULARITY_GOLDFILES_VERSION}/stellar_collapse_ideal.h5
-      ${CMAKE_BINARY_DIR}/stellar_collapse_ideal.h5
-      )
-  endif()
 endif()
 
 if (SINGULARITY_BUILD_PYTHON AND SINGULARITY_TEST_PYTHON)

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -992,7 +992,7 @@ SCENARIO("Stellar Collapse EOS", "[StellarCollapse][EOSBuilder]") {
   const std::string savename = "stellar_collapse_ideal_2.sp5";
   static constexpr Real MeV2K_ = 1.e9 * 11.604525006;
   GIVEN("A stellar collapse EOS") {
-    const std::string filename = "../stellar_collapse_ideal.h5";
+    const std::string filename = "./goldfiles/stellar_collapse_ideal.h5";
     THEN("We can load the file") { // don't bother filtering bmod here.
       StellarCollapse sc(filename, false, false);
       AND_THEN("Some properties we expect for ideal gas hold") {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As requested by @mauneyc-LANL @dholladay00 and motivated by issues @annapiegra is having with oneapi, this PR does the following:
- Stores an hdf5 "gold" file as a release
- Downloads the file in cmake if needed
- Removes `py-h5py` from spack and cmake dependencies.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
