### PR TITLE
Update ports-of-call and introduce error handling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,10 +14,10 @@ variables:
   SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+python+tests%gcc@${SINGULARITY_EOS_GCC_VERSION} ^openmpi@${SINGULARITY_EOS_OPENMPI_VERSION}"
 
 before_script:
-  - ls utils/singularity-eos/singularity-eos
+  - pwd
+  - ls
   - git submodule sync --recursive
   - git submodule update --init --recursive
-  - ls utils/singularity-eos/singularity-eos
   - export HOME=${CI_PROJECT_DIR}
   - export SPACK_DISABLE_LOCAL_CONFIG=true
   - export SPACK_USER_CACHE_PATH=/tmp/spack-local

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,10 @@ variables:
   SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+python+tests%gcc@${SINGULARITY_EOS_GCC_VERSION} ^openmpi@${SINGULARITY_EOS_OPENMPI_VERSION}"
 
 before_script:
+  - ls utils/singularity-eos/singularity-eos
+  - git submodule sync --recursive
+  - git submodule update --init --recursive
+  - ls utils/singularity-eos/singularity-eos
   - export HOME=${CI_PROJECT_DIR}
   - export SPACK_DISABLE_LOCAL_CONFIG=true
   - export SPACK_USER_CACHE_PATH=/tmp/spack-local

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,13 +14,6 @@ variables:
   SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+python+tests%gcc@${SINGULARITY_EOS_GCC_VERSION} ^openmpi@${SINGULARITY_EOS_OPENMPI_VERSION}"
 
 before_script:
-  - pwd
-  - ls
-  - git submodule sync --recursive
-  - git submodule update --init --recursive
-  - ls utils
-  - ls utils/ports-of-call
-  - ls utils/ports-of-call/ports-of-call
   - export HOME=${CI_PROJECT_DIR}
   - export SPACK_DISABLE_LOCAL_CONFIG=true
   - export SPACK_USER_CACHE_PATH=/tmp/spack-local

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,9 @@ before_script:
   - ls
   - git submodule sync --recursive
   - git submodule update --init --recursive
+  - ls utils
+  - ls utils/ports-of-call
+  - ls utils/ports-of-call/ports-of-call
   - export HOME=${CI_PROJECT_DIR}
   - export SPACK_DISABLE_LOCAL_CONFIG=true
   - export SPACK_USER_CACHE_PATH=/tmp/spack-local

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "utils/kokkos"]
 	path = utils/kokkos
 	url = https://github.com/kokkos/kokkos.git
+[submodule "utils/ports-of-call"]
+	path = utils/ports-of-call
+	url = ../ports-of-call.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [[PR214]](https://github.com/lanl/singularity-eos/pull/214) added documentation about adding a new EOS
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR223]](https://github.com/lanl/singularity-eos/pull/223) Update ports-of-call and add portable error handling
 - [[PR219]](https://github.com/lanl/singularity-eos/pull/219) Removed static analysis from re-git pipeline
 
 ### Infrastructure (changes irrelevant to downstream codes)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,7 @@ singularity_import_dependency(
 )
 
 # ports-of-call
-# type: ghost submodule
+# type: soft submodule
 singularity_import_dependency(
   PKG ports-of-call
   TARGETS ports-of-call::ports-of-call

--- a/doc/sphinx/src/contributing.rst
+++ b/doc/sphinx/src/contributing.rst
@@ -234,6 +234,12 @@ data that is particular to the EOS you have developed, and only for those
 specific tests should you instantiate an object whose type is your specific
 EOS. Otherwise, use the ``EOS`` object.
 
+If you wish to test error handling in your EOS, you may use the macro
+``REQUIRE_MAYBE_THROWS``, which is defined in the ``eos_unit_test_helpers.hpp``
+header file. This macro will check if your code throws an exception if
+compiled for CPU only and otherwise is a no-op. This is intended to combine with
+the ``PORTABLE_THROW_OR_ABORT` macro defined in ``ports-of-call``.
+
 Step 4: Fortran interface
 `````````````````````````
 

--- a/singularity-eos/base/eos_error.hpp
+++ b/singularity-eos/base/eos_error.hpp
@@ -15,14 +15,8 @@
 #ifndef SINGULARITY_EOS_BASE_EOS_ERROR_HPP_
 #define SINGULARITY_EOS_BASE_EOS_ERROR_HPP_
 
-#ifdef SINGULARITY_ENABLE_EXCEPTIONS
-#include <stdexcept>
-#define EOS_ERROR(x) (throw std::runtime_error(x))
-#else
-#define EOS_ERROR(x)                                                                     \
-  printf("%s\n", x);                                                                     \
-  assert(false);
-#endif
+#include <ports-of-call/portable_errors>
+#define EOS_ERROR(x) PORTABLE_ABORT(x)
 #define UNDEFINED_ERROR EOS_ERROR("DEFINE ME\n")
 
 #endif // SINGULARITY_EOS_BASE_EOS_ERROR_HPP_

--- a/singularity-eos/base/eos_error.hpp
+++ b/singularity-eos/base/eos_error.hpp
@@ -15,7 +15,7 @@
 #ifndef SINGULARITY_EOS_BASE_EOS_ERROR_HPP_
 #define SINGULARITY_EOS_BASE_EOS_ERROR_HPP_
 
-#include <ports-of-call/portable_errors>
+#include <ports-of-call/portable_errors.hpp>
 #define EOS_ERROR(x) PORTABLE_ABORT(x)
 #define UNDEFINED_ERROR EOS_ERROR("DEFINE ME\n")
 

--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -16,6 +16,7 @@ class PortsOfCall(CMakePackage):
     maintainers = ['rbberger']
 
     version("main", branch="main")
+    version("1.4.1", sha256="82d2c75fcca8bd613273fd4126749df68ccc22fbe4134ba673b4275f9972b78d")
     version("1.4.0", sha256="e08ae556b7c30d14d77147d248d118cf5343a2e8c0847943385c602394bda0fa")
     version('1.3.0', sha256='54b4a62539c23b1a345dd87c1eac65f4f69db4e50336cd81a15a627ce80ce7d9')
     version('1.2.0', sha256='b802ffa07c5f34ea9839f23841082133d8af191efe5a526cb7e53ec338ac146b')

--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -16,6 +16,7 @@ class PortsOfCall(CMakePackage):
     maintainers = ['rbberger']
 
     version("main", branch="main")
+    version("1.4.0", sha256="e08ae556b7c30d14d77147d248d118cf5343a2e8c0847943385c602394bda0fa")
     version('1.3.0', sha256='54b4a62539c23b1a345dd87c1eac65f4f69db4e50336cd81a15a627ce80ce7d9')
     version('1.2.0', sha256='b802ffa07c5f34ea9839f23841082133d8af191efe5a526cb7e53ec338ac146b')
     version('1.1.0', sha256='c47f7e24c82176b69229a2bcb23a6adcf274dc90ec77a452a36ccae0b12e6e39')

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -63,7 +63,7 @@ class SingularityEos(CMakePackage, CudaPackage):
 
     depends_on("eospac", when="+eospac")
     depends_on("spiner")
-    depends_on("ports-of-call@main")
+    depends_on("ports-of-call@1.4.0")
     depends_on("spiner +kokkos", when="+kokkos")
 
     depends_on("mpark-variant")

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -63,6 +63,7 @@ class SingularityEos(CMakePackage, CudaPackage):
 
     depends_on("eospac", when="+eospac")
     depends_on("spiner")
+    depends_on("ports-of-call@main")
     depends_on("spiner +kokkos", when="+kokkos")
 
     depends_on("mpark-variant")

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -63,7 +63,7 @@ class SingularityEos(CMakePackage, CudaPackage):
 
     depends_on("eospac", when="+eospac")
     depends_on("spiner")
-    depends_on("ports-of-call@1.4.0:")
+    depends_on("ports-of-call@1.4.1:")
     depends_on("spiner +kokkos", when="+kokkos")
 
     depends_on("mpark-variant")

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -63,7 +63,7 @@ class SingularityEos(CMakePackage, CudaPackage):
 
     depends_on("eospac", when="+eospac")
     depends_on("spiner")
-    depends_on("ports-of-call@1.4.0")
+    depends_on("ports-of-call@1.4.0:")
     depends_on("spiner +kokkos", when="+kokkos")
 
     depends_on("mpark-variant")

--- a/spack-repo/packages/spiner/package.py
+++ b/spack-repo/packages/spiner/package.py
@@ -36,8 +36,7 @@ class Spiner(CMakePackage, CudaPackage):
 
     depends_on("cmake@3.23:")
     depends_on("catch2@2.13.7:2.13.10")
-    depends_on("ports-of-call@main")
-    #depends_on("ports-of-call@1.2.1:")
+    depends_on("ports-of-call@1.2.1:")
 
     # Currently the raw cuda backend of ports-of-call is not supported.
     for _flag in list(CudaPackage.cuda_arch_values):

--- a/spack-repo/packages/spiner/package.py
+++ b/spack-repo/packages/spiner/package.py
@@ -36,7 +36,8 @@ class Spiner(CMakePackage, CudaPackage):
 
     depends_on("cmake@3.23:")
     depends_on("catch2@2.13.7:2.13.10")
-    depends_on("ports-of-call@1.2.1:")
+    depends_on("ports-of-call@main")
+    #depends_on("ports-of-call@1.2.1:")
 
     # Currently the raw cuda backend of ports-of-call is not supported.
     for _flag in list(CudaPackage.cuda_arch_values):

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -106,6 +106,6 @@ inline void compare_two_eoss(const EOS &test_e, const EOS &ref_e) {
 #define REQUIRE_MAYBE_THROWS(...) REQUIRE_THROWS(__VA_ARGS__)
 #else
 #define REQUIRE_MAYBE_THROWS(...) ((void)0)
-endif // PORTABILITY_STRATEGY_NONE
+#endif // PORTABILITY_STRATEGY_NONE
 
 #endif // _SINGULARITY_EOS_TEST_TEST_HELPERS_

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -103,7 +103,7 @@ inline void compare_two_eoss(const EOS &test_e, const EOS &ref_e) {
 // Macro that checks for an exception or is a no-op depending on
 // whether or not a non-serial backend is supplied
 #ifdef PORTABILITY_STRATEGY_NONE
-#define REQUIRE_MAYBE_THROWS(...) REQUIRE_THROWS(__VA_ARGS__)
+#define REQUIRE_MAYBE_THROWS(...) REQUIRE_THROWS( __VA_ARGS__ )
 #else
 #define REQUIRE_MAYBE_THROWS(...) ((void)0)
 #endif // PORTABILITY_STRATEGY_NONE

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2022. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -100,4 +100,12 @@ inline void compare_two_eoss(const EOS &test_e, const EOS &ref_e) {
   return;
 }
 
-#endif
+// Macro that checks for an exception or is a no-op depending on
+// whether or not a non-serial backend is supplied
+#ifdef PORTABILITY_STRATEGY_NONE
+#define REQUIRE_MAYBE_THROWS(...) REQUIRE_THROWS(__VA_ARGS__)
+#else
+#define REQUIRE_MAYBE_THROWS(...) ((void)0)
+endif // PORTABILITY_STRATEGY_NONE
+
+#endif // _SINGULARITY_EOS_TEST_TEST_HELPERS_

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -103,7 +103,7 @@ inline void compare_two_eoss(const EOS &test_e, const EOS &ref_e) {
 // Macro that checks for an exception or is a no-op depending on
 // whether or not a non-serial backend is supplied
 #ifdef PORTABILITY_STRATEGY_NONE
-#define REQUIRE_MAYBE_THROWS(...) REQUIRE_THROWS( __VA_ARGS__ )
+#define REQUIRE_MAYBE_THROWS(...) REQUIRE_THROWS(__VA_ARGS__)
 #else
 #define REQUIRE_MAYBE_THROWS(...) ((void)0)
 #endif // PORTABILITY_STRATEGY_NONE

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -133,7 +133,9 @@ inline void compare_two_eoss(E1 &&test_e, E2 &&ref_e) {
 }
 
 SCENARIO("Test that we can either throw an error on host or do nothing on device", "[RequireMaybe]") {
-  REQUIRE_MAYBE_THROWS( [&](){ PORTABLE_ALWAYS_THROW_OR_ABORT("Error message"); }() );
+  // TODO(JMM): For whatever reason, the preprocessor does not like it if I
+  // call `PORTABLE_ALWAYS_THROW_OR_ABORT
+  REQUIRE_MAYBE_THROWS( PORTABLE_ALWAYS_THROW_OR_ABORT("Error message") );
 }
 
 SCENARIO("Test that fast logs are invertible and run on device", "[FastMath]") {

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -133,7 +133,7 @@ inline void compare_two_eoss(E1 &&test_e, E2 &&ref_e) {
 }
 
 SCENARIO("Test that we can either throw an error on host or do nothing on device", "[RequireMaybe]") {
-  REQUIRE_MAYBE_THROWS( PORTABLE_ALWAYS_THROW_OR_ABORT("This is an error") );
+  REQUIRE_MAYBE_THROWS( [&](){ PORTABLE_ALWAYS_THROW_OR_ABORT("Error message"); }() );
 }
 
 SCENARIO("Test that fast logs are invertible and run on device", "[FastMath]") {

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -132,10 +132,11 @@ inline void compare_two_eoss(E1 &&test_e, E2 &&ref_e) {
   return;
 }
 
-SCENARIO("Test that we can either throw an error on host or do nothing on device", "[RequireMaybe]") {
+SCENARIO("Test that we can either throw an error on host or do nothing on device",
+         "[RequireMaybe]") {
   // TODO(JMM): For whatever reason, the preprocessor does not like it if I
   // call `PORTABLE_ALWAYS_THROW_OR_ABORT
-  REQUIRE_MAYBE_THROWS( PORTABLE_ALWAYS_THROW_OR_ABORT("Error message") );
+  REQUIRE_MAYBE_THROWS(PORTABLE_ALWAYS_THROW_OR_ABORT("Error message"));
 }
 
 SCENARIO("Test that fast logs are invertible and run on device", "[FastMath]") {

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -21,6 +21,7 @@
 
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
+#include <ports-of-call/portable_errors.hpp>
 #include <singularity-eos/base/fast-math/logs.hpp>
 #include <singularity-eos/base/root-finding-1d/root_finding.hpp>
 #include <singularity-eos/eos/eos.hpp>
@@ -129,6 +130,10 @@ inline void compare_two_eoss(E1 &&test_e, E2 &&ref_e) {
                             << " test T min.: " << test_e.MinimumTemperature());
   CHECK(isClose(test_e.MinimumTemperature(), ref_e.MinimumTemperature(), 1.e-15));
   return;
+}
+
+SCENARIO("Test that we can either throw an error on host or do nothing on device", "[RequireMaybe]") {
+  REQUIRE_MAYBE_THROWS( PORTABLE_ALWAYS_THROW_OR_ABORT("This is an error") );
 }
 
 SCENARIO("Test that fast logs are invertible and run on device", "[FastMath]") {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This pulls my error handling machinery through `singularity-eos`, mostly motivated by @aematt's request for testing. I make a few changes of note:
1. I make `ports-of-call` its own submodule. This is unfortunately required for now. Once @mauneyc-LANL 's PR #221 is through, this won't be necessary and the submodule should be removed. Note that I **do not** update `spiner`. I think @mauneyc-LANL 's changes to `spiner` make it incompatible with the submodule path for now. So spiner stays on the old commit until #221 goes through.
2. I create a new macro, `REQUIRE_MAYBE_THROWS` which is to be used in units tests with catch. It either resolves to a `REQUIRE_THROWS` if `PORTABILITY_STRATEGY_NONE` or a no-op. This is what @aematts should use.
3. As a temp hack, I replace `EOS_ERROR` with `PORTABLE_ABORT`. We should move to `PORTABLE_*` everywhere with time. This is just for backwards compatibility.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [x] If preparing for a new release, update the version in cmake.
