### PR TITLE
Add entropy interpolation to stellar collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current develop
 
+### Added (entropy calculation for stellar collapse eos)
+- [[PR226]](https://github.com/lanl/singularity-eos/pull/226) added entropy interpolation to stellar collapse eos
+
 ### Fixed (Repair bugs, etc)
 - [[PR215]](https://github.com/lanl/singularity-eos/pull/215) and [[PR216]](https://github.com/lanl/singularity-eos/pull/216) fix duplicate definition of EPS and fix CI
 

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -104,6 +104,9 @@ class StellarCollapse : public EosBase<StellarCollapse> {
   Real PressureFromDensityInternalEnergy(const Real rho, const Real sie,
                                          Real *lambda = nullptr) const;
   PORTABLE_INLINE_FUNCTION
+  Real EntropyFromDensityTemperature(const Real rho, const Real temperature,
+                                     Real *lambda = nullptr) const;
+  PORTABLE_INLINE_FUNCTION
   Real SpecificHeatFromDensityTemperature(const Real rho, const Real temperature,
                                           Real *lambda = nullptr) const;
   PORTABLE_INLINE_FUNCTION
@@ -291,7 +294,7 @@ class StellarCollapse : public EosBase<StellarCollapse> {
   static constexpr Real TNormal_ = 5 * GK2MeV_; // Threshold of NSE
   static constexpr Real rhoNormal_ = 2.e12;     // 1./100'th of nuclear density
   static constexpr Real YeNormal_ = 0.3517;     // Beta equilibrium value
-  Real sieNormal_, PNormal_;
+  Real sieNormal_, PNormal_, SNormal_;
   Real CvNormal_, bModNormal_, dPdENormal_, dVdTNormal_;
 
   // offsets must be non-negative
@@ -421,6 +424,7 @@ inline StellarCollapse StellarCollapse::GetOnDevice() {
   other.lEOffset_ = lEOffset_;
   other.sieNormal_ = sieNormal_;
   other.PNormal_ = PNormal_;
+  other.SNormal_ = SNormal_;
   other.CvNormal_ = CvNormal_;
   other.bModNormal_ = bModNormal_;
   other.dPdENormal_ = dPdENormal_;
@@ -483,6 +487,16 @@ Real StellarCollapse::PressureFromDensityInternalEnergy(const Real rho, const Re
   getLogsFromRhoSie_(rho, sie, lambda, lRho, lT, Ye);
   const Real lP = lP_.interpToReal(Ye, lT, lRho);
   return lP2P_(lP);
+}
+
+PORTABLE_INLINE_FUNCTION
+Real StellarCollapse::EntropyFromDensityTemperature(const Real rho,
+                                                    const Real temperature,
+                                                    Real *lambda) const {
+  Real lRho, lT, Ye;
+  getLogsFromRhoT_(rho, temperature, lambda, lRho, lT, Ye);
+  const Real entropy = entropy_.interpToReal(Ye, lT, lRho);
+  return (entropy > robust::EPS() ? entropy : robust::EPS());
 }
 
 PORTABLE_INLINE_FUNCTION
@@ -883,6 +897,9 @@ inline void StellarCollapse::setNormalValues_() {
 
   const Real lP = lP_.interpToReal(Ye, lT, lRho);
   PNormal_ = lP2P_(lP);
+
+  const Real entropy = entropy_.interpToReal(Ye, lT, lRho);
+  SNormal_ = entropy;
 
   const Real Cv = dEdT_.interpToReal(Ye, lT, lRho);
   CvNormal_ = (Cv > robust::EPS() ? Cv : robust::EPS());

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -1127,6 +1127,7 @@ SCENARIO("Stellar Collapse EOS", "[StellarCollapse][EOSBuilder]") {
 #endif
 
             const int N = 123;
+            constexpr Real gamma = 1.4;
             const Real dY = (yemax - yemin) / (N + 1);
             const Real dlT = (ltmax - ltmin) / (N + 1);
             const Real dlR = (lrhomax - lrhomin) / (N + 1);
@@ -1139,7 +1140,7 @@ SCENARIO("Stellar Collapse EOS", "[StellarCollapse][EOSBuilder]") {
                   Real lR = lrhomin + i * dlR;
                   Real T = std::pow(10., lT);
                   Real R = std::pow(10., lR);
-                  Real e1, e2, p1, p2, cv1, cv2, b1, b2;
+                  Real e1, e2, p1, p2, cv1, cv2, b1, b2, s1, s2;
                   unsigned long output =
                       (singularity::thermalqs::pressure |
                        singularity::thermalqs::specific_internal_energy |
@@ -1149,10 +1150,14 @@ SCENARIO("Stellar Collapse EOS", "[StellarCollapse][EOSBuilder]") {
 
                   sc1_d.FillEos(R, T, e1, p1, cv1, b1, output, lambda);
                   sc2_d.FillEos(R, T, e2, p2, cv2, b2, output, lambda);
+                  // Fill entropy. Will need to change later.
+                  s1 = sc1_d.EntropyFromDensityTemperature(R, T, lambda);
+                  s2 = p2 * std::pow(R, -gamma); // ideal
                   if (!isClose(e1, e2)) nwrong_d() += 1;
                   if (!isClose(p1, p2)) nwrong_d() += 1;
                   if (!isClose(cv1, cv2)) nwrong_d() += 1;
                   if (!isClose(b1, b2)) nwrong_d() += 1;
+                  if (!isClose(s1, s2)) nwrong_d() += 1;
                 });
 #ifdef PORTABILITY_STRATEGY_KOKKOS
             Kokkos::deep_copy(nwrong_h, nwrong_d);


### PR DESCRIPTION
This PR adds a function `EntropyFromDensityTemperature` to `eos_stellar_collapse.hpp` that interpolates entropy from the tabulated Eos. I added a placeholder test to ensure that the interpolated entropy is comparable to the ideal gas entropy when appropriate.

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
