### PR TITLE
Added untracked headers in cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current develop
 
+### Fixed (issue #227)
+- [[PR228]](https://github.com/lanl/singularity-eos/pull/228) added untracked header files in cmake
+
 ### Added (entropy calculation for stellar collapse eos)
 - [[PR226]](https://github.com/lanl/singularity-eos/pull/226) added entropy interpolation to stellar collapse eos
 

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -13,27 +13,32 @@
 #------------------------------------------------------------------------------#
 
 set(EOS_HEADERS
-    base/constants.hpp
-    base/eos_error.hpp
+    closure/mixed_cell_models.hpp
     base/fast-math/logs.hpp
-    base/math_utils.hpp
     base/robust_utils.hpp
     base/root-finding-1d/root_finding.hpp
+    base/variadic_utils.hpp
+    base/math_utils.hpp
+    base/constants.hpp
+    base/eos_error.hpp
+    base/sp5/singularity_eos_sp5.hpp
     eos/eos.hpp
-    eos/eos_builder.hpp
-    eos/eos_davis.hpp
-    eos/eos_eospac.hpp
-    eos/eos_gruneisen.hpp
-    eos/eos_ideal.hpp
-    eos/eos_jwl.hpp
-    eos/eos_spiner.hpp
-    eos/eos_stellar_collapse.hpp
     eos/eos_variant.hpp
-    eos/modifiers/eos_unitsystem.hpp
-    eos/modifiers/ramps_eos.hpp
-    eos/modifiers/scaled_eos.hpp
-    eos/modifiers/shifted_eos.hpp
+    eos/singularity_eos.hpp
+    eos/eos_stellar_collapse.hpp
+    eos/eos_ideal.hpp
+    eos/eos_spiner.hpp
+    eos/eos_davis.hpp
+    eos/eos_gruneisen.hpp
+    eos/eos_builder.hpp
+    eos/eos_jwl.hpp
     eos/modifiers/relativistic_eos.hpp
+    eos/modifiers/scaled_eos.hpp
+    eos/modifiers/ramps_eos.hpp
+    eos/modifiers/shifted_eos.hpp
+    eos/modifiers/eos_unitsystem.hpp
+    eos/eos_base.hpp
+    eos/eos_eospac.hpp
 )
 
 set(EOS_SRCS


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Addressing #227 . `singularity-eos/CMakeLists.txt` updated to include all header files in code.

This could be an impetus to automate source file discovery in the build, but my impression is `GLOB` and similar commands are not recommended. This could be an outdated mode of thought, tho.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- N/A  Adds a test for any bugs fixed. Adds tests for new features.
- N/A  Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- N/A If preparing for a new release, update the version in cmake.
