### PR TITLE
Fix install CMake variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current develop
 
+### Fixed (Repair, bugs, ect)
+- [[PR232]](https://github.com/lanl/singularity-eos/pull/228) Fixed uninitialized cmake path variables
+
 ### Fixed (issue #227)
 - [[PR228]](https://github.com/lanl/singularity-eos/pull/228) and [[PR229]](https://github.com/lanl/singularity-eos/pull/229) added untracked header files in cmake
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,7 @@ target_link_options(singularity-eos
     ${xlfix}
 )
 
+include(GNUInstallDirs)
 foreach(_sdir ${_subdirs2add})
   singularity_msg(STATUS "Adding ${_sdir}...")
   add_subdirectory(${_sdir})


### PR DESCRIPTION
Changes to `eospac-wrapper` included some install boilerplate, but these used cmake variables (`CMAKE_INSTALL_LIBDIR`) that were not given a value yet (through `include(GNUInstallDirs)`. 

This adds `include(GNUInstallDirs)` so that these variables are filled.

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- N/A Adds a test for any bugs fixed. Adds tests for new features.
- N/A Format your changes by using the `make format` command after configuring with `cmake`.
- N/A Document any new features, update documentation for changes made.
- N/A Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- N/A If preparing for a new release, update the version in cmake.
