### PR TITLE
add local mpark-variant in spack-repo due to spack bug

### DIFF
--- a/spack-repo/packages/mpark-variant/icpc.patch
+++ b/spack-repo/packages/mpark-variant/icpc.patch
@@ -1,0 +1,33 @@
+From 2d933fe544bd5841e9016ab7e8066521ebe33f30 Mon Sep 17 00:00:00 2001
+From: sbolding <sbolding@lanl.gov>
+Date: Mon, 29 Mar 2021 19:13:28 -0600
+Subject: [PATCH] Apply patch for icpc
+
+icpc in some way utilizes the preprocessor of the associated "developer
+tools" used by the compiler. This leads to, in some cases, a
+preprocessor claiming support for `__tuple_element_packs`, even though
+icpc (as of version 21.1) can't actually parse such code.  Just use the
+MPARK_TUPLE_ELEMENT_PACK impl with __icc until icpc supports it.
+
+Fixes #77
+---
+ include/mpark/config.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/mpark/config.hpp b/include/mpark/config.hpp
+index f85ffb55c..128fa9235 100644
+--- a/include/mpark/config.hpp
++++ b/include/mpark/config.hpp
+@@ -50,7 +50,7 @@
+ #define MPARK_BUILTIN_UNREACHABLE
+ #endif
+ 
+-#if __has_builtin(__type_pack_element)
++#if __has_builtin(__type_pack_element) && !(defined(__ICC))
+ #define MPARK_TYPE_PACK_ELEMENT
+ #endif
+ 
+-- 
+2.24.3 (Apple Git-128)
+
+

--- a/spack-repo/packages/mpark-variant/nvcc.patch
+++ b/spack-repo/packages/mpark-variant/nvcc.patch
@@ -1,0 +1,40 @@
+From d7fb6201cbe830c2aef35b3fd0df040f9eae6d4d Mon Sep 17 00:00:00 2001
+From: Gavin Ridley <gavin.keith.ridley@gmail.com>
+Date: Tue, 31 Dec 2019 14:42:14 -0500
+Subject: [PATCH] now compiles in nvcc 10.2
+
+---
+ include/mpark/variant.hpp | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/include/mpark/variant.hpp b/include/mpark/variant.hpp
+index ef496619b..f4848db88 100644
+--- a/include/mpark/variant.hpp
++++ b/include/mpark/variant.hpp
+@@ -2001,20 +2001,20 @@ namespace mpark {
+ #ifdef MPARK_CPP14_CONSTEXPR
+   namespace detail {
+ 
+-    inline constexpr bool all(std::initializer_list<bool> bs) {
++    inline constexpr bool any(std::initializer_list<bool> bs) {
+       for (bool b : bs) {
+-        if (!b) {
+-          return false;
++        if (b) {
++          return true;
+         }
+       }
+-      return true;
++      return false;
+     }
+ 
+   }  // namespace detail
+ 
+   template <typename Visitor, typename... Vs>
+   inline constexpr decltype(auto) visit(Visitor &&visitor, Vs &&... vs) {
+-    return (detail::all({!vs.valueless_by_exception()...})
++    return (!detail::any({vs.valueless_by_exception()...})
+                 ? (void)0
+                 : throw_bad_variant_access()),
+            detail::visitation::variant::visit_value(
+

--- a/spack-repo/packages/mpark-variant/package.py
+++ b/spack-repo/packages/mpark-variant/package.py
@@ -1,0 +1,43 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class MparkVariant(CMakePackage):
+    """C++17 `std::variant` for C++11/14/17"""
+
+    homepage = "https://github.com/mpark/variant"
+    url = "https://github.com/mpark/variant/archive/v1.4.0.tar.gz"
+    git = "https://github.com/mpark/variant.git"
+    maintainers = ["ax3l"]
+
+    tags = ["e4s"]
+
+    version("1.4.0", sha256="8f6b28ab3640b5d76d5b6664dda7257a4405ce59179220431b8fd196c79b2ecb")
+    version("1.3.0", sha256="d0f7e41f818fcc839797a8017e76b8b66b323651c304cff641a83a56ae9943c6")
+
+    # Ref.: https://github.com/mpark/variant/pull/73
+    patch("nvcc.patch", when="@:1.4.0")
+    # Ref.: https://github.com/mpark/variant/issues/60
+    patch("version.patch", when="@1.4.0")
+    # Ref.: https://github.com/mpark/variant/pull/78
+    patch("icpc.patch", when="@:1.4.0")
+
+    cxx11_msg = (
+        "MPark.Variant needs a C++11-capable compiler. "
+        "See https://github.com/mpark/variant#requirements"
+    )
+    conflicts("%gcc@:4.7", msg=cxx11_msg)
+    conflicts("%clang@:3.5", msg=cxx11_msg)
+
+    conflicts(
+        "%gcc@7.3.1",
+        msg="GCC 7.3.1 has a bug that prevents using MPark.Variant. "
+        "See https://github.com/mpark/variant/issues/43 and "
+        "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84785 "
+        "Please use a different compiler version or another "
+        "compiler.",
+    )

--- a/spack-repo/packages/mpark-variant/version.patch
+++ b/spack-repo/packages/mpark-variant/version.patch
@@ -1,0 +1,11 @@
+--- ./CMakeLists.txt	2021-02-21 17:27:04.709115800 -0700
++++ ./CMakeLists.txt.new	2021-02-21 17:27:35.589115800 -0700
+@@ -7,7 +7,7 @@
+ 
+ cmake_minimum_required(VERSION 3.6.3)
+ 
+-project(MPark.Variant VERSION 1.3.0 LANGUAGES CXX)
++project(MPark.Variant VERSION 1.4.0 LANGUAGES CXX)
+ 
+ # Option.
+ set(MPARK_VARIANT_INCLUDE_TESTS "" CACHE STRING


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Added `mpark-variant` in `spack-repo/packages` as a workaround for a spack internal bug. The `mpark-variant` is just a copy of what's in `Spack v0.19.1`.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [x] If preparing for a new release, update the version in cmake.
