### PR TITLE
Add explicit dependency to sphinx-rtd-theme (and through it, jQuery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Fixed (Repair bugs, etc)
+- [[PR239]](https://github.com/lanl/singularity-eos/pull/239#issuecomment-1473166925) Add JQuery to dependencies for docs to repair build
 - [[PR238]](https://github.com/lanl/singularity-eos/pull/238) Fixed broken examples
 - [[PR228]](https://github.com/lanl/singularity-eos/pull/228) added untracked header files in cmake
 - [[PR215]](https://github.com/lanl/singularity-eos/pull/215) and [[PR216]](https://github.com/lanl/singularity-eos/pull/216) fix duplicate definition of EPS and fix CI

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Singularity-EOS'
-copyright = '2021-2022. Triad National Security'
+copyright = '2021-2023. Triad National Security'
 author = 'The Singularity-EOS Team'
 
 
@@ -30,6 +30,7 @@ author = 'The Singularity-EOS Team'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
+    'sphinx_rtd_theme',
     'sphinx_multiversion'
 ]
 


### PR DESCRIPTION
## PR Summary

Newer Sphinx and sphinx-rtd-theme do not include jQuery, which is a necessary feature for `sphinx_multiversion` to properly work. This adds the `sphinx_rtd_theme` extension to our doc configuration, which also pulls in `sphinxcontrib-jquery` for us.

See 	https://blog.readthedocs.com/sphinx6-upgrade/

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
