### PR TITLE
Limit undefined behaviour and fix some wharnings too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current develop
 
 ### Fixed (Repair bugs, etc)
-- [[PR243]](https://github.com/lanl/singularity-eos/pull/243) Remove undefined behavior caused by diagnostic variables
+- [[PR243]](https://github.com/lanl/singularity-eos/pull/243) Remove undefined behavior caused by diagnostic variables. Also fixed some compiler warnings.
 - [[PR239]](https://github.com/lanl/singularity-eos/pull/239#issuecomment-1473166925) Add JQuery to dependencies for docs to repair build
 - [[PR238]](https://github.com/lanl/singularity-eos/pull/238) Fixed broken examples
 - [[PR228]](https://github.com/lanl/singularity-eos/pull/228) added untracked header files in cmake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Fixed (Repair bugs, etc)
+- [[PR243]](https://github.com/lanl/singularity-eos/pull/243) Remove undefined behavior caused by diagnostic variables
 - [[PR239]](https://github.com/lanl/singularity-eos/pull/239#issuecomment-1473166925) Add JQuery to dependencies for docs to repair build
 - [[PR238]](https://github.com/lanl/singularity-eos/pull/238) Fixed broken examples
 - [[PR228]](https://github.com/lanl/singularity-eos/pull/228) added untracked header files in cmake

--- a/singularity-eos/base/root-finding-1d/root_finding.hpp
+++ b/singularity-eos/base/root-finding-1d/root_finding.hpp
@@ -149,7 +149,7 @@ PORTABLE_INLINE_FUNCTION Status regula_falsi(const T &f, const Real ytarget,
                                              const Real guess, Real a, Real b,
                                              const Real xtol, const Real ytol,
                                              Real &xroot,
-                                             const RootCounts *counts=nullptr) {
+                                             const RootCounts *counts = nullptr) {
   constexpr int max_iter = SECANT_NITER_MAX;
   auto func = [&](const Real x) { return f(x) - ytarget; };
   Real ya = func(a);
@@ -231,7 +231,7 @@ template <typename T>
 PORTABLE_INLINE_FUNCTION Status findRoot(const T &f, const Real ytarget, Real xguess,
                                          const Real xmin, const Real xmax,
                                          const Real xtol, const Real ytol, Real &xroot,
-                                         const RootCounts *counts=nullptr) {
+                                         const RootCounts *counts = nullptr) {
   Status status;
 
   // first check if we're at the max or min values
@@ -296,7 +296,7 @@ template <typename T>
 PORTABLE_INLINE_FUNCTION Status secant(const T &f, const Real ytarget, const Real xguess,
                                        const Real xmin, const Real xmax, const Real xtol,
                                        const Real ytol, Real &xroot,
-                                       const RootCounts *counts=nullptr) {
+                                       const RootCounts *counts = nullptr) {
   Real dx;
   Real x_last, y, yp, ym, dyNum, dyDen, dy;
 
@@ -399,7 +399,7 @@ template <typename T>
 PORTABLE_INLINE_FUNCTION Status bisect(const T &f, const Real ytarget, const Real xguess,
                                        const Real xmin, const Real xmax, const Real xtol,
                                        const Real ytol, Real &xroot,
-                                       const RootCounts *counts=nullptr) {
+                                       const RootCounts *counts = nullptr) {
   Real xl, xr, fl, fr, dx;
 
   Real grow = 0.01;

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -34,6 +34,25 @@ static inline auto member_func_name(const char *type_name, const char *func_name
 namespace singularity {
 namespace eos_base {
 
+namespace impl {
+PORTABLE_FORCEINLINE_FUNCTION
+char *StrCopy(char *dest, const char *src){
+  int i = 0;
+  do {
+    dest[i] = src[i];}
+  while (src[i++] != 0);
+  return dest;
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+char *StrCat(char *dest, const char *src){
+  int i = 0;
+  while (dest[i] != 0) i++;
+  StrCopy(dest+i, src);
+  return dest;
+}
+} // namespace impl
+
 // This Macro adds the `using` statements that allow for the base class
 // vector functionality to overload the scalar implementations in the derived
 // classes
@@ -391,8 +410,8 @@ class EosBase {
   void EntropyIsNotEnabled(const char *eosname) const {
     // Construct the error message using char* so it works on device
     char msg[120] = "Entropy is not enabled for the '";
-    std::strcat(msg, eosname);
-    std::strcat(msg, "' EOS");
+    impl::StrCat(msg, eosname);
+    impl::StrCat(msg, "' EOS");
     PORTABLE_ALWAYS_THROW_OR_ABORT(msg);
   }
 };

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -35,21 +35,24 @@ namespace singularity {
 namespace eos_base {
 
 namespace impl {
+// Cuda doesn't have strcat, so we implement it ourselves
 PORTABLE_FORCEINLINE_FUNCTION
-char *StrCopy(char *dest, const char *src){
-  int i = 0;
-  do {
-    dest[i] = src[i];}
-  while (src[i++] != 0);
-  return dest;
-}
-
-PORTABLE_FORCEINLINE_FUNCTION
-char *StrCat(char *dest, const char *src){
-  int i = 0;
-  while (dest[i] != 0) i++;
-  StrCopy(dest+i, src);
-  return dest;
+char* StrCat(char* destination, const char* source) {
+  int i, j;
+  
+  // move to the end of the destination string
+  // specifically avoid strlen, which isn't on GPU
+  for (i = 0; destination[i] != '\0'; i++);
+  // Appends characters of the source to the destination string
+  for (j = 0; source[j] != '\0'; j++) {
+    destination[i + j] = source[j];
+  }
+  
+  // null terminate destination string
+  destination[i + j] = '\0';
+  
+  // the destination is returned by standard `strcat()`
+  return destination;
 }
 } // namespace impl
 

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -38,17 +38,15 @@ namespace impl {
 // Cuda doesn't have strcat, so we implement it ourselves
 PORTABLE_FORCEINLINE_FUNCTION
 char *StrCat(char *destination, const char *source) {
-  int i, j;
+  int i, j; // not in loops because they're re-used.
 
-  // move to the end of the destination string
   // specifically avoid strlen, which isn't on GPU
   for (i = 0; destination[i] != '\0'; i++) {
   }
-  // Appends characters of the source to the destination string
+  // assumes destination has enough memory allocated
   for (j = 0; source[j] != '\0'; j++) {
     destination[i + j] = source[j];
   }
-
   // null terminate destination string
   destination[i + j] = '\0';
 

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -42,8 +42,7 @@ char *StrCat(char *destination, const char *source) {
 
   // move to the end of the destination string
   // specifically avoid strlen, which isn't on GPU
-  for (i = 0; destination[i] != '\0'; i++)
-    ;
+  for (i = 0; destination[i] != '\0'; i++) {}
   // Appends characters of the source to the destination string
   for (j = 0; source[j] != '\0'; j++) {
     destination[i + j] = source[j];

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -35,6 +35,7 @@ namespace singularity {
 namespace eos_base {
 
 namespace impl {
+constexpr std::size_t MAX_NUM_CHARS = 81;
 // Cuda doesn't have strcat, so we implement it ourselves
 PORTABLE_FORCEINLINE_FUNCTION
 char *StrCat(char *destination, const char *source) {
@@ -45,6 +46,9 @@ char *StrCat(char *destination, const char *source) {
   }
   // assumes destination has enough memory allocated
   for (j = 0; source[j] != '\0'; j++) {
+    // MAX_NUM_CHARS-1 to leave room for null terminator
+    PORTABLE_REQUIRE((i + j) < MAX_NUM_CHARS - 1,
+                     "Concat string must be within allowed size");
     destination[i + j] = source[j];
   }
   // null terminate destination string
@@ -415,7 +419,7 @@ class EosBase {
     // base msg length 32 + 5 chars = 37 chars
     // + 1 char for null terminator
     // maximum allowed EOS length = 44 chars
-    char msg[81] = "Entropy is not enabled for the '";
+    char msg[impl::MAX_NUM_CHARS] = "Entropy is not enabled for the '";
     impl::StrCat(msg, eosname);
     impl::StrCat(msg, "' EOS");
     PORTABLE_ALWAYS_THROW_OR_ABORT(msg);

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -42,7 +42,8 @@ char *StrCat(char *destination, const char *source) {
 
   // move to the end of the destination string
   // specifically avoid strlen, which isn't on GPU
-  for (i = 0; destination[i] != '\0'; i++) {}
+  for (i = 0; destination[i] != '\0'; i++) {
+  }
   // Appends characters of the source to the destination string
   for (j = 0; source[j] != '\0'; j++) {
     destination[i + j] = source[j];

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -37,20 +37,21 @@ namespace eos_base {
 namespace impl {
 // Cuda doesn't have strcat, so we implement it ourselves
 PORTABLE_FORCEINLINE_FUNCTION
-char* StrCat(char* destination, const char* source) {
+char *StrCat(char *destination, const char *source) {
   int i, j;
-  
+
   // move to the end of the destination string
   // specifically avoid strlen, which isn't on GPU
-  for (i = 0; destination[i] != '\0'; i++);
+  for (i = 0; destination[i] != '\0'; i++)
+    ;
   // Appends characters of the source to the destination string
   for (j = 0; source[j] != '\0'; j++) {
     destination[i + j] = source[j];
   }
-  
+
   // null terminate destination string
   destination[i + j] = '\0';
-  
+
   // the destination is returned by standard `strcat()`
   return destination;
 }

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -413,7 +413,11 @@ class EosBase {
   PORTABLE_FORCEINLINE_FUNCTION
   void EntropyIsNotEnabled(const char *eosname) const {
     // Construct the error message using char* so it works on device
-    char msg[120] = "Entropy is not enabled for the '";
+    // WARNING: This needs to be updated if EOS names get longer
+    // base msg length 32 + 5 chars = 37 chars
+    // + 1 char for null terminator
+    // maximum allowed EOS length = 44 chars
+    char msg[81] = "Entropy is not enabled for the '";
     impl::StrCat(msg, eosname);
     impl::StrCat(msg, "' EOS");
     PORTABLE_ALWAYS_THROW_OR_ABORT(msg);

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -333,9 +333,8 @@ PORTABLE_INLINE_FUNCTION void DavisReactants::DensityEnergyFromPressureTemperatu
   };
   using RootFinding1D::regula_falsi;
   using RootFinding1D::Status;
-  RootFinding1D::RootCounts counts;
   auto status =
-      regula_falsi(PofRatT, press, _rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho, counts);
+      regula_falsi(PofRatT, press, _rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho);
   if (status != Status::SUCCESS) {
     // Root finder failed even though the solution was bracketed... this is an error
     EOS_ERROR("DavisReactants::DensityEnergyFromPressureTemperature: "
@@ -401,10 +400,9 @@ PORTABLE_INLINE_FUNCTION void DavisProducts::DensityEnergyFromPressureTemperatur
   };
   using RootFinding1D::regula_falsi;
   using RootFinding1D::Status;
-  RootFinding1D::RootCounts counts;
   const Real rho0 = 1.0 / _vc;
   auto status =
-      regula_falsi(PofRatT, press, rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho, counts);
+      regula_falsi(PofRatT, press, rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho);
   if (status != Status::SUCCESS) {
     // Root finder failed even though the solution was bracketed... this is an error
     EOS_ERROR("DavisProducts::DensityEnergyFromPressureTemperature: "

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -333,8 +333,7 @@ PORTABLE_INLINE_FUNCTION void DavisReactants::DensityEnergyFromPressureTemperatu
   };
   using RootFinding1D::regula_falsi;
   using RootFinding1D::Status;
-  auto status =
-      regula_falsi(PofRatT, press, _rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho);
+  auto status = regula_falsi(PofRatT, press, _rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho);
   if (status != Status::SUCCESS) {
     // Root finder failed even though the solution was bracketed... this is an error
     EOS_ERROR("DavisReactants::DensityEnergyFromPressureTemperature: "
@@ -401,8 +400,7 @@ PORTABLE_INLINE_FUNCTION void DavisProducts::DensityEnergyFromPressureTemperatur
   using RootFinding1D::regula_falsi;
   using RootFinding1D::Status;
   const Real rho0 = 1.0 / _vc;
-  auto status =
-      regula_falsi(PofRatT, press, rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho);
+  auto status = regula_falsi(PofRatT, press, rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho);
   if (status != Status::SUCCESS) {
     // Root finder failed even though the solution was bracketed... this is an error
     EOS_ERROR("DavisProducts::DensityEnergyFromPressureTemperature: "

--- a/singularity-eos/eos/eos_gruneisen.hpp
+++ b/singularity-eos/eos/eos_gruneisen.hpp
@@ -367,8 +367,7 @@ PORTABLE_INLINE_FUNCTION void Gruneisen::DensityEnergyFromPressureTemperature(
     };
     using RootFinding1D::regula_falsi;
     using RootFinding1D::Status;
-    auto status =
-        regula_falsi(PofRatE, press, _rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho);
+    auto status = regula_falsi(PofRatE, press, _rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho);
     if (status != Status::SUCCESS) {
       // Root finder failed even though the solution was bracketed... this is an error
       EOS_ERROR("Gruneisen::DensityEnergyFromPressureTemperature: "

--- a/singularity-eos/eos/eos_gruneisen.hpp
+++ b/singularity-eos/eos/eos_gruneisen.hpp
@@ -243,13 +243,12 @@ PORTABLE_INLINE_FUNCTION Real Gruneisen::ComputeRhoMax(const Real s1, const Real
       using RootFinding1D::regula_falsi;
       using RootFinding1D::RootCounts;
       using RootFinding1D::Status;
-      RootCounts counts;
       static constexpr Real factor = 100;
       static constexpr Real xtol = factor * EPS;
       static constexpr Real ytol = factor / 10 * EPS;
       static constexpr Real eta_guess = 0.001;
       auto status =
-          regula_falsi(poly, 0., eta_guess, minbound, maxbound, xtol, ytol, root, counts);
+          regula_falsi(poly, 0., eta_guess, minbound, maxbound, xtol, ytol, root);
       if (status != Status::SUCCESS) {
         // Root finder failed even though the solution was bracketed... this is an error
         EOS_ERROR("Gruneisen initialization: Cubic root find failed. Maximum "
@@ -368,9 +367,8 @@ PORTABLE_INLINE_FUNCTION void Gruneisen::DensityEnergyFromPressureTemperature(
     };
     using RootFinding1D::regula_falsi;
     using RootFinding1D::Status;
-    RootFinding1D::RootCounts counts;
     auto status =
-        regula_falsi(PofRatE, press, _rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho, counts);
+        regula_falsi(PofRatE, press, _rho0, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho);
     if (status != Status::SUCCESS) {
       // Root finder failed even though the solution was bracketed... this is an error
       EOS_ERROR("Gruneisen::DensityEnergyFromPressureTemperature: "

--- a/singularity-eos/eos/eos_jwl.hpp
+++ b/singularity-eos/eos/eos_jwl.hpp
@@ -188,9 +188,8 @@ JWL::DensityEnergyFromPressureTemperature(const Real press, const Real temp, Rea
   auto PofRatT = [&](const Real r) { return _Cv * temp * r * _w + ReferencePressure(r); };
   using RootFinding1D::regula_falsi;
   using RootFinding1D::Status;
-  RootFinding1D::RootCounts counts;
   auto status =
-      regula_falsi(PofRatT, press, rhoguess, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho, counts);
+      regula_falsi(PofRatT, press, rhoguess, 1.0e-5, 1.0e3, 1.0e-8, 1.0e-8, rho);
   if (status != Status::SUCCESS) {
     // Root finder failed even though the solution was bracketed... this is an error
     EOS_ERROR("JWL::DensityEnergyFromPressureTemperature: "

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -890,7 +890,7 @@ inline void SpinerEOSDependsRhoT::setlTColdCrit_() {
       Real lTupper = bMod_.range(0).x(ilast + 1) + 1.0e-14;
       Real lTGuess = 0.5 * (lTlower + lTupper);
       auto status = ROOT_FINDER(sieFunc, sieCold, lTGuess, lTlower, lTupper, ROOT_THRESH,
-                                ROOT_THRESH, lT, counts);
+                                ROOT_THRESH, lT);
       if (status != RootFinding1D::Status::SUCCESS) {
         lT = lTGuess;
       }
@@ -1172,6 +1172,7 @@ Real SpinerEOSDependsRhoT::lRhoFromPlT_(const Real P, const Real lT,
   Real lRho;
   Real lRhoGuess = reproducible_ ? lRhoMax_ : 0.5 * (lRhoMin_ + lRhoMax_);
   // Real lRhoGuess = lRhoMin_ + 0.9*(lRhoMax_ - lRhoMin_);
+  const RootFinding1D::RootCounts *pcounts = (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
   if (lambda != nullptr && lRhoMin_ <= lambda[Lambda::lRho] &&
       lambda[Lambda::lRho] <= lRhoMax_) {
     lRhoGuess = lambda[Lambda::lRho];
@@ -1182,23 +1183,23 @@ Real SpinerEOSDependsRhoT::lRhoFromPlT_(const Real P, const Real lT,
     status =
         ROOT_FINDER(PFunc, P, lRhoGuess,
                     // lRhoMin_, lRhoMax_,
-                    lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, counts);
+                    lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, pcounts);
   } else if (lT >= lTMax_) { // ideal gas
     whereAmI = TableStatus::OffTop;
     const callable_interp::prod_interp_1d PFunc(gm1Max_, dEdTMax_, lT);
     status =
         ROOT_FINDER(PFunc, P, lRhoGuess,
                     // lRhoMin_, lRhoMax_,
-                    lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, counts);
+                    lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, pcounts);
   } else { // on table
     whereAmI = TableStatus::OnTable;
     const callable_interp::l_interp PFunc(P_, lT);
     status =
         ROOT_FINDER(PFunc, P, lRhoGuess,
                     // lRhoMin_, lRhoMax_,
-                    lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, counts);
+                    lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, pcounts);
   }
-  if (status_ != RootFinding1D::Status::SUCCESS) {
+  if (status != RootFinding1D::Status::SUCCESS) {
 #if EPINER_EOS_VERBOSE
     std::stringstream errorMessage;
     errorMessage << "inverting P table for logRho failed\n"
@@ -1223,6 +1224,7 @@ PORTABLE_INLINE_FUNCTION
 Real SpinerEOSDependsRhoT::lTFromlRhoSie_(const Real lRho, const Real sie,
                                           TableStatus &whereAmI, Real *lambda) const {
 
+  const RootFinding1D::RootCounts *pcounts = (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
   RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
   Real lT;
 
@@ -1231,13 +1233,17 @@ Real SpinerEOSDependsRhoT::lTFromlRhoSie_(const Real lRho, const Real sie,
     // On the cold curve. No unique temperature.
     // return the minimum temperature in the table.
     lT = lTMin_;
-    counts.increment(0);
+    if (pcounts != nullptr) {
+      pcounts->increment(0);
+    }
   } else if (whereAmI == TableStatus::OffTop) { // Assume ideal gas
     const Real Cv = dEdTMax_.interpToReal(lRho);
     const Real e0 = sielTMax_.interpToReal(lRho);
     const Real T = TMax_ + robust::ratio(sie - e0, Cv);
     lT = lT_(T);
-    counts.increment(0);
+    if (pcounts != nullptr) {
+      pcounts->increment(0);
+    }
   } else {
     Real lTGuess = reproducible_ ? lTMin_ : 0.5 * (lTMin_ + lTMax_);
     if (lambda != nullptr && lTMin_ <= lambda[Lambda::lT] &&
@@ -1246,7 +1252,7 @@ Real SpinerEOSDependsRhoT::lTFromlRhoSie_(const Real lRho, const Real sie,
     }
     const callable_interp::r_interp sieFunc(sie_, lRho);
     status = ROOT_FINDER(sieFunc, sie, lTGuess, lTMin_, lTMax_, ROOT_THRESH, ROOT_THRESH,
-                         lT, counts);
+                         lT, pcounts);
 
     if (status != RootFinding1D::Status::SUCCESS) {
 #if SPINER_EOS_VERBOSE
@@ -1268,7 +1274,9 @@ Real SpinerEOSDependsRhoT::lTFromlRhoSie_(const Real lRho, const Real sie,
     lambda[Lambda::lRho] = lRho;
     lambda[Lambda::lT] = lT;
   }
-  status_ = status;
+  if (memoryStatus_ != DataStatus::OnDevice) {
+    status_ = status;
+  }
   whereAmI_ = whereAmI;
   return lT;
 }
@@ -1276,6 +1284,7 @@ Real SpinerEOSDependsRhoT::lTFromlRhoSie_(const Real lRho, const Real sie,
 PORTABLE_INLINE_FUNCTION
 Real SpinerEOSDependsRhoT::lTFromlRhoP_(const Real lRho, const Real press,
                                         TableStatus &whereAmI, Real *lambda) const {
+  const RootFinding1D::RootCounts *pcounts = (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
   RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
   Real lT, lTGuess;
 
@@ -1285,11 +1294,15 @@ Real SpinerEOSDependsRhoT::lTFromlRhoP_(const Real lRho, const Real press,
   if (press <= PCold) {
     whereAmI = TableStatus::OffBottom;
     lT = lTMin_;
-    counts.increment(0);
+    if (pcounts != nullptr) {
+      pcounts->increment(0);
+    }
   } else if (press >= PMax) {
     whereAmI = TableStatus::OffTop;
     lT = lTMax_;
-    counts.increment(0);
+    if (pcounts != nullptr) {
+      pcounts->increment(0);
+    }
   } else {
     whereAmI = TableStatus::OnTable;
     if (lambda != nullptr && lTMin_ <= lambda[Lambda::lT] &&
@@ -1300,7 +1313,7 @@ Real SpinerEOSDependsRhoT::lTFromlRhoP_(const Real lRho, const Real press,
     }
     const callable_interp::r_interp PFunc(P_, lRho);
     status = ROOT_FINDER(PFunc, press, lTGuess, lTMin_, lTMax_, ROOT_THRESH, ROOT_THRESH,
-                         lT, counts);
+                         lT, pcounts);
     if (status != RootFinding1D::Status::SUCCESS) {
 #if SPINER_EOS_VERBOSE
       std::stringstream errorMessage;
@@ -1318,7 +1331,9 @@ Real SpinerEOSDependsRhoT::lTFromlRhoP_(const Real lRho, const Real press,
     lambda[Lambda::lRho] = lRho;
     lambda[Lambda::lT] = lT;
   }
-  status_ = status;
+  if (memoryStatus_ != DataStatus::OnDevice) {
+    status_ = status;
+  }
   whereAmI_ = whereAmI;
   return lT;
 }
@@ -1845,23 +1860,28 @@ Real SpinerEOSDependsRhoSie::interpRhoSie_(const Real rho, const Real sie,
 PORTABLE_INLINE_FUNCTION
 Real SpinerEOSDependsRhoSie::lRhoFromPlT_(const Real P, const Real lT,
                                           Real *lambda) const {
+  const RootFinding1D::RootCounts *pcounts = (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
   Real lRho;
   Real dPdRhoMax = dPdRhoMax_.interpToReal(lT);
   Real PMax = PlRhoMax_.interpToReal(lT);
   if (dPdRhoMax > 0 && P > PMax) {
     Real rho = (P - PMax) / dPdRhoMax + rhoMax_;
     lRho = toLog_(rho, lRhoOffset_);
-    counts.increment(0);
+    if (pcounts != nullptr) {
+      pcounts->increment(0);
+    }
   } else {
     Real lRhoGuess = reproducible_ ? lRhoMin_ : 0.5 * (lRhoMin_ + lRhoMax_);
     if (lambda != nullptr && lRhoMin_ <= *lambda && *lambda <= lRhoMax_) {
       lRhoGuess = *lambda;
     }
     const callable_interp::l_interp PFunc(dependsRhoT_.P, lT);
-    status_ = ROOT_FINDER(PFunc, P, lRhoGuess, lRhoMin_, lRhoMax_, robust::EPS(),
-                          robust::EPS(), lRho, counts);
-
-    if (status_ != RootFinding1D::Status::SUCCESS) {
+    auto status = ROOT_FINDER(PFunc, P, lRhoGuess, lRhoMin_, lRhoMax_, robust::EPS(),
+                              robust::EPS(), lRho, pcounts);
+    if (memoryStatus_ != DataStatus::OnDevice) {
+      status_ = status;
+    }
+    if (status != RootFinding1D::Status::SUCCESS) {
 #if SPINER_EOS_VERBOSE
       std::stringstream errorMessage;
       errorMessage << "inverting P table for logRho failed\n"

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -1172,7 +1172,8 @@ Real SpinerEOSDependsRhoT::lRhoFromPlT_(const Real P, const Real lT,
   Real lRho;
   Real lRhoGuess = reproducible_ ? lRhoMax_ : 0.5 * (lRhoMin_ + lRhoMax_);
   // Real lRhoGuess = lRhoMin_ + 0.9*(lRhoMax_ - lRhoMin_);
-  const RootFinding1D::RootCounts *pcounts = (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
+  const RootFinding1D::RootCounts *pcounts =
+      (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
   if (lambda != nullptr && lRhoMin_ <= lambda[Lambda::lRho] &&
       lambda[Lambda::lRho] <= lRhoMax_) {
     lRhoGuess = lambda[Lambda::lRho];
@@ -1224,7 +1225,8 @@ PORTABLE_INLINE_FUNCTION
 Real SpinerEOSDependsRhoT::lTFromlRhoSie_(const Real lRho, const Real sie,
                                           TableStatus &whereAmI, Real *lambda) const {
 
-  const RootFinding1D::RootCounts *pcounts = (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
+  const RootFinding1D::RootCounts *pcounts =
+      (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
   RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
   Real lT;
 
@@ -1284,7 +1286,8 @@ Real SpinerEOSDependsRhoT::lTFromlRhoSie_(const Real lRho, const Real sie,
 PORTABLE_INLINE_FUNCTION
 Real SpinerEOSDependsRhoT::lTFromlRhoP_(const Real lRho, const Real press,
                                         TableStatus &whereAmI, Real *lambda) const {
-  const RootFinding1D::RootCounts *pcounts = (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
+  const RootFinding1D::RootCounts *pcounts =
+      (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
   RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
   Real lT, lTGuess;
 
@@ -1860,7 +1863,8 @@ Real SpinerEOSDependsRhoSie::interpRhoSie_(const Real rho, const Real sie,
 PORTABLE_INLINE_FUNCTION
 Real SpinerEOSDependsRhoSie::lRhoFromPlT_(const Real P, const Real lT,
                                           Real *lambda) const {
-  const RootFinding1D::RootCounts *pcounts = (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
+  const RootFinding1D::RootCounts *pcounts =
+      (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
   Real lRho;
   Real dPdRhoMax = dPdRhoMax_.interpToReal(lT);
   Real PMax = PlRhoMax_.interpToReal(lT);

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -430,6 +430,8 @@ inline StellarCollapse StellarCollapse::GetOnDevice() {
   other.lTMax_ = lTMax_;
   other.YeMin_ = YeMin_;
   other.YeMax_ = YeMax_;
+  other.sieMin_ = sieMin_;
+  other.sieMax_ = sieMax_;
   other.lEOffset_ = lEOffset_;
   other.sieNormal_ = sieNormal_;
   other.PNormal_ = PNormal_;
@@ -816,6 +818,7 @@ inline void StellarCollapse::medianFilter_(Spiner::DataBox &db) {
   Spiner::DataBox tmp;
   tmp.copy(db);
   medianFilter_(tmp, db);
+  free(tmp);
 }
 
 inline void StellarCollapse::medianFilter_(const Spiner::DataBox &in,

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -942,7 +942,8 @@ Real StellarCollapse::lTFromlRhoSie_(const Real lRho, const Real sie,
   Real Ye = lambda[Lambda::Ye];
   Real lTGuess = lambda[Lambda::lT];
 
-  const RootFinding1D::RootCounts *pcounts = (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
+  const RootFinding1D::RootCounts *pcounts =
+      (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
 
   // If sie above hot curve or below cold curve, force it onto the table.
   // TODO(JMM): Rethink this as needed.

--- a/singularity-eos/eos/eos_vinet.hpp
+++ b/singularity-eos/eos/eos_vinet.hpp
@@ -156,7 +156,7 @@ inline void Vinet::CheckVinet() {
   }
 }
 
-PORTABLE_INLINE_FUNCTION void Vinet::InitializeVinet(const Real *d2tod40input) {
+inline void Vinet::InitializeVinet(const Real *d2tod40input) {
 
   // The PressureCoeffsd2tod40Size (=39) allowed d2 to d40 coefficients
   // for the pressure reference curve vs rho

--- a/singularity-eos/eos/modifiers/ramps_eos.hpp
+++ b/singularity-eos/eos/modifiers/ramps_eos.hpp
@@ -50,20 +50,19 @@ void pAlpha2BilinearRampParams(const T &eos, const Real alpha0, const Real Pe,
   auto rmid_func = PORTABLE_LAMBDA(const Real x) {
     return eos.PressureFromDensityTemperature(alpha0 * x, T0);
   };
-  RootFinding1D::RootCounts co{};
   // get upper bound to density informed by the reference
   // bulk modulus
   const Real max_exp_arg = std::log(std::numeric_limits<Real>::max() * 0.99);
   const Real exp_arg = std::min(max_exp_arg, ratio((2.0 * Pc - P0), bmod0));
   const Real rho_ub = rho0 * std::exp(exp_arg);
   // finds where rmid_func = Pe
-  RootFinding1D::findRoot(rmid_func, Pe, rho0, r0, rho_ub, 1.e-12, 1.e-12, rmid, co);
+  RootFinding1D::findRoot(rmid_func, Pe, rho0, r0, rho_ub, 1.e-12, 1.e-12, rmid);
   // calculate r1
   auto r1_func = PORTABLE_LAMBDA(const Real x) {
     return eos.PressureFromDensityTemperature(x, T0);
   };
   // finds where r1_func = Pc
-  RootFinding1D::findRoot(r1_func, Pc, rmid, r0, rho_ub, 1.e-12, 1.e-12, r1, co);
+  RootFinding1D::findRoot(r1_func, Pc, rmid, r0, rho_ub, 1.e-12, 1.e-12, r1);
   // a
   a = ratio(r0 * Pe, rmid - r0);
   // b

--- a/singularity-eos/eos/singularity_eos.cpp
+++ b/singularity-eos/eos/singularity_eos.cpp
@@ -612,10 +612,9 @@ int get_sg_eos( // sizing information
             eos_v(pte_idxs(tid, 0))
                 .ValuesAtReferenceState(r_rho, r_temp, r_sie, r_press, r_cv, r_bmod,
                                         r_dpde, r_dvdt);
-            RootFinding1D::RootCounts co{};
             Real temp_i;
             RootFinding1D::findRoot(p_from_t, press_v(i), r_temp, 1.e-10 * r_temp,
-                                    1.e10 * r_temp, 1.e-12, 1.e-12, temp_i, co);
+                                    1.e10 * r_temp, 1.e-12, 1.e-12, temp_i);
             sie_pte(tid, 0) = eos_v(pte_idxs(tid, 0))
                                   .InternalEnergyFromDensityTemperature(rho_pte(tid, 0),
                                                                         temp_i, cache[0]);

--- a/test/profile_eos.cpp
+++ b/test/profile_eos.cpp
@@ -222,8 +222,8 @@ int main(int argc, char *argv[]) {
 
     EOSBuilder::EOSType type = EOSBuilder::EOSType::IdealGas;
     EOSBuilder::params_t params;
-    params["Cv"] = 1e7 * 0.716; // specific heat in ergs/(g K)
-    params["gm1"] = 0.4;        // gamma - 1
+    params["Cv"].emplace<Real>(1e7 * 0.716); // specific heat in ergs/(g K)
+    params["gm1"].emplace<Real>(0.4);        // gamma - 1
     EOS eos = EOSBuilder::buildEOS(type, params);
     get_timing(ncycles, ncells_1d, RHO_MIN, RHO_MAX, T_MIN, T_MAX, "IdealGas", eos);
 

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -180,9 +180,8 @@ SCENARIO("Test that fast logs are invertible and run on device", "[FastMath]") {
 
 SCENARIO("Rudimentary test of the root finder", "[RootFinding1D]") {
 
-  GIVEN("A root counts object") {
+  GIVEN("Root finding") {
     using namespace RootFinding1D;
-    RootCounts counts;
 
     THEN("A root can be found for shift = 1, scale = 2, offset = 0.5") {
       int ntimes = 100;
@@ -208,9 +207,7 @@ SCENARIO("Rudimentary test of the root finder", "[RootFinding1D]") {
 #endif
       portableFor(
           "find roots", 0, ntimes, PORTABLE_LAMBDA(const int i) {
-            RootCounts per_thread_counts;
-            statuses(i) = regula_falsi(f, 0, guess, -1, 3, 1e-10, 1e-10, roots(i),
-                                       per_thread_counts);
+            statuses(i) = regula_falsi(f, 0, guess, -1, 3, 1e-10, 1e-10, roots(i));
           });
 #ifdef PORTABILITY_STRATEGY_KOKKOS
       Kokkos::View<Status> s_copy(statuses, 0);
@@ -226,7 +223,6 @@ SCENARIO("Rudimentary test of the root finder", "[RootFinding1D]") {
       PORTABLE_FREE(rootsp);
       REQUIRE(status == Status::SUCCESS);
       REQUIRE(isClose(root, 0.744658));
-      REQUIRE(100. * counts[counts.more()] / counts.total() <= 10);
     }
   }
 }
@@ -918,9 +914,6 @@ SCENARIO("SpinerEOS depends on Rho and T", "[SpinerEOS],[DependsRhoT][EOSPAC]") 
     }
     // Failing to call finalize leads to a memory leak,
     // but otherwise behaviour is as expected.
-    // It's possible to this automatically clean up with
-    // some form of reference counting. If this is a priority,
-    // we can re-examine.
     steelEOS_host_polymorphic.Finalize(); // host and device must be
                                           // finalized separately.
     steelEOS.Finalize();                  // cleans up memory on device.

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -475,9 +475,8 @@ SCENARIO("Ideal gas entropy", "[IdealGas][Entropy]") {
     constexpr Real EntropyT0 = 100;
     constexpr Real EntropyRho0 = 1e-03;
     EOS host_eos = IdealGas(gm1, Cv, EntropyT0, EntropyRho0);
-    EOS eos = host_eos.GetOnDevice();
     THEN("The entropy at the reference state should be zero") {
-      auto entropy = eos.EntropyFromDensityTemperature(EntropyRho0, EntropyT0);
+      auto entropy = host_eos.EntropyFromDensityTemperature(EntropyRho0, EntropyT0);
       INFO("Entropy should be zero but it is " << entropy);
       CHECK(isClose(entropy, 0.0, 1.e-14));
     }
@@ -487,7 +486,7 @@ SCENARIO("Ideal gas entropy", "[IdealGas][Entropy]") {
       constexpr Real rho = 0.1; // rho**3 = EntropyRho0
       THEN("The entropy should be 2. / 3. * gm1 * Cv * log(EntropyRho0)") {
         const Real entropy_true = 2. / 3. * gm1 * Cv * log(EntropyRho0);
-        auto entropy = eos.EntropyFromDensityTemperature(rho, T);
+        auto entropy = host_eos.EntropyFromDensityTemperature(rho, T);
         INFO("Entropy: " << entropy << "  True entropy: " << entropy_true);
         CHECK(isClose(entropy, entropy_true, 1e-12));
       }
@@ -498,7 +497,7 @@ SCENARIO("Ideal gas entropy", "[IdealGas][Entropy]") {
       constexpr Real rho = EntropyRho0;
       THEN("The entropy should be -1. / 2. * Cv * log(EntropyT0)") {
         const Real entropy_true = -1. / 2. * Cv * log(EntropyT0);
-        auto entropy = eos.EntropyFromDensityTemperature(rho, T);
+        auto entropy = host_eos.EntropyFromDensityTemperature(rho, T);
         INFO("Entropy: " << entropy << "  True entropy: " << entropy_true);
         CHECK(isClose(entropy, entropy_true, 1e-12));
       }
@@ -1111,7 +1110,6 @@ SCENARIO("Stellar Collapse EOS", "[StellarCollapse][EOSBuilder]") {
   using singularity::IdealGas;
   using singularity::StellarCollapse;
   const std::string savename = "stellar_collapse_ideal_2.sp5";
-  static constexpr Real MeV2K_ = 1.e9 * 11.604525006;
   GIVEN("A stellar collapse EOS") {
     const std::string filename = "./goldfiles/stellar_collapse_ideal.h5";
     THEN("We can load the file") { // don't bother filtering bmod here.

--- a/test/test_eos_vinet.cpp
+++ b/test/test_eos_vinet.cpp
@@ -34,8 +34,6 @@ using singularity::Vinet;
 SCENARIO("Vinet EOS rho sie", "[VectorEOS][VinetEOS]") {
   GIVEN("Parameters for a Vinet EOS") {
     // Unit conversions
-    constexpr Real cm = 1.;
-    constexpr Real us = 1e-06;
     constexpr Real Mbcc_per_g = 1e12;
     // Vinet parameters for copper
     constexpr Real rho0 = 8.93;
@@ -222,8 +220,6 @@ SCENARIO("Vinet EOS rho sie", "[VectorEOS][VinetEOS]") {
 SCENARIO("Vinet EOS rho T", "[VectorEOS][VinetEOS]") {
   GIVEN("Parameters for a Vinet EOS") {
     // Unit conversions
-    constexpr Real cm = 1.;
-    constexpr Real us = 1e-06;
     constexpr Real Mbcc_per_g = 1e12;
     // Vinet parameters for copper
     constexpr Real rho0 = 8.93;
@@ -422,8 +418,6 @@ SCENARIO("Vinet EOS rho T", "[VectorEOS][VinetEOS]") {
 SCENARIO("Vinet EOS SetUp", "[VectorEOS][VinetEOS]") {
   GIVEN("Parameters for a Vinet EOS") {
     // Unit conversions
-    constexpr Real cm = 1.;
-    constexpr Real us = 1e-06;
     constexpr Real Mbcc_per_g = 1e12;
     // Vinet parameters for copper
     Real rho0 = 8.93;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In a downstream code, @AstroBarker experienced a cuda "unspecified launch failure" for some applications and on some architectures. After some effort, we narrowed it down to the `RootFinding1D::RootCounts` and `RootFinding1D::RootStatus` variables used in the tabulated EOS's. Each EOS had an internal instants of `RootCounts` and `Status` used for diagnostics when the code was run on host in serial. 

Writing to these variables in multiple threads is undefined behavior. However,  I intentionally put the logic in the code anyway. My reasoning was that since they wouldn't be *read* except for diagnostic purposes in serial, this undefined behavior shouldn't cause any problems. This reasoning was apparently incorrect.

I still think these variables are useful, so I don't want to eliminate this capability completely. However, I want to avoid them being written to in a "device" context (whatever that means going forward), to prevent us from hitting this fail case in the future. So I have made the following changes:
- The root counts object is now an *optional* parameter of the root finding routines. You pass in a pointer, if that pointer isn't null, the histogram is recorded.
- The root counts and root status fields owned by each tabulated EOS object are only written to if the EOS believes itself to be "on host."

Note that this strategy doesn't prevent someone from sticking a host EOS in an `openmp for` loop, so this doesn't entirely escape the issue, but it seems to be a safe enough workaround. A more complete solution would be to hide the histogram/status logic behind a compile-time flag or remove it entirely. I'd be open to that if people feel strongly, but I think this is probably good enough for now.

@AstroBarker please try this branch and see if it resolves the issues you were seeing.

@dholladay00 @mauneyc-LANL @rbberger @jhp-lanl  I'd like your feedback on this solution. Do you agree this feels safe enough for now? Or should we more aggressively eliminate any possibility of UB here?

While I'm at it, I cleaned up some warnings I was seeing when compiling the code which were getting on my nerves:
- A few unused variable warnings
- I re-implemented `strcat` with device decorations (needed for the error message for entropy not implemented), as the standard library version is not implemented on device
- I made some device/inline annotations consistent in a few spots.

There are more warnings in the code than this... and I'd like to clean them up when we have the time. But one thing at a time.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
