### PR TITLE
add mass fractions to stellarcollapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR232]](https://github.com/lanl/singularity-eos/pull/228) Fixed uninitialized cmake path variables
 
 ### Added (new features/APIs/variables/...)
+- [[PR250]](https://github.com/lanl/singularity-eos/pull/250) added mass fraction output to stellar collapse eos
 - [[PR226]](https://github.com/lanl/singularity-eos/pull/226) added entropy interpolation to stellar collapse eos
 - [[PR202]](https://github.com/lanl/singularity-eos/pull/202) added the Vinet analytical EOS wth test cases and documentation.
 - [[PR226]](https://github.com/lanl/singularity-eos/pull/226) added entropy interpolation to stellar collapse eos

--- a/doc/sphinx/src/models.rst
+++ b/doc/sphinx/src/models.rst
@@ -1115,6 +1115,23 @@ whether or not to apply the above-described median filter.
 
 which saves the current EOS data in ``sp5`` format.
 
+The ``StellarCollapse`` model, if used alone, also provides several
+additional functions of interest for those running, e.g., supernova
+simulations:
+
+.. cpp:function:: void MassFractionsFromDensityTemperature(const Real rho, const Real temperature, Real &Xa, Real &Xn, Real &Xp, Real &Abar, Real &Zbar, Real *lambda = nullptr) const
+
+which returns the mass fractions for alpha particles, ``Xa``, heavy
+ions ``Xh``, neutrons ``Xn``, and protons ``Xp``, as well as the
+average atomic mass ``Abar`` and atomic number ``Zbar`` for heavy
+ions, assuming nuclear statistical equilibrium.
+
+In addition, the user may query the bounds of the table via the
+functions ``lRhoMin()``, ``lRhoMax()``, ``lTMin()``, ``lTMax()``,
+``TMin()``, ``TMax()``, ``YeMin()``, ``YeMax()``, ``sieMin()``, and
+``sieMax()``, which all return a ``Real`` number. The ``l`` prefix
+indicates log base 10.
+
 .. _Stellar Collapse: https://stellarcollapse.org/equationofstate.html
 
 .. _OConnor and Ott: https://doi.org/10.1088/0264-9381/27/11/114103

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -599,10 +599,9 @@ void StellarCollapse::DensityEnergyFromPressureTemperature(const Real press,
 }
 
 PORTABLE_INLINE_FUNCTION
-void StellarCollapse::MassFractionsFromDensityTemperature(const Real rho, const Real temperature,
-                                                          Real &Xa, Real &Xh, Real &Xn, Real &Xp,
-                                                          Real &Abar, Real &Zbar,
-                                                          Real *lambda = nullptr) const {
+void StellarCollapse::MassFractionsFromDensityTemperature(
+    const Real rho, const Real temperature, Real &Xa, Real &Xh, Real &Xn, Real &Xp,
+    Real &Abar, Real &Zbar, Real *lambda = nullptr) const {
   Real lRho, lT, Ye;
   getLogsFromRhoT_(rho, temperature, lambda, lRho, lT, Ye);
   Xa = Xa_.interpToReal(Ye, lRho, lT);

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -601,7 +601,7 @@ void StellarCollapse::DensityEnergyFromPressureTemperature(const Real press,
 PORTABLE_INLINE_FUNCTION
 void StellarCollapse::MassFractionsFromDensityTemperature(
     const Real rho, const Real temperature, Real &Xa, Real &Xh, Real &Xn, Real &Xp,
-    Real &Abar, Real &Zbar, Real *lambda = nullptr) const {
+    Real &Abar, Real &Zbar, Real *lambda) const {
   Real lRho, lT, Ye;
   getLogsFromRhoT_(rho, temperature, lambda, lRho, lT, Ye);
   Xa = Xa_.interpToReal(Ye, lRho, lT);

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -132,6 +132,14 @@ class StellarCollapse : public EosBase<StellarCollapse> {
   PORTABLE_INLINE_FUNCTION
   void DensityEnergyFromPressureTemperature(const Real press, const Real temp,
                                             Real *lambda, Real &rho, Real &sie) const;
+
+  // Properties of an NSE EOS
+  PORTABLE_INLINE_FUNCTION
+  void MassFractionsFromDensityTemperature(const Real rho, const Real temperature,
+                                           Real &Xa, Real &Xh, Real &Xn, Real &Xp,
+                                           Real &Abar, Real &Zbar,
+                                           Real *lambda = nullptr) const;
+
   PORTABLE_INLINE_FUNCTION
   void FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, Real &bmod,
                const unsigned long output, Real *lambda = nullptr) const;
@@ -588,6 +596,21 @@ void StellarCollapse::DensityEnergyFromPressureTemperature(const Real press,
                                                            const Real temp, Real *lambda,
                                                            Real &rho, Real &sie) const {
   EOS_ERROR("StellarCollapse::DensityEnergyFromPRessureTemperature is a stub");
+}
+
+PORTABLE_INLINE_FUNCTION
+void StellarCollapse::MassFractionsFromDensityTemperature(const Real rho, const Real temperature,
+                                                          Real &Xa, Real &Xh, Real &Xn, Real &Xp,
+                                                          Real &Abar, Real &Zbar,
+                                                          Real *lambda = nullptr) const {
+  Real lRho, lT, Ye;
+  getLogsFromRhoT_(rho, temperature, lambda, lRho, lT, Ye);
+  Xa = Xa_.interpToReal(Ye, lRho, lT);
+  Xh = Xh_.interpToReal(Ye, lRho, lT);
+  Xn = Xn_.interpToReal(Ye, lRho, lT);
+  Xp = Xp_.interpToReal(Ye, lRho, lT);
+  Abar = Abar_.interpToReal(Ye, lRho, lT);
+  Zbar = Zbar_.interpToReal(Ye, lRho, lT);
 }
 
 PORTABLE_INLINE_FUNCTION

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -1119,6 +1119,9 @@ SCENARIO("Stellar Collapse EOS", "[StellarCollapse][EOSBuilder]") {
           Real Ye = yemin + i * dY;
           lambda[0] = Ye;
           REQUIRE(isClose(sie, sc.InternalEnergyFromDensityTemperature(rho, t, lambda)));
+          Real Xa, Xh, Xn, Xp, Abar, Zbar;
+          sc.MassFractionsFromDensityTemperature(rho, t, Xa, Xh, Xn, Xp, Abar, Zbar, lambda);
+          REQUIRE(isClose(Ye, Xp));
         }
         Real rhomin = sc.rhoMin();
         Real rhomax = sc.rhoMax();

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -1120,7 +1120,8 @@ SCENARIO("Stellar Collapse EOS", "[StellarCollapse][EOSBuilder]") {
           lambda[0] = Ye;
           REQUIRE(isClose(sie, sc.InternalEnergyFromDensityTemperature(rho, t, lambda)));
           Real Xa, Xh, Xn, Xp, Abar, Zbar;
-          sc.MassFractionsFromDensityTemperature(rho, t, Xa, Xh, Xn, Xp, Abar, Zbar, lambda);
+          sc.MassFractionsFromDensityTemperature(rho, t, Xa, Xh, Xn, Xp, Abar, Zbar,
+                                                 lambda);
           REQUIRE(isClose(Ye, Xp));
         }
         Real rhomin = sc.rhoMin();


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This is a feature needed by NGP code Phoebus, which provides additional astrophysical data tabulated in the stellar collapse table. It should have no effect unless a user specifically pulls a `StellarCollapse` equation of state out of the variant.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
