### PR TITLE
Fix install of eospac-wrapper

### DIFF
--- a/eospac-wrapper/CMakeLists.txt
+++ b/eospac-wrapper/CMakeLists.txt
@@ -22,8 +22,6 @@ add_library(eospac-wrapper
   ${EOSWRAPPER_SRCS} ${EOSWRAPPER_HEADERS}
 )
 
-add_library(singularity-eos::eospac-wrapper ALIAS eospac-wrapper)
-
 target_include_directories(eospac-wrapper
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -49,18 +47,5 @@ install(
 )
 
 install(
-  TARGETS eospac-wrapper EXPORT eospac-wrapperTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  TARGETS eospac-wrapper EXPORT singularity-eosTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-
-install(
-  EXPORT eospac-wrapperTargets
-  FILE eospac-wrapperTargets.cmake
-  NAMESPACE singularity-eos::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/singularity-eos
-  )
-
-export(
-  EXPORT eospac-wrapperTargets
-  FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/eospac-wrapperTargets.cmake
-  NAMESPACE singularity-eos::
-  )

--- a/eospac-wrapper/CMakeLists.txt
+++ b/eospac-wrapper/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(eospac-wrapper
   ${EOSWRAPPER_SRCS} ${EOSWRAPPER_HEADERS}
 )
 
+add_library(singularity-eos::eospac-wrapper ALIAS eospac-wrapper)
+
 target_include_directories(eospac-wrapper
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

`eospac-wrapper` was generating cmake install files seperately from `singularity-eos`

`install(
  TARGETS eospac-wrapper EXPORT eospac-wrapperTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}
)`

The `EXPORT eospac-wrapperTargets` specifies a install target file. When `find_package` is used downstream, these files do not get consumed, so cmake reports that there is an dangling target reference to `singularity-eos::eospac-wrapper`.

This PR simplifies the install of `eospac-wrapper`, so that the target is defined in the same file as `singularity-eos`

`install(
  TARGETS eospac-wrapper EXPORT singularity-eosTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}
)`

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
