### PR TITLE
Add the ability to pull an unmodified EOS out of a modified one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR232]](https://github.com/lanl/singularity-eos/pull/228) Fixed uninitialized cmake path variables
 
 ### Added (new features/APIs/variables/...)
+- [[PR254]](https://github.com/lanl/singularity-eos/pull/254) added ability to peel off modifiers as needed
 - [[PR250]](https://github.com/lanl/singularity-eos/pull/250) added mass fraction output to stellar collapse eos
 - [[PR226]](https://github.com/lanl/singularity-eos/pull/226) added entropy interpolation to stellar collapse eos
 - [[PR202]](https://github.com/lanl/singularity-eos/pull/202) added the Vinet analytical EOS wth test cases and documentation.

--- a/doc/sphinx/src/modifiers.rst
+++ b/doc/sphinx/src/modifiers.rst
@@ -194,3 +194,14 @@ Modifiers can be composed. For example:
 
   using namespace singularity;
   auto my_eos = ShiftedEOS<ScaledEOS<IdealGas>>(ScaledEOS(IdealGas(gm1, Cv), scale), shift);
+
+Undoing Modifiers
+------------------
+
+Modifiers can also be undone, extracting the underlying EOS. Continuing the example above,
+
+.. code-block:: cpp
+
+   auto unmodified = my_eos.GetUnmodifiedObject();
+
+will extract the underlying ``IdealGas`` EOS model out from the scale and shift.

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -269,6 +269,31 @@ modifiers. However, note that modifiers do not commute, and only one
 order is supported. The ordering, inside-out, is ``UnitSystem`` or
 ``RelativisticEOS``, then ``ScaledEOS``, then ``ShiftedEOS``.
 
+Relevant to the broad ``singularity-eos`` API, EOS models provide
+introspection. To check if an EOS is modified, call
+
+.. cpp:function:: bool IsModified() const;
+
+This will return ``true`` for a modified model and ``false``
+otherwise. Modifiers can also be undone. To get a completely
+unmodified EOS model, call
+
+.. cpp:function:: auto GetUnmodifiedObject();
+
+The return value here will be either the type of the ``EOS`` variant
+type or the unmodified model (for example ``IdealGas``) or, depending
+on whether this method was callled within a variant or on a standalone
+model outside a variant.
+
+If you have chained modifiers, e.g.,
+``ShifedEOS<ScaledEOS<IdealGas>``, you can undo only one of the
+modifiers with the
+
+.. cpp-function:: auto UnmodifyOnce();
+
+method, which has the same return type pattern as above, but only
+undoes one level of modification.
+
 For more details on modifiers, see the :ref:`modifiers<modifiers>`
 section. If you need a combination of modifiers not supported by
 default, we recommend building a custom variant as described above.

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -289,7 +289,7 @@ If you have chained modifiers, e.g.,
 ``ShifedEOS<ScaledEOS<IdealGas>``, you can undo only one of the
 modifiers with the
 
-.. cpp-function:: auto UnmodifyOnce();
+.. cpp:function:: auto UnmodifyOnce();
 
 method, which has the same return type pattern as above, but only
 undoes one level of modification.

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -424,6 +424,14 @@ class EosBase {
     impl::StrCat(msg, "' EOS");
     PORTABLE_ALWAYS_THROW_OR_ABORT(msg);
   }
+
+  // Tooling for modifiers
+  PORTABLE_FORCEINLINE_FUNCTION
+  bool IsModified() const { return false; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  auto UnmodifyOnce() { return *static_cast<CRTP *>(this); }
+  PORTABLE_FORCEINLINE_FUNCTION
+  auto GetUnmodifiedObject() { return *static_cast<CRTP *>(this); }
 };
 } // namespace eos_base
 } // namespace singularity

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -840,6 +840,22 @@ class Variant {
         eos_);
   }
 
+  // Tooling for modifiers
+  PORTABLE_FORCEINLINE_FUNCTION
+  bool IsModified() const {
+    return mpark::visit([](const auto &eos) { return eos.IsModified(); }, eos_);
+  }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Variant UnmodifyOnce() {
+    return mpark::visit(
+        [](auto &eos) { return eos_variant<EOSs...>(eos.UnmodifyOnce()); }, eos_);
+  }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Variant GetUnmodifiedObject() {
+    return mpark::visit(
+        [](auto &eos) { return eos_variant<EOSs...>(eos.GetUnmodifiedObject()); }, eos_);
+  }
+
   PORTABLE_INLINE_FUNCTION
   unsigned long PreferredInput() const noexcept {
     return mpark::visit([](const auto &eos) { return eos.PreferredInput(); }, eos_);

--- a/singularity-eos/eos/modifiers/eos_unitsystem.hpp
+++ b/singularity-eos/eos/modifiers/eos_unitsystem.hpp
@@ -269,6 +269,13 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
     printf("Units = %e %e %e %e\n", rho_unit_, sie_unit_, temp_unit_, press_unit_);
   }
 
+  PORTABLE_FORCEINLINE_FUNCTION
+  bool IsModified() const { return true; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  T UnmodifyOnce() { return t_; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  auto GetUnmodifiedObject() { return t_.GetUnmodifiedObject(); }
+
  private:
   T t_;
 

--- a/singularity-eos/eos/modifiers/ramps_eos.hpp
+++ b/singularity-eos/eos/modifiers/ramps_eos.hpp
@@ -258,6 +258,13 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
   // Vector functions that overload the scalar versions declared here.
   SG_ADD_BASE_CLASS_USINGS(BilinearRampEOS<T>)
 
+  PORTABLE_FORCEINLINE_FUNCTION
+  bool IsModified() const { return true; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  T UnmodifyOnce() { return t_; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  auto GetUnmodifiedObject() { return t_.GetUnmodifiedObject(); }
+
  private:
   T t_;
   Real r0_;

--- a/singularity-eos/eos/modifiers/relativistic_eos.hpp
+++ b/singularity-eos/eos/modifiers/relativistic_eos.hpp
@@ -185,6 +185,13 @@ class RelativisticEOS : public EosBase<RelativisticEOS<T>> {
     t_.ValuesAtReferenceState(rho, temp, sie, press, cv, bmod, dpde, dvdt, lambda);
   }
 
+  PORTABLE_FORCEINLINE_FUNCTION
+  bool IsModified() const { return true; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  T UnmodifyOnce() { return t_; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  auto GetUnmodifiedObject() { return t_.GetUnmodifiedObject(); }
+
  private:
   T t_;
   Real cl_, cl2_;

--- a/singularity-eos/eos/modifiers/scaled_eos.hpp
+++ b/singularity-eos/eos/modifiers/scaled_eos.hpp
@@ -201,6 +201,13 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
     return t_.MinimumTemperature();
   }
 
+  PORTABLE_FORCEINLINE_FUNCTION
+  bool IsModified() const { return true; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  T UnmodifyOnce() { return t_; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  auto GetUnmodifiedObject() { return t_.GetUnmodifiedObject(); }
+
  private:
   T t_;
   double scale_;

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -192,6 +192,13 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
     return t_.MinimumTemperature();
   }
 
+  PORTABLE_FORCEINLINE_FUNCTION
+  bool IsModified() const { return true; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  T UnmodifyOnce() { return t_; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  auto GetUnmodifiedObject() { return t_.GetUnmodifiedObject(); }
+
  private:
   T t_;
   double shift_;

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -232,7 +232,7 @@ SCENARIO("EOS Variant Type", "[Variant][EOS]") {
   std::cout << demangle(typeid(EOS).name()) << std::endl;
 }
 
-SCENARIO("EOS Builder and Modifiers", "[EOSBuilder],[Modifiers][IdealGas]") {
+SCENARIO("EOS Builder and Modifiers", "[EOSBuilder][Modifiers][IdealGas]") {
 
   GIVEN("Parameters for a shifted and scaled ideal gas") {
     constexpr Real Cv = 2.0;
@@ -248,6 +248,14 @@ SCENARIO("EOS Builder and Modifiers", "[EOSBuilder],[Modifiers][IdealGas]") {
       THEN("The shift and scale parameters pass through correctly") {
 
         REQUIRE(eos.PressureFromDensityInternalEnergy(rho, sie) == 0.3);
+      }
+      THEN("We can UnmodifyOnce to get the shifted EOS object") {
+        EOS shifted = eos.UnmodifyOnce();
+        REQUIRE(shifted.IsType<ShiftedEOS<IdealGas>>());
+        AND_THEN("We can extract the unmodified object") {
+          EOS unmod = eos.GetUnmodifiedObject();
+          REQUIRE(unmod.IsType<IdealGas>());
+        }
       }
     }
     WHEN("We use the EOSBuilder") {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Sometimes you may wish to have access to the unmodified model... for example, because you wish to access model-specific features (i.e., the mass fractions in the stellar collapse tables), because you want to drop out of code units and use cgs, or because you wish to swap one modifier for another at runtime.

This PR lets you do those things. I provide three functions, shared across all models, that let you do this:
1. `bool Model::IsModified() const` returns true if the EOS has a modifier applied to it and false otherwise.
2. `auto UnmodifyOnce()` if the EOS is modified, pull off the most recent modifier. Returns either the variant or an appropriate type.
3. `auto GetUnmodifiedObject()` returns the underlying EOS with all modifiers removed. Type again is either the variant or the appropriate type.

This feature is needed by the NGP codes but I believe it will be useful broadly for any downstream code that uses C++. (Obviously it's of no help to the fortran codes.)

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
