### PR TITLE
Add GitHub action to update spackages :robot:

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -13,19 +13,19 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout this repo
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
         - name: create build
           run: mkdir build
         - name: Checkout ports-of-call
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             repository: lanl/ports-of-call
             path: build/ports-of-call
             fetch-depth: 0
         - name: Checkout spiner
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             repository: lanl/spiner
             path: build/spiner

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,0 +1,55 @@
+name: Check Spack dependencies for updates
+
+on:
+  # for manual jobs
+  workflow_dispatch:
+  # triggers at around 15:00 UTC (with some delay)
+  schedule:
+   - cron: '0 15 * * *'
+
+jobs:
+    deps:
+      name:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout this repo
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+        - name: create build
+          run: mkdir build
+        - name: Checkout ports-of-call
+          uses: actions/checkout@v2
+          with:
+            repository: lanl/ports-of-call
+            path: build/ports-of-call
+            fetch-depth: 0
+        - name: Checkout spiner
+          uses: actions/checkout@v2
+          with:
+            repository: lanl/spiner
+            path: build/spiner
+            fetch-depth: 0
+        - name: copy over spack-repo/packages
+          run: |
+            # assume ports-of-call may be newer than spiner
+            cp -R build/spiner/spack-repo/packages/* spack-repo/packages/
+            cp -R build/ports-of-call/spack-repo/packages/* spack-repo/packages/
+        - name: is there a difference?
+          run: git diff --exit-code --compact-summary
+          id: no_change
+        - name: create branch
+          if: ${{ steps.no_change.conclusion == 'failure' }}
+          run: |
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git branch -D github-bot/update_spackages || true
+            git checkout -b github-bot/update_spackages
+            git add spack-repo
+            git commit -m "spack updates"
+            git push -f --set-upstream origin github-bot/update_spackages
+        - name: create pull request
+          if: ${{ steps.no_change.conclusion == 'failure' }}
+          run: gh pr create -B main -H github-bot/update_spackages --title 'Update spackages' --body 'Created by Github action'
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
 
       steps:      
         - name: Checkout code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
             submodules: recursive

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -13,7 +13,7 @@ jobs:
 
       steps:      
         - name: Checkout code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: Set system to non-interactive mode
           run: export DEBIAN_FRONTEND=noninteractive
         - name: install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
       steps:
         - name: Checkout code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             submodules: recursive
         - name: Set system to non-interactive mode

--- a/.github/workflows/tests_minimal.yml
+++ b/.github/workflows/tests_minimal.yml
@@ -13,7 +13,7 @@ jobs:
 
       steps:
         - name: Checkout code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             submodules: recursive
         - name: Set system to non-interactive mode

--- a/doc/sphinx/src/contributing.rst
+++ b/doc/sphinx/src/contributing.rst
@@ -122,6 +122,11 @@ submit issues on the relevant github pages. However, if you can't
 figure out where an issue belongs, no big deal. Submit where you can
 and we'll engage with you to figure out how to proceed.
 
+.. note::
+   There are scheduled workflows triggered by GitHub actions that will
+   automatically check ``spiner`` and ``ports-of-call`` for Spack updates.  If
+   detected, the GitHub action bot will create a PR with the necessary changes.
+
 Process for adding a new EOS
 ----------------------------
 


### PR DESCRIPTION
## PR Summary

This adds a manual and scheduled action to check for changes in ports-of-call and spiner spackages and migrate them over to singularity-eos. If a change is detected, it will create a PR authored by a bot.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
