### PR TITLE
Implement modifiers for EOSPAC

### DIFF
--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -82,6 +82,35 @@ char *StrCat(char *destination, const char *source) {
   using EosBase<EOSDERIVED>::EntropyFromDensityInternalEnergy;                           \
   using EosBase<EOSDERIVED>::EntropyIsNotEnabled;
 
+class Factor {
+  Real value_ = 1.0;
+  bool is_set_ = false;
+
+ public:
+  bool is_set() const { return is_set_; }
+
+  Real get() const { return value_; }
+
+  void set(Real v) {
+    is_set_ = true;
+    value_ = v;
+  }
+
+  void apply(Real v) {
+    is_set_ = true;
+    value_ *= v;
+  }
+
+  void clear() {
+    is_set_ = false;
+    value_ = 1.0;
+  }
+};
+
+struct Transform {
+  Factor x, y, f;
+};
+
 /*
 This is a CRTP that allows for static inheritance so that default behavior for
 various member functions can be defined.
@@ -127,8 +156,8 @@ class EosBase {
   template <typename LambdaIndexer>
   inline void TemperatureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
                                                    Real *temperatures, Real * /*scratch*/,
-                                                   const int num,
-                                                   LambdaIndexer &&lambdas) const {
+                                                   const int num, LambdaIndexer &&lambdas,
+                                                   Transform && = Transform()) const {
     TemperatureFromDensityInternalEnergy(rhos, sies, temperatures, num,
                                          std::forward<LambdaIndexer>(lambdas));
   }
@@ -163,7 +192,8 @@ class EosBase {
   inline void InternalEnergyFromDensityTemperature(const Real *rhos,
                                                    const Real *temperatures, Real *sies,
                                                    Real * /*scratch*/, const int num,
-                                                   LambdaIndexer &&lambdas) const {
+                                                   LambdaIndexer &&lambdas,
+                                                   Transform && = Transform()) const {
     InternalEnergyFromDensityTemperature(rhos, temperatures, sies, num,
                                          std::forward<LambdaIndexer>(lambdas));
   }
@@ -195,8 +225,8 @@ class EosBase {
   template <typename LambdaIndexer>
   inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
                                              Real *pressures, Real * /*scratch*/,
-                                             const int num,
-                                             LambdaIndexer &&lambdas) const {
+                                             const int num, LambdaIndexer &&lambdas,
+                                             Transform && = Transform()) const {
     PressureFromDensityTemperature(rhos, temperatures, pressures, num,
                                    std::forward<LambdaIndexer>(lambdas));
   }
@@ -227,8 +257,8 @@ class EosBase {
   template <typename LambdaIndexer>
   inline void PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
                                                 Real *pressures, Real * /*scratch*/,
-                                                const int num,
-                                                LambdaIndexer &&lambdas) const {
+                                                const int num, LambdaIndexer &&lambdas,
+                                                Transform && = Transform()) const {
     PressureFromDensityInternalEnergy(rhos, sies, pressures, num,
                                       std::forward<LambdaIndexer>(lambdas));
   }
@@ -260,8 +290,8 @@ class EosBase {
   template <typename LambdaIndexer>
   inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
                                             Real *entropies, Real * /*scratch*/,
-                                            const int num,
-                                            LambdaIndexer &&lambdas) const {
+                                            const int num, LambdaIndexer &&lambdas,
+                                            Transform && = Transform()) const {
     EntropyFromDensityTemperature(rhos, temperatures, entropies, num,
                                   std::forward<LambdaIndexer>(lambdas));
   }
@@ -292,8 +322,8 @@ class EosBase {
   template <typename LambdaIndexer>
   inline void EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies,
                                                Real *entropies, Real * /*scratch*/,
-                                               const int num,
-                                               LambdaIndexer &&lambdas) const {
+                                               const int num, LambdaIndexer &&lambdas,
+                                               Transform && = Transform()) const {
     EntropyFromDensityInternalEnergy(rhos, sies, entropies, num,
                                      std::forward<LambdaIndexer>(lambdas));
   }
@@ -327,7 +357,8 @@ class EosBase {
   inline void SpecificHeatFromDensityTemperature(const Real *rhos,
                                                  const Real *temperatures, Real *cvs,
                                                  Real * /*scratch*/, const int num,
-                                                 LambdaIndexer &&lambdas) const {
+                                                 LambdaIndexer &&lambdas,
+                                                 Transform && = Transform()) const {
     SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, num,
                                        std::forward<LambdaIndexer>(lambdas));
   }
@@ -359,7 +390,8 @@ class EosBase {
   inline void SpecificHeatFromDensityInternalEnergy(const Real *rhos, const Real *sies,
                                                     Real *cvs, Real * /*scratch*/,
                                                     const int num,
-                                                    LambdaIndexer &&lambdas) const {
+                                                    LambdaIndexer &&lambdas,
+                                                    Transform && = Transform()) const {
     SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, num,
                                           std::forward<LambdaIndexer>(lambdas));
   }
@@ -393,7 +425,8 @@ class EosBase {
   inline void BulkModulusFromDensityTemperature(const Real *rhos,
                                                 const Real *temperatures, Real *bmods,
                                                 Real * /*scratch*/, const int num,
-                                                LambdaIndexer &&lambdas) const {
+                                                LambdaIndexer &&lambdas,
+                                                Transform && = Transform()) const {
     BulkModulusFromDensityTemperature(rhos, temperatures, bmods, num,
                                       std::forward<LambdaIndexer>(lambdas));
   }
@@ -424,8 +457,8 @@ class EosBase {
   template <typename LambdaIndexer>
   inline void BulkModulusFromDensityInternalEnergy(const Real *rhos, const Real *sies,
                                                    Real *bmods, Real * /*scratch*/,
-                                                   const int num,
-                                                   LambdaIndexer &&lambdas) const {
+                                                   const int num, LambdaIndexer &&lambdas,
+                                                   Transform && = Transform()) const {
     BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, num,
                                          std::forward<LambdaIndexer>(lambdas));
   }
@@ -459,7 +492,8 @@ class EosBase {
   inline void GruneisenParamFromDensityTemperature(const Real *rhos,
                                                    const Real *temperatures, Real *gm1s,
                                                    Real * /*scratch*/, const int num,
-                                                   LambdaIndexer &&lambdas) const {
+                                                   LambdaIndexer &&lambdas,
+                                                   Transform && = Transform()) const {
     GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, num,
                                          std::forward<LambdaIndexer>(lambdas));
   }
@@ -492,7 +526,8 @@ class EosBase {
   inline void GruneisenParamFromDensityInternalEnergy(const Real *rhos, const Real *sies,
                                                       Real *gm1s, Real * /*scratch*/,
                                                       const int num,
-                                                      LambdaIndexer &&lambdas) const {
+                                                      LambdaIndexer &&lambdas,
+                                                      Transform && = Transform()) const {
     GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, num,
                                             std::forward<LambdaIndexer>(lambdas));
   }

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -93,6 +93,10 @@ member functions is to perform a `portableFor` loop over all of the input states
 template <typename CRTP>
 class EosBase {
  public:
+  template <typename T, typename R>
+  struct is_raw_pointer
+      : std::is_same<std::remove_reference_t<std::remove_cv_t<T>>, R *> {};
+
   // Vector member functions
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -112,13 +112,27 @@ class EosBase {
               copy.TemperatureFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   TemperatureFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                        RealIndexer &&temperatures, Real * /*scratch*/,
                                        const int num, LambdaIndexer &&lambdas) const {
-    TemperatureFromDensityInternalEnergy(rhos, sies, temperatures, num, lambdas);
+    TemperatureFromDensityInternalEnergy(std::forward<ConstRealIndexer>(rhos),
+                                         std::forward<ConstRealIndexer>(sies),
+                                         std::forward<RealIndexer>(temperatures), num,
+                                         std::forward<LambdaIndexer>(lambdas));
   }
+
+  template <typename LambdaIndexer>
+  inline void TemperatureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                                   Real *temperatures, Real * /*scratch*/,
+                                                   const int num,
+                                                   LambdaIndexer &&lambdas) const {
+    TemperatureFromDensityInternalEnergy(rhos, sies, temperatures, num,
+                                         std::forward<LambdaIndexer>(lambdas));
+  }
+
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void InternalEnergyFromDensityTemperature(ConstRealIndexer &&rhos,
                                                    ConstRealIndexer &&temperatures,
@@ -133,13 +147,25 @@ class EosBase {
                                                               lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void InternalEnergyFromDensityTemperature(ConstRealIndexer &&rhos,
                                                    ConstRealIndexer &&temperatures,
                                                    RealIndexer &&sies, Real * /*scratch*/,
                                                    const int num,
                                                    LambdaIndexer &&lambdas) const {
-    InternalEnergyFromDensityTemperature(rhos, temperatures, sies, num, lambdas);
+    InternalEnergyFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                         std::forward<ConstRealIndexer>(temperatures),
+                                         std::forward<RealIndexer>(sies), num,
+                                         std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename LambdaIndexer>
+  inline void InternalEnergyFromDensityTemperature(const Real *rhos,
+                                                   const Real *temperatures, Real *sies,
+                                                   Real * /*scratch*/, const int num,
+                                                   LambdaIndexer &&lambdas) const {
+    InternalEnergyFromDensityTemperature(rhos, temperatures, sies, num,
+                                         std::forward<LambdaIndexer>(lambdas));
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void PressureFromDensityTemperature(ConstRealIndexer &&rhos,
@@ -155,12 +181,24 @@ class EosBase {
               copy.PressureFromDensityTemperature(rhos[i], temperatures[i], lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   PressureFromDensityTemperature(ConstRealIndexer &&rhos, ConstRealIndexer &&temperatures,
                                  RealIndexer &&pressures, Real * /*scratch*/,
                                  const int num, LambdaIndexer &&lambdas) const {
-    PressureFromDensityTemperature(rhos, temperatures, pressures, num, lambdas);
+    PressureFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                   std::forward<ConstRealIndexer>(temperatures),
+                                   std::forward<RealIndexer>(pressures), num,
+                                   std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename LambdaIndexer>
+  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                             Real *pressures, Real * /*scratch*/,
+                                             const int num,
+                                             LambdaIndexer &&lambdas) const {
+    PressureFromDensityTemperature(rhos, temperatures, pressures, num,
+                                   std::forward<LambdaIndexer>(lambdas));
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void PressureFromDensityInternalEnergy(ConstRealIndexer &&rhos,
@@ -176,12 +214,23 @@ class EosBase {
               copy.PressureFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   PressureFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                     RealIndexer &&pressures, Real * /*scratch*/,
                                     const int num, LambdaIndexer &&lambdas) const {
-    PressureFromDensityInternalEnergy(rhos, sies, pressures, num, lambdas);
+    PressureFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(pressures), num, std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename LambdaIndexer>
+  inline void PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                                Real *pressures, Real * /*scratch*/,
+                                                const int num,
+                                                LambdaIndexer &&lambdas) const {
+    PressureFromDensityInternalEnergy(rhos, sies, pressures, num,
+                                      std::forward<LambdaIndexer>(lambdas));
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void EntropyFromDensityTemperature(ConstRealIndexer &&rhos,
@@ -197,12 +246,24 @@ class EosBase {
               copy.EntropyFromDensityTemperature(rhos[i], temperatures[i], lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   EntropyFromDensityTemperature(ConstRealIndexer &&rhos, ConstRealIndexer &&temperatures,
                                 RealIndexer &&entropies, Real * /*scratch*/,
                                 const int num, LambdaIndexer &&lambdas) const {
-    EntropyFromDensityTemperature(rhos, temperatures, entropies, num, lambdas);
+    EntropyFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                  std::forward<ConstRealIndexer>(temperatures),
+                                  std::forward<RealIndexer>(entropies), num,
+                                  std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename LambdaIndexer>
+  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                            Real *entropies, Real * /*scratch*/,
+                                            const int num,
+                                            LambdaIndexer &&lambdas) const {
+    EntropyFromDensityTemperature(rhos, temperatures, entropies, num,
+                                  std::forward<LambdaIndexer>(lambdas));
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void EntropyFromDensityInternalEnergy(ConstRealIndexer &&rhos,
@@ -218,12 +279,23 @@ class EosBase {
               copy.EntropyFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   EntropyFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                    RealIndexer &&entropies, Real * /*scratch*/,
                                    const int num, LambdaIndexer &&lambdas) const {
-    EntropyFromDensityInternalEnergy(rhos, sies, entropies, num, lambdas);
+    EntropyFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(entropies), num, std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename LambdaIndexer>
+  inline void EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                               Real *entropies, Real * /*scratch*/,
+                                               const int num,
+                                               LambdaIndexer &&lambdas) const {
+    EntropyFromDensityInternalEnergy(rhos, sies, entropies, num,
+                                     std::forward<LambdaIndexer>(lambdas));
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void SpecificHeatFromDensityTemperature(ConstRealIndexer &&rhos,
@@ -239,13 +311,25 @@ class EosBase {
                                                            lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void SpecificHeatFromDensityTemperature(ConstRealIndexer &&rhos,
                                                  ConstRealIndexer &&temperatures,
                                                  RealIndexer &&cvs, Real * /*scratch*/,
                                                  const int num,
                                                  LambdaIndexer &&lambdas) const {
-    SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, num, lambdas);
+    SpecificHeatFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                       std::forward<ConstRealIndexer>(temperatures),
+                                       std::forward<RealIndexer>(cvs), num,
+                                       std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityTemperature(const Real *rhos,
+                                                 const Real *temperatures, Real *cvs,
+                                                 Real * /*scratch*/, const int num,
+                                                 LambdaIndexer &&lambdas) const {
+    SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, num,
+                                       std::forward<LambdaIndexer>(lambdas));
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void SpecificHeatFromDensityInternalEnergy(ConstRealIndexer &&rhos,
@@ -261,12 +345,23 @@ class EosBase {
               copy.SpecificHeatFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   SpecificHeatFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                         RealIndexer &&cvs, Real * /*scratch*/,
                                         const int num, LambdaIndexer &&lambdas) const {
-    SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, num, lambdas);
+    SpecificHeatFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(cvs), num, std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                                    Real *cvs, Real * /*scratch*/,
+                                                    const int num,
+                                                    LambdaIndexer &&lambdas) const {
+    SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, num,
+                                          std::forward<LambdaIndexer>(lambdas));
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void BulkModulusFromDensityTemperature(ConstRealIndexer &&rhos,
@@ -282,13 +377,25 @@ class EosBase {
                                                             lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void BulkModulusFromDensityTemperature(ConstRealIndexer &&rhos,
                                                 ConstRealIndexer &&temperatures,
                                                 RealIndexer &&bmods, Real * /*scratch*/,
                                                 const int num,
                                                 LambdaIndexer &&lambdas) const {
-    BulkModulusFromDensityTemperature(rhos, temperatures, bmods, num, lambdas);
+    BulkModulusFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                      std::forward<ConstRealIndexer>(temperatures),
+                                      std::forward<RealIndexer>(bmods), num,
+                                      std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityTemperature(const Real *rhos,
+                                                const Real *temperatures, Real *bmods,
+                                                Real * /*scratch*/, const int num,
+                                                LambdaIndexer &&lambdas) const {
+    BulkModulusFromDensityTemperature(rhos, temperatures, bmods, num,
+                                      std::forward<LambdaIndexer>(lambdas));
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void BulkModulusFromDensityInternalEnergy(ConstRealIndexer &&rhos,
@@ -304,12 +411,23 @@ class EosBase {
               copy.BulkModulusFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   BulkModulusFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                        RealIndexer &&bmods, Real * /*scratch*/,
                                        const int num, LambdaIndexer &&lambdas) const {
-    BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, num, lambdas);
+    BulkModulusFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(bmods), num, std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                                   Real *bmods, Real * /*scratch*/,
+                                                   const int num,
+                                                   LambdaIndexer &&lambdas) const {
+    BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, num,
+                                         std::forward<LambdaIndexer>(lambdas));
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void GruneisenParamFromDensityTemperature(ConstRealIndexer &&rhos,
@@ -325,13 +443,25 @@ class EosBase {
                                                               lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void GruneisenParamFromDensityTemperature(ConstRealIndexer &&rhos,
                                                    ConstRealIndexer &&temperatures,
                                                    RealIndexer &&gm1s, Real * /*scratch*/,
                                                    const int num,
                                                    LambdaIndexer &&lambdas) const {
-    GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, num, lambdas);
+    GruneisenParamFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                         std::forward<ConstRealIndexer>(temperatures),
+                                         std::forward<RealIndexer>(gm1s), num,
+                                         std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename LambdaIndexer>
+  inline void GruneisenParamFromDensityTemperature(const Real *rhos,
+                                                   const Real *temperatures, Real *gm1s,
+                                                   Real * /*scratch*/, const int num,
+                                                   LambdaIndexer &&lambdas) const {
+    GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, num,
+                                         std::forward<LambdaIndexer>(lambdas));
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void GruneisenParamFromDensityInternalEnergy(ConstRealIndexer &&rhos,
@@ -347,13 +477,24 @@ class EosBase {
               copy.GruneisenParamFromDensityInternalEnergy(rhos[i], sies[i], lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void GruneisenParamFromDensityInternalEnergy(ConstRealIndexer &&rhos,
                                                       ConstRealIndexer &&sies,
                                                       RealIndexer &&gm1s,
                                                       Real * /*scratch*/, const int num,
                                                       LambdaIndexer &&lambdas) const {
-    GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, num, lambdas);
+    GruneisenParamFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(gm1s), num, std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename LambdaIndexer>
+  inline void GruneisenParamFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                                      Real *gm1s, Real * /*scratch*/,
+                                                      const int num,
+                                                      LambdaIndexer &&lambdas) const {
+    GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, num,
+                                            std::forward<LambdaIndexer>(lambdas));
   }
   template <typename RealIndexer, typename LambdaIndexer>
   inline void FillEos(RealIndexer &&rhos, RealIndexer &&temps, RealIndexer &&energies,

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -309,10 +309,11 @@ class EOSPAC : public EosBase<EOSPAC> {
 
   // EOSPAC vector implementations
   template <typename LambdaIndexer>
-  inline void TemperatureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                                   Real *temperatures, Real *scratch,
-                                                   const int num,
-                                                   LambdaIndexer /*lambdas*/) const {
+  inline void
+  TemperatureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                       Real *temperatures, Real *scratch, const int num,
+                                       LambdaIndexer /*lambdas*/,
+                                       Transform &&transform = Transform()) const {
     using namespace EospacWrapper;
     EOS_REAL *R = const_cast<EOS_REAL *>(&rhos[0]);
     EOS_REAL *E = const_cast<EOS_REAL *>(&sies[0]);
@@ -321,9 +322,29 @@ class EOSPAC : public EosBase<EOSPAC> {
     EOS_REAL *dTde = scratch + 1 * num;
 
     EOS_INTEGER table = TofRE_table_;
-    EOS_INTEGER options[]{EOS_Y_CONVERT};
-    EOS_REAL values[]{sieFromSesame(1.0)};
-    EOS_INTEGER nopts = 1;
+    EOS_INTEGER options[3];
+    EOS_REAL values[3];
+    EOS_INTEGER nopts = 0;
+
+    if (transform.x.is_set()) {
+      options[nopts] = EOS_X_CONVERT;
+      values[nopts] = 1.0 / transform.x.get();
+      ++nopts;
+    }
+
+    options[nopts] = EOS_Y_CONVERT;
+    values[nopts] = sieFromSesame(1.0);
+    if (transform.y.is_set()) {
+      values[nopts] /= transform.y.get();
+    }
+    ++nopts;
+
+    if (transform.f.is_set()) {
+      options[nopts] = EOS_F_CONVERT;
+      values[nopts] = transform.f.get();
+      ++nopts;
+    }
+
     eosSafeInterpolate(&table, num, R, E, T, dTdr, dTde, "TofRE", Verbosity::Quiet,
                        options, values, nopts);
   }
@@ -331,8 +352,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   template <typename LambdaIndexer>
   inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
                                              Real *pressures, Real *scratch,
-                                             const int num,
-                                             LambdaIndexer /*lambdas*/) const {
+                                             const int num, LambdaIndexer /*lambdas*/,
+                                             Transform &&transform = Transform()) const {
     using namespace EospacWrapper;
     EOS_REAL *R = const_cast<EOS_REAL *>(&rhos[0]);
     EOS_REAL *T = const_cast<EOS_REAL *>(&temperatures[0]);
@@ -341,9 +362,35 @@ class EOSPAC : public EosBase<EOSPAC> {
     EOS_REAL *dPdT = scratch + 1 * num;
 
     EOS_INTEGER table = PofRT_table_;
-    EOS_INTEGER options[]{EOS_F_CONVERT, EOS_XY_PASSTHRU};
-    EOS_REAL values[]{pressureFromSesame(1.0), 1.0};
-    EOS_INTEGER nopts = 2;
+    EOS_INTEGER options[3];
+    EOS_REAL values[3];
+    EOS_INTEGER nopts = 0;
+
+    if (!transform.x.is_set() && !transform.y.is_set()) {
+      options[nopts] = EOS_XY_PASSTHRU;
+      values[nopts] = 1.0;
+      ++nopts;
+    } else {
+      if (transform.x.is_set()) {
+        options[nopts] = EOS_X_CONVERT;
+        values[nopts] = 1.0 / transform.x.get();
+        ++nopts;
+      }
+
+      if (transform.y.is_set()) {
+        options[nopts] = EOS_Y_CONVERT;
+        values[nopts] = 1.0 / transform.y.get();
+        ++nopts;
+      }
+    }
+
+    options[nopts] = EOS_F_CONVERT;
+    values[nopts] = pressureFromSesame(1.0);
+
+    if (transform.f.is_set()) {
+      values[nopts] *= transform.f.get();
+    }
+    ++nopts;
 
     eosSafeInterpolate(&table, num, R, T, P, dPdr, dPdT, "PofRT", Verbosity::Quiet,
                        options, values, nopts);
@@ -459,10 +506,11 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename LambdaIndexer>
-  inline void InternalEnergyFromDensityTemperature(const Real *rhos,
-                                                   const Real *temperatures, Real *sies,
-                                                   Real *scratch, const int num,
-                                                   LambdaIndexer /*lambdas*/) const {
+  inline void
+  InternalEnergyFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                       Real *sies, Real *scratch, const int num,
+                                       LambdaIndexer /*lambdas*/,
+                                       Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -474,19 +522,44 @@ class EOSPAC : public EosBase<EOSPAC> {
     EOS_REAL *DEDR = scratch + 1 * num;
 
     EOS_INTEGER table = EofRT_table_;
-    EOS_INTEGER options[]{EOS_F_CONVERT, EOS_XY_PASSTHRU};
-    EOS_REAL values[]{sieFromSesame(1.0), 1.0};
-    EOS_INTEGER nopts = 2;
+    EOS_INTEGER options[3];
+    EOS_REAL values[3];
+    EOS_INTEGER nopts = 0;
+
+    if (!transform.x.is_set() && !transform.y.is_set()) {
+      options[nopts] = EOS_XY_PASSTHRU;
+      values[nopts] = 1.0;
+      ++nopts;
+    } else {
+      if (transform.x.is_set()) {
+        options[nopts] = EOS_X_CONVERT;
+        values[nopts] = 1.0 / transform.x.get();
+        ++nopts;
+      }
+
+      if (transform.y.is_set()) {
+        options[nopts] = EOS_Y_CONVERT;
+        values[nopts] = 1.0 / transform.y.get();
+        ++nopts;
+      }
+    }
+
+    options[nopts] = EOS_F_CONVERT;
+    values[nopts] = sieFromSesame(1.0);
+
+    if (transform.f.is_set()) {
+      values[nopts] *= transform.f.get();
+    }
+    ++nopts;
 
     eosSafeInterpolate(&table, num, R, T, E, DEDR, DEDT, "EofRT", Verbosity::Quiet,
                        options, values, nopts);
   }
 
   template <typename LambdaIndexer>
-  inline void PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                                Real *pressures, Real *scratch,
-                                                const int num,
-                                                LambdaIndexer /*lambdas*/) const {
+  inline void PressureFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *pressures, Real *scratch, const int num,
+      LambdaIndexer /*lambdas*/, Transform &&transform = Transform()) const {
     using namespace EospacWrapper;
     EOS_REAL *R = const_cast<EOS_REAL *>(&rhos[0]);
     EOS_REAL *E = const_cast<EOS_REAL *>(&sies[0]);
@@ -499,9 +572,23 @@ class EOSPAC : public EosBase<EOSPAC> {
 
     EOS_INTEGER table = TofRE_table_;
     {
-      EOS_INTEGER options[]{EOS_Y_CONVERT};
-      EOS_REAL values[]{sieFromSesame(1.0)};
-      EOS_INTEGER nopts = 1;
+      EOS_INTEGER options[2];
+      EOS_REAL values[2];
+      EOS_INTEGER nopts = 0;
+
+      if (transform.x.is_set()) {
+        options[nopts] = EOS_X_CONVERT;
+        values[nopts] = 1.0 / transform.x.get();
+        ++nopts;
+      }
+
+      options[nopts] = EOS_Y_CONVERT;
+      values[nopts] = sieFromSesame(1.0);
+
+      if (transform.y.is_set()) {
+        values[nopts] /= transform.y.get();
+      }
+      ++nopts;
 
       eosSafeInterpolate(&table, num, R, E, T, dTdr, dTde, "TofRE", Verbosity::Quiet,
                          options, values, nopts);
@@ -509,19 +596,36 @@ class EOSPAC : public EosBase<EOSPAC> {
 
     table = PofRT_table_;
     {
-      EOS_INTEGER options[]{EOS_F_CONVERT, EOS_XY_PASSTHRU};
-      EOS_REAL values[]{pressureFromSesame(1.0), 1.0};
-      EOS_INTEGER nopts = 2;
+      EOS_INTEGER options[2];
+      EOS_REAL values[2];
+      EOS_INTEGER nopts = 0;
+
+      if (transform.x.is_set()) {
+        options[nopts] = EOS_X_CONVERT;
+        values[nopts] = 1.0 / transform.x.get();
+      } else {
+        options[nopts] = EOS_XY_PASSTHRU;
+        values[nopts] = 1.0;
+      }
+      ++nopts;
+
+      options[nopts] = EOS_F_CONVERT;
+      values[nopts] = pressureFromSesame(1.0);
+
+      if (transform.f.is_set()) {
+        values[nopts] *= transform.f.get();
+      }
+      ++nopts;
+
       eosSafeInterpolate(&table, num, R, T, P, dPdr, dPdT, "PofRT", Verbosity::Quiet,
                          options, values, nopts);
     }
   }
 
   template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityTemperature(const Real *rhos,
-                                                 const Real *temperatures, Real *cvs,
-                                                 Real *scratch, const int num,
-                                                 LambdaIndexer /*lambdas*/) const {
+  inline void SpecificHeatFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
+      LambdaIndexer /*lambdas*/, Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -533,9 +637,36 @@ class EOSPAC : public EosBase<EOSPAC> {
     EOS_REAL *DEDR = scratch + 1 * num;
 
     EOS_INTEGER table = EofRT_table_;
-    EOS_INTEGER options[]{EOS_F_CONVERT, EOS_XY_PASSTHRU};
-    EOS_REAL values[]{cvFromSesame(1.0), 1.0};
-    EOS_INTEGER nopts = 2;
+
+    EOS_INTEGER options[3];
+    EOS_REAL values[3];
+    EOS_INTEGER nopts = 0;
+
+    if (!transform.x.is_set() && !transform.y.is_set()) {
+      options[nopts] = EOS_XY_PASSTHRU;
+      values[nopts] = 1.0;
+      ++nopts;
+    } else {
+      if (transform.x.is_set()) {
+        options[nopts] = EOS_X_CONVERT;
+        values[nopts] = 1.0 / transform.x.get();
+        ++nopts;
+      }
+      if (transform.y.is_set()) {
+        options[nopts] = EOS_Y_CONVERT;
+        values[nopts] = 1.0 / transform.y.get();
+        ++nopts;
+      }
+    }
+
+    options[nopts] = EOS_F_CONVERT;
+    values[nopts] = cvFromSesame(1.0);
+
+    if (transform.f.is_set()) {
+      values[nopts] *= transform.f.get();
+    }
+    ++nopts;
+
     eosSafeInterpolate(&table, num, R, T, E, DEDR, DEDT, "EofRT", Verbosity::Quiet,
                        options, values, nopts);
 
@@ -546,10 +677,10 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                                    Real *cvs, Real *scratch,
-                                                    const int num,
-                                                    LambdaIndexer /*lambdas*/) const {
+  inline void SpecificHeatFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
+      LambdaIndexer /*lambdas*/, Transform &&transform = Transform()) const {
+
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -559,39 +690,67 @@ class EOSPAC : public EosBase<EOSPAC> {
     EOS_REAL *T = scratch + 0 * num;
     EOS_REAL *dTdr = scratch + 1 * num;
     EOS_REAL *dTde = scratch + 2 * num;
+    EOS_REAL *NE = scratch + 3 * num;
     EOS_REAL *DEDT = dTdr;
     EOS_REAL *DEDR = dTde;
 
     EOS_INTEGER table = TofRE_table_;
     {
-      EOS_INTEGER options[]{EOS_Y_CONVERT};
-      EOS_REAL values[]{sieFromSesame(1.0)};
-      EOS_INTEGER nopts = 1;
+      EOS_INTEGER options[2];
+      EOS_REAL values[2];
+      EOS_INTEGER nopts = 0;
+
+      if (transform.x.is_set()) {
+        options[nopts] = EOS_X_CONVERT;
+        values[nopts] = 1.0 / transform.x.get();
+        ++nopts;
+      }
+
+      options[nopts] = EOS_Y_CONVERT;
+      values[nopts] = sieFromSesame(1.0);
+      if (transform.y.is_set()) {
+        values[nopts] /= transform.y.get();
+      }
+      ++nopts;
+
       eosSafeInterpolate(&table, num, R, E, T, dTdr, dTde, "TofRE", Verbosity::Quiet,
                          options, values, nopts);
     }
 
     table = EofRT_table_;
     {
-      EOS_INTEGER options[]{EOS_XY_PASSTHRU};
-      EOS_REAL values[]{1.0};
-      EOS_INTEGER nopts = 1;
-      eosSafeInterpolate(&table, num, R, T, E, DEDR, DEDT, "EofRT", Verbosity::Quiet,
+      EOS_INTEGER options[2];
+      EOS_REAL values[2];
+      EOS_INTEGER nopts = 0;
+
+      if (transform.x.is_set()) {
+        options[nopts] = EOS_X_CONVERT;
+        values[nopts] = 1.0 / transform.x.get();
+      } else {
+        options[nopts] = EOS_XY_PASSTHRU;
+        values[nopts] = 1.0;
+      }
+      ++nopts;
+
+      eosSafeInterpolate(&table, num, R, T, NE, DEDR, DEDT, "EofRT", Verbosity::Quiet,
                          options, values, nopts);
     }
 
+    const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
+
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          cvs[i] =
-              cvFromSesame(std::max(DEDT[i], 0.0)); // Here we do something to the data!
+          cvs[i] = f * cvFromSesame(
+                           std::max(DEDT[i], 0.0)); // Here we do something to the data!
         });
   }
 
   template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityTemperature(const Real *rhos,
-                                                const Real *temperatures, Real *bmods,
-                                                Real *scratch, const int num,
-                                                LambdaIndexer /*lambdas*/) const {
+  inline void
+  BulkModulusFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                    Real *bmods, Real *scratch, const int num,
+                                    LambdaIndexer /*lambdas*/,
+                                    Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -605,28 +764,44 @@ class EOSPAC : public EosBase<EOSPAC> {
     EOS_REAL *DEDT = scratch + 4 * num;
     EOS_REAL *DEDR = scratch + 5 * num;
 
-    EOS_INTEGER table = EofRT_table_;
-    {
-      EOS_INTEGER options[]{EOS_XY_PASSTHRU};
-      EOS_REAL values[]{1.0};
-      EOS_INTEGER nopts = 1;
-      eosSafeInterpolate(&table, num, R, T, E, DEDR, DEDT, "EofRT", Verbosity::Quiet,
-                         options, values, nopts);
+    EOS_INTEGER options[2];
+    EOS_REAL values[2];
+    EOS_INTEGER nopts = 0;
+
+    if (!transform.x.is_set() && !transform.y.is_set()) {
+      options[nopts] = EOS_XY_PASSTHRU;
+      values[nopts] = 1.0;
+      ++nopts;
+    } else {
+      if (transform.x.is_set()) {
+        options[nopts] = EOS_X_CONVERT;
+        values[nopts] = 1.0 / transform.x.get();
+        ++nopts;
+      }
+      if (transform.y.is_set()) {
+        options[nopts] = EOS_Y_CONVERT;
+        values[nopts] = 1.0 / transform.y.get();
+        ++nopts;
+      }
     }
 
+    EOS_INTEGER table = EofRT_table_;
+    eosSafeInterpolate(&table, num, R, T, E, DEDR, DEDT, "EofRT", Verbosity::Quiet,
+                       options, values, nopts);
+
     table = PofRT_table_;
-    {
-      EOS_INTEGER options[]{EOS_XY_PASSTHRU};
-      EOS_REAL values[]{1.0};
-      EOS_INTEGER nopts = 1;
-      eosSafeInterpolate(&table, num, R, T, P, DPDR, DPDT, "PofRT", Verbosity::Quiet,
-                         options, values, nopts);
-    }
+    eosSafeInterpolate(&table, num, R, T, P, DPDR, DPDT, "PofRT", Verbosity::Quiet,
+                       options, values, nopts);
+
+    // WARNING: DEDR and DPDR are divided by EOS_X_CONVERT
+    // This is why the BMOD calculation was changed below compared to the scalar version.
 
     // Thermodynamics: Bt = rho*dP/drho|T, Bs=Bt*Cv/Cp, Cv=dE/dT|v, and
     // Cp-Cv=-T(dP/dT|v)^2/(dP/dV|T) or Cp-Cv=-T/rho^2 (dP/dT|v)^2/(dP/drho|T)
     // Therefore: Bs=Bt Cv/(CV+above)
     // BMOD = rho*dx[0]*CV/(CV-T[0]/(rho*rho)*dy[0]*dy[0]/dx[0]);
+    const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
+    const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
@@ -634,7 +809,7 @@ class EOSPAC : public EosBase<EOSPAC> {
           Real BMOD = 0.0;
           if (DEDT[i] > 0.0 && rho > 0.0) {
             const Real DPDE = DPDT[i] / DEDT[i];
-            BMOD = rho * DPDR[i] + DPDE * (P[i] / rho - rho * DEDR[i]);
+            BMOD = rho * DPDR[i] + DPDE * (P[i] / (rho * x) - rho * DEDR[i]);
           } else if (rho > 0.0) { // Case: DEDT <= 0
             // We need a different DPDE call apparently????
             // In xRAGE, they call out to P(rho,e) in this case to get the
@@ -647,15 +822,14 @@ class EOSPAC : public EosBase<EOSPAC> {
             // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
             BMOD = std::max(rho * DPDR[i], 0.0);
           }
-          bmods[i] = bulkModulusFromSesame(std::max(BMOD, 0.0));
+          bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
         });
   }
 
   template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                                   Real *bmods, Real *scratch,
-                                                   const int num,
-                                                   LambdaIndexer /*lambdas*/) const {
+  inline void BulkModulusFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
+      LambdaIndexer /*lambdas*/, Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -674,35 +848,53 @@ class EOSPAC : public EosBase<EOSPAC> {
 
     EOS_INTEGER table = TofRE_table_;
     {
-      EOS_INTEGER options[]{EOS_Y_CONVERT};
-      EOS_REAL values[]{sieFromSesame(1.0)};
-      EOS_INTEGER nopts = 1;
+      EOS_INTEGER options[2];
+      EOS_REAL values[2];
+      EOS_INTEGER nopts = 0;
+      if (transform.x.is_set()) {
+        options[nopts] = EOS_X_CONVERT;
+        values[nopts] = 1.0 / transform.x.get();
+        ++nopts;
+      }
+      options[nopts] = EOS_Y_CONVERT;
+      values[nopts] = sieFromSesame(1.0);
+      if (transform.y.is_set()) {
+        values[nopts] /= transform.y.get();
+      }
+      ++nopts;
       eosSafeInterpolate(&table, num, R, E, T, dTdr, dTde, "TofRE", Verbosity::Quiet,
                          options, values, nopts);
     }
 
-    table = EofRT_table_;
-    {
-      EOS_INTEGER options[]{EOS_XY_PASSTHRU};
-      EOS_REAL values[]{1.0};
-      EOS_INTEGER nopts = 1;
-      eosSafeInterpolate(&table, num, R, T, Etmp, DEDR, DEDT, "EofRT", Verbosity::Quiet,
-                         options, values, nopts);
+    EOS_INTEGER options[1];
+    EOS_REAL values[1];
+    EOS_INTEGER nopts = 0;
+    if (transform.x.is_set()) {
+      options[nopts] = EOS_X_CONVERT;
+      values[nopts] = 1.0 / transform.x.get();
+    } else {
+      options[nopts] = EOS_XY_PASSTHRU;
+      values[nopts] = 1.0;
     }
+    ++nopts;
+
+    table = EofRT_table_;
+    eosSafeInterpolate(&table, num, R, T, Etmp, DEDR, DEDT, "EofRT", Verbosity::Quiet,
+                       options, values, nopts);
 
     table = PofRT_table_;
-    {
-      EOS_INTEGER options[]{EOS_XY_PASSTHRU};
-      EOS_REAL values[]{1.0};
-      EOS_INTEGER nopts = 1;
-      eosSafeInterpolate(&table, num, R, T, P, DPDR, DPDT, "PofRT", Verbosity::Quiet,
-                         options, values, nopts);
-    }
+    eosSafeInterpolate(&table, num, R, T, P, DPDR, DPDT, "PofRT", Verbosity::Quiet,
+                       options, values, nopts);
+
+    // WARNING: DEDR and DPDR are divided by EOS_X_CONVERT
+    // This is why the BMOD calculation was changed below compared to the scalar version.
 
     // Thermodynamics: Bt = rho*dP/drho|T, Bs=Bt*Cv/Cp, Cv=dE/dT|v, and
     // Cp-Cv=-T(dP/dT|v)^2/(dP/dV|T) or Cp-Cv=-T/rho^2 (dP/dT|v)^2/(dP/drho|T)
     // Therefore: Bs=Bt Cv/(CV+above)
     // BMOD = rho*dx[0]*CV/(CV-T[0]/(rho*rho)*dy[0]*dy[0]/dx[0]);
+    const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
+    const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
@@ -710,7 +902,7 @@ class EOSPAC : public EosBase<EOSPAC> {
           Real BMOD = 0.0;
           if (DEDT[i] > 0.0 && rho > 0.0) {
             const Real DPDE = DPDT[i] / DEDT[i];
-            BMOD = rho * DPDR[i] + DPDE * (P[i] / rho - rho * DEDR[i]);
+            BMOD = rho * DPDR[i] + DPDE * (P[i] / (rho * x) - rho * DEDR[i]);
           } else if (rho > 0.0) { // Case: DEDT <= 0
             // We need a different DPDE call apparently????
             // In xRAGE, they call out to P(rho,e) in this case to get the
@@ -723,15 +915,16 @@ class EOSPAC : public EosBase<EOSPAC> {
             // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
             BMOD = std::max(rho * DPDR[i], 0.0);
           }
-          bmods[i] = bulkModulusFromSesame(std::max(BMOD, 0.0));
+          bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
         });
   }
 
   template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityTemperature(const Real *rhos,
-                                                   const Real *temperatures, Real *gm1s,
-                                                   Real *scratch, const int num,
-                                                   LambdaIndexer /*lambdas*/) const {
+  inline void
+  GruneisenParamFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                       Real *gm1s, Real *scratch, const int num,
+                                       LambdaIndexer /*lambdas*/,
+                                       Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -744,36 +937,48 @@ class EOSPAC : public EosBase<EOSPAC> {
     EOS_REAL *DPDT = scratch + 3 * num;
     EOS_REAL *P = E;
 
-    EOS_INTEGER table = EofRT_table_;
-    {
-      EOS_INTEGER options[]{EOS_XY_PASSTHRU};
-      EOS_REAL values[]{1.0};
-      EOS_INTEGER nopts = 1;
-      eosSafeInterpolate(&table, num, R, T, E, dx, DEDT, "EofRT", Verbosity::Quiet,
-                         options, values, nopts);
+    EOS_INTEGER options[2];
+    EOS_REAL values[2];
+    EOS_INTEGER nopts = 0;
+
+    if (!transform.x.is_set() && !transform.y.is_set()) {
+      options[nopts] = EOS_XY_PASSTHRU;
+      values[nopts] = 1.0;
+      ++nopts;
+    } else {
+      if (transform.x.is_set()) {
+        options[nopts] = EOS_X_CONVERT;
+        values[nopts] = 1.0 / transform.x.get();
+        ++nopts;
+      }
+      if (transform.y.is_set()) {
+        options[nopts] = EOS_Y_CONVERT;
+        values[nopts] = 1.0 / transform.y.get();
+        ++nopts;
+      }
     }
+    EOS_INTEGER table = EofRT_table_;
+    eosSafeInterpolate(&table, num, R, T, E, dx, DEDT, "EofRT", Verbosity::Quiet, options,
+                       values, nopts);
 
     table = PofRT_table_;
-    {
-      EOS_INTEGER options[]{EOS_XY_PASSTHRU};
-      EOS_REAL values[]{1.0};
-      EOS_INTEGER nopts = 1;
-      eosSafeInterpolate(&table, num, R, T, P, dx, DPDT, "PofRT", Verbosity::Quiet,
-                         options, values, nopts);
-    }
+    eosSafeInterpolate(&table, num, R, T, P, dx, DPDT, "PofRT", Verbosity::Quiet, options,
+                       values, nopts);
+
+    const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
+    const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           const Real DPDE = DPDT[i] / DEDT[i];
-          gm1s[i] = robust::ratio(pressureFromSesame(sieToSesame(DPDE)), R[i]);
+          gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
         });
   }
 
   template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                                      Real *gm1s, Real *scratch,
-                                                      const int num,
-                                                      LambdaIndexer /*lambdas*/) const {
+  inline void GruneisenParamFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
+      LambdaIndexer /*lambdas*/, Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -790,35 +995,52 @@ class EOSPAC : public EosBase<EOSPAC> {
 
     EOS_INTEGER table = TofRE_table_;
     {
-      EOS_INTEGER options[]{EOS_Y_CONVERT};
-      EOS_REAL values[]{sieFromSesame(1.0)};
-      EOS_INTEGER nopts = 1;
+      EOS_INTEGER options[3];
+      EOS_REAL values[3];
+      EOS_INTEGER nopts = 0;
+
+      if (transform.x.is_set()) {
+        options[nopts] = EOS_X_CONVERT;
+        values[nopts] = 1.0 / transform.x.get();
+        ++nopts;
+      }
+
+      options[nopts] = EOS_Y_CONVERT;
+      values[nopts] = sieFromSesame(1.0);
+      if (transform.y.is_set()) {
+        values[nopts] /= transform.y.get();
+      }
+      ++nopts;
       eosSafeInterpolate(&table, num, R, E, T, dx, dy, "TofRE", Verbosity::Quiet, options,
                          values, nopts);
     }
 
-    table = EofRT_table_;
-    {
-      EOS_INTEGER options[]{EOS_XY_PASSTHRU};
-      EOS_REAL values[]{1.0};
-      EOS_INTEGER nopts = 1;
-      eosSafeInterpolate(&table, num, R, T, Etmp, dx, DEDT, "EofRT", Verbosity::Quiet,
-                         options, values, nopts);
+    EOS_INTEGER options[1];
+    EOS_REAL values[1];
+    EOS_INTEGER nopts = 0;
+    if (transform.x.is_set()) {
+      options[nopts] = EOS_X_CONVERT;
+      values[nopts] = 1.0 / transform.x.get();
+    } else {
+      options[nopts] = EOS_XY_PASSTHRU;
+      values[nopts] = 1.0;
     }
+    ++nopts;
+    table = EofRT_table_;
+    eosSafeInterpolate(&table, num, R, T, Etmp, dx, DEDT, "EofRT", Verbosity::Quiet,
+                       options, values, nopts);
 
     table = PofRT_table_;
-    {
-      EOS_INTEGER options[]{EOS_XY_PASSTHRU};
-      EOS_REAL values[]{1.0};
-      EOS_INTEGER nopts = 1;
-      eosSafeInterpolate(&table, num, R, T, P, dx, DPDT, "PofRT", Verbosity::Quiet,
-                         options, values, nopts);
-    }
+    eosSafeInterpolate(&table, num, R, T, P, dx, DPDT, "PofRT", Verbosity::Quiet, options,
+                       values, nopts);
+
+    const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
+    const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           const Real DPDE = DPDT[i] / DEDT[i];
-          gm1s[i] = robust::ratio(pressureFromSesame(sieToSesame(DPDE)), R[i]);
+          gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
         });
   }
 
@@ -949,7 +1171,7 @@ class EOSPAC : public EosBase<EOSPAC> {
         {"InternalEnergyFromDensityTemperature", 2},
         {"PressureFromDensityInternalEnergy", 3},
         {"SpecificHeatFromDensityTemperature", 2},
-        {"SpecificHeatFromDensityInternalEnergy", 3},
+        {"SpecificHeatFromDensityInternalEnergy", 4},
         {"BulkModulusFromDensityTemperature", 6},
         {"BulkModulusFromDensityInternalEnergy", 6},
         {"GruneisenParamFromDensityTemperature", 4},

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -82,6 +82,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                        Real *lambda = nullptr) const;
 
   // Generic (Scalar)
+  using EosBase<EOSPAC>::is_raw_pointer;
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void
   TemperatureFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
@@ -91,7 +92,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                           lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   TemperatureFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                        RealIndexer &&temperatures, Real * /*scratch*/,
@@ -109,7 +110,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                           lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void InternalEnergyFromDensityTemperature(ConstRealIndexer &&rhos,
                                                    ConstRealIndexer &&temperatures,
                                                    RealIndexer &&sies, Real * /*scratch*/,
@@ -128,7 +129,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                     lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   PressureFromDensityTemperature(ConstRealIndexer &&rhos, ConstRealIndexer &&temperatures,
                                  RealIndexer &&pressures, Real * /*scratch*/,
@@ -146,7 +147,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                        lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   PressureFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                     RealIndexer &&pressures, Real * /*scratch*/,
@@ -164,7 +165,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                    lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   EntropyFromDensityTemperature(ConstRealIndexer &&rhos, ConstRealIndexer &&temperatures,
                                 RealIndexer &&entropies, Real * /*scratch*/,
@@ -182,7 +183,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                       lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   EntropyFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                    RealIndexer &&entropies, Real * /*scratch*/,
@@ -200,7 +201,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                         lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void SpecificHeatFromDensityTemperature(ConstRealIndexer &&rhos,
                                                  ConstRealIndexer &&temperatures,
                                                  RealIndexer &&cvs, Real * /*scratch*/,
@@ -218,7 +219,7 @@ class EOSPAC : public EosBase<EOSPAC> {
     EosBase<EOSPAC>::SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, num, lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   SpecificHeatFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                         RealIndexer &&cvs, Real * /*scratch*/,
@@ -235,7 +236,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                        lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void BulkModulusFromDensityTemperature(ConstRealIndexer &&rhos,
                                                 ConstRealIndexer &&temperatures,
                                                 RealIndexer &&bmods, Real * /*scratch*/,
@@ -254,7 +255,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                           lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void
   BulkModulusFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                        RealIndexer &&bmods, Real * /*scratch*/,
@@ -272,7 +273,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                           lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void GruneisenParamFromDensityTemperature(ConstRealIndexer &&rhos,
                                                    ConstRealIndexer &&temperatures,
                                                    RealIndexer &&gm1s, Real * /*scratch*/,
@@ -291,7 +292,7 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                              lambdas);
   }
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            std::enable_if_t<!std::is_same<std::remove_cv_t<RealIndexer>, Real>::value>>
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
   inline void GruneisenParamFromDensityInternalEnergy(ConstRealIndexer &&rhos,
                                                       ConstRealIndexer &&sies,
                                                       RealIndexer &&gm1s,

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -271,7 +271,9 @@ class Variant {
   TemperatureFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                        RealIndexer &&temperatures, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return TemperatureFromDensityInternalEnergy(rhos, sies, temperatures, num, lambdas);
+    return TemperatureFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(temperatures), num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -281,8 +283,10 @@ class Variant {
                                        LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &temperatures, &num, &lambdas](const auto &eos) {
-          return eos.TemperatureFromDensityInternalEnergy(rhos, sies, temperatures, num,
-                                                          lambdas);
+          return eos.TemperatureFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(temperatures), num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -292,8 +296,9 @@ class Variant {
                                                    RealIndexer &&temperatures,
                                                    Real *scratch, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return TemperatureFromDensityInternalEnergy(rhos, sies, temperatures, scratch, num,
-                                                lambdas);
+    return TemperatureFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(temperatures), scratch, num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -303,8 +308,10 @@ class Variant {
                                        const int num, LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &temperatures, &scratch, &num, &lambdas](const auto &eos) {
-          return eos.TemperatureFromDensityInternalEnergy(rhos, sies, temperatures,
-                                                          scratch, num, lambdas);
+          return eos.TemperatureFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(temperatures), scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -315,7 +322,10 @@ class Variant {
                                                    RealIndexer &&sies,
                                                    const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return InternalEnergyFromDensityTemperature(rhos, temperatures, sies, num, lambdas);
+    return InternalEnergyFromDensityTemperature(
+        std::forward<ConstRealIndexer>(rhos),
+        std::forward<ConstRealIndexer>(temperatures), std::forward<RealIndexer>(sies),
+        num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -325,8 +335,10 @@ class Variant {
                                                    LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &sies, &num, &lambdas](const auto &eos) {
-          return eos.InternalEnergyFromDensityTemperature(rhos, temperatures, sies, num,
-                                                          lambdas);
+          return eos.InternalEnergyFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures),
+              std::forward<RealIndexer>(sies), num, std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -337,8 +349,9 @@ class Variant {
                                                    RealIndexer &&sies, Real *scratch,
                                                    const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return InternalEnergyFromDensityTemperature(rhos, temperatures, sies, scratch, num,
-                                                lambdas);
+    return InternalEnergyFromDensityTemperature(
+        std::forward<ConstRealIndexer>(rhos),
+        std::forward<ConstRealIndexer>(temperatures), sies, scratch, num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -349,8 +362,10 @@ class Variant {
                                                    LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &sies, &scratch, &num, &lambdas](const auto &eos) {
-          return eos.InternalEnergyFromDensityTemperature(rhos, temperatures, sies,
-                                                          scratch, num, lambdas);
+          return eos.InternalEnergyFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures), sies, scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -360,7 +375,10 @@ class Variant {
   PressureFromDensityTemperature(ConstRealIndexer &&rhos, ConstRealIndexer &&temperatures,
                                  RealIndexer &&pressures, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return PressureFromDensityTemperature(rhos, temperatures, pressures, num, lambdas);
+    return PressureFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                          std::forward<ConstRealIndexer>(temperatures),
+                                          std::forward<RealIndexer>(pressures), num,
+                                          lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -370,8 +388,11 @@ class Variant {
                                              LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &pressures, &num, &lambdas](const auto &eos) {
-          return eos.PressureFromDensityTemperature(rhos, temperatures, pressures, num,
-                                                    lambdas);
+          return eos.PressureFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures),
+              std::forward<RealIndexer>(pressures), num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -382,8 +403,10 @@ class Variant {
                                              RealIndexer &&pressures, Real *scratch,
                                              const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return PressureFromDensityTemperature(rhos, temperatures, pressures, scratch, num,
-                                          lambdas);
+    return PressureFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                          std::forward<ConstRealIndexer>(temperatures),
+                                          std::forward<RealIndexer>(pressures), scratch,
+                                          num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -393,8 +416,11 @@ class Variant {
                                  LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &pressures, &scratch, &num, &lambdas](const auto &eos) {
-          return eos.PressureFromDensityTemperature(rhos, temperatures, pressures,
-                                                    scratch, num, lambdas);
+          return eos.PressureFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures),
+              std::forward<RealIndexer>(pressures), scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -404,7 +430,9 @@ class Variant {
   PressureFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                     RealIndexer &&pressures, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return PressureFromDensityInternalEnergy(rhos, sies, pressures, num, lambdas);
+    return PressureFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(pressures), num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -414,8 +442,10 @@ class Variant {
                                                 LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &pressures, &num, &lambdas](const auto &eos) {
-          return eos.PressureFromDensityInternalEnergy(rhos, sies, pressures, num,
-                                                       lambdas);
+          return eos.PressureFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(pressures), num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -426,8 +456,9 @@ class Variant {
                                                 RealIndexer &&pressures, Real *scratch,
                                                 const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return PressureFromDensityInternalEnergy(rhos, sies, pressures, scratch, num,
-                                             lambdas);
+    return PressureFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(pressures), scratch, num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -437,8 +468,10 @@ class Variant {
                                     LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &pressures, &scratch, &num, &lambdas](const auto &eos) {
-          return eos.PressureFromDensityInternalEnergy(rhos, sies, pressures, scratch,
-                                                       num, lambdas);
+          return eos.PressureFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(pressures), scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -448,7 +481,10 @@ class Variant {
   EntropyFromDensityTemperature(ConstRealIndexer &&rhos, ConstRealIndexer &&temperatures,
                                 RealIndexer &&entropies, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return EntropyFromDensityTemperature(rhos, temperatures, entropies, num, lambdas);
+    return EntropyFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                         std::forward<ConstRealIndexer>(temperatures),
+                                         std::forward<RealIndexer>(entropies), num,
+                                         lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -458,8 +494,11 @@ class Variant {
                                             LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &entropies, &num, &lambdas](const auto &eos) {
-          return eos.EntropyFromDensityTemperature(rhos, temperatures, entropies, num,
-                                                   lambdas);
+          return eos.EntropyFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures),
+              std::forward<RealIndexer>(entropies), num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -470,8 +509,10 @@ class Variant {
                                             RealIndexer &&entropies, Real *scratch,
                                             const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return EntropyFromDensityTemperature(rhos, temperatures, entropies, scratch, num,
-                                         lambdas);
+    return EntropyFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                         std::forward<ConstRealIndexer>(temperatures),
+                                         std::forward<RealIndexer>(entropies), scratch,
+                                         num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -481,8 +522,11 @@ class Variant {
                                 LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &entropies, &scratch, &num, &lambdas](const auto &eos) {
-          return eos.EntropyFromDensityTemperature(rhos, temperatures, entropies, scratch,
-                                                   num, lambdas);
+          return eos.EntropyFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures),
+              std::forward<RealIndexer>(entropies), scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -492,7 +536,9 @@ class Variant {
   EntropyFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                    RealIndexer &&entropies, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return EntropyFromDensityInternalEnergy(rhos, sies, entropies, num, lambdas);
+    return EntropyFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(entropies), num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -502,8 +548,10 @@ class Variant {
                                                LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &entropies, &num, &lambdas](const auto &eos) {
-          return eos.EntropyFromDensityInternalEnergy(rhos, sies, entropies, num,
-                                                      lambdas);
+          return eos.EntropyFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(entropies), num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -514,7 +562,9 @@ class Variant {
                                                RealIndexer &&entropies, Real *scratch,
                                                const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return EntropyFromDensityInternalEnergy(rhos, sies, entropies, scratch, num, lambdas);
+    return EntropyFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(entropies), scratch, num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -524,8 +574,10 @@ class Variant {
                                    LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &entropies, &scratch, &num, &lambdas](const auto &eos) {
-          return eos.EntropyFromDensityInternalEnergy(rhos, sies, entropies, scratch, num,
-                                                      lambdas);
+          return eos.EntropyFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(entropies), scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -535,7 +587,10 @@ class Variant {
                                                  ConstRealIndexer &&temperatures,
                                                  RealIndexer &&cvs, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, num, lambdas);
+    return SpecificHeatFromDensityTemperature(
+        std::forward<ConstRealIndexer>(rhos),
+        std::forward<ConstRealIndexer>(temperatures), std::forward<RealIndexer>(cvs), num,
+        lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -545,8 +600,10 @@ class Variant {
                                                  LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &cvs, &num, &lambdas](const auto &eos) {
-          return eos.SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, num,
-                                                        lambdas);
+          return eos.SpecificHeatFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures),
+              std::forward<RealIndexer>(cvs), num, std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -557,8 +614,10 @@ class Variant {
                                                  RealIndexer &&cvs, Real *scratch,
                                                  const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, scratch, num,
-                                              lambdas);
+    return SpecificHeatFromDensityTemperature(
+        std::forward<ConstRealIndexer>(rhos),
+        std::forward<ConstRealIndexer>(temperatures), std::forward<RealIndexer>(cvs),
+        scratch, num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -569,8 +628,11 @@ class Variant {
                                                  LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &cvs, &scratch, &num, &lambdas](const auto &eos) {
-          return eos.SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, scratch,
-                                                        num, lambdas);
+          return eos.SpecificHeatFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures),
+              std::forward<RealIndexer>(cvs), scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -580,7 +642,9 @@ class Variant {
   SpecificHeatFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                         RealIndexer &&cvs, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, num, lambdas);
+    return SpecificHeatFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(cvs), num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -590,7 +654,9 @@ class Variant {
                                                     LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &cvs, &num, &lambdas](const auto &eos) {
-          return eos.SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, num, lambdas);
+          return eos.SpecificHeatFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(cvs), num, std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -600,7 +666,9 @@ class Variant {
                                                     RealIndexer &&cvs, Real *scratch,
                                                     const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, scratch, num, lambdas);
+    return SpecificHeatFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(cvs), scratch, num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -610,8 +678,10 @@ class Variant {
                                         LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &cvs, &scratch, &num, &lambdas](const auto &eos) {
-          return eos.SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, scratch, num,
-                                                           lambdas);
+          return eos.SpecificHeatFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(cvs), scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -622,7 +692,10 @@ class Variant {
                                                 RealIndexer &&bmods,
                                                 const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return BulkModulusFromDensityTemperature(rhos, temperatures, bmods, num, lambdas);
+    return BulkModulusFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                             std::forward<ConstRealIndexer>(temperatures),
+                                             std::forward<RealIndexer>(bmods), num,
+                                             lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -632,8 +705,11 @@ class Variant {
                                                 LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &bmods, &num, &lambdas](const auto &eos) {
-          return eos.BulkModulusFromDensityTemperature(rhos, temperatures, bmods, num,
-                                                       lambdas);
+          return eos.BulkModulusFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures),
+              std::forward<RealIndexer>(bmods), num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -643,8 +719,10 @@ class Variant {
                                                 RealIndexer &&bmods, Real *scratch,
                                                 const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return BulkModulusFromDensityTemperature(rhos, temperatures, bmods, scratch, num,
-                                             lambdas);
+    return BulkModulusFromDensityTemperature(std::forward<ConstRealIndexer>(rhos),
+                                             std::forward<ConstRealIndexer>(temperatures),
+                                             std::forward<RealIndexer>(bmods), scratch,
+                                             num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -655,8 +733,11 @@ class Variant {
                                                 LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &bmods, &scratch, &num, &lambdas](const auto &eos) {
-          return eos.BulkModulusFromDensityTemperature(rhos, temperatures, bmods, scratch,
-                                                       num, lambdas);
+          return eos.BulkModulusFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures),
+              std::forward<RealIndexer>(bmods), scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -666,7 +747,9 @@ class Variant {
   BulkModulusFromDensityInternalEnergy(ConstRealIndexer &&rhos, ConstRealIndexer &&sies,
                                        RealIndexer &&bmods, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, num, lambdas);
+    return BulkModulusFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(bmods), num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -676,8 +759,10 @@ class Variant {
                                                    LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &bmods, &num, &lambdas](const auto &eos) {
-          return eos.BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, num,
-                                                          lambdas);
+          return eos.BulkModulusFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(bmods), num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -688,7 +773,9 @@ class Variant {
                                                    RealIndexer &&bmods, Real *scratch,
                                                    const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, scratch, num, lambdas);
+    return BulkModulusFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(bmods), scratch, num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -698,8 +785,10 @@ class Variant {
                                        LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &bmods, &scratch, &num, &lambdas](const auto &eos) {
-          return eos.BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, scratch, num,
-                                                          lambdas);
+          return eos.BulkModulusFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(bmods), scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -710,7 +799,10 @@ class Variant {
                                                    RealIndexer &&gm1s,
                                                    const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, num, lambdas);
+    return GruneisenParamFromDensityTemperature(
+        std::forward<ConstRealIndexer>(rhos),
+        std::forward<ConstRealIndexer>(temperatures), std::forward<RealIndexer>(gm1s),
+        num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -720,8 +812,10 @@ class Variant {
                                                    LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &gm1s, &num, &lambdas](const auto &eos) {
-          return eos.GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, num,
-                                                          lambdas);
+          return eos.GruneisenParamFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures),
+              std::forward<RealIndexer>(gm1s), num, std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -732,8 +826,10 @@ class Variant {
                                                    RealIndexer &&gm1s, Real *scratch,
                                                    const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, scratch, num,
-                                                lambdas);
+    return GruneisenParamFromDensityTemperature(
+        std::forward<ConstRealIndexer>(rhos),
+        std::forward<ConstRealIndexer>(temperatures), std::forward<RealIndexer>(gm1s),
+        scratch, num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -744,8 +840,11 @@ class Variant {
                                                    LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &temperatures, &gm1s, &scratch, &num, &lambdas](const auto &eos) {
-          return eos.GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s,
-                                                          scratch, num, lambdas);
+          return eos.GruneisenParamFromDensityTemperature(
+              std::forward<ConstRealIndexer>(rhos),
+              std::forward<ConstRealIndexer>(temperatures),
+              std::forward<RealIndexer>(gm1s), scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -756,7 +855,9 @@ class Variant {
                                                       RealIndexer &&gm1s,
                                                       const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, num, lambdas);
+    return GruneisenParamFromDensityInternalEnergy(std::forward<ConstRealIndexer>(rhos),
+                                                   std::forward<ConstRealIndexer>(sies),
+                                                   gm1s, num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -766,8 +867,9 @@ class Variant {
                                                       LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &gm1s, &lambdas, &num](const auto &eos) {
-          return eos.GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, num,
-                                                             lambdas);
+          return eos.GruneisenParamFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(gm1s), num, std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -778,8 +880,9 @@ class Variant {
                                                       RealIndexer &&gm1s, Real *scratch,
                                                       const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, scratch, num,
-                                                   lambdas);
+    return GruneisenParamFromDensityInternalEnergy(
+        std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+        std::forward<RealIndexer>(gm1s), scratch, num, lambdas);
   }
 
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
@@ -790,8 +893,10 @@ class Variant {
                                                       LambdaIndexer &&lambdas) const {
     return mpark::visit(
         [&rhos, &sies, &gm1s, &scratch, &lambdas, &num](const auto &eos) {
-          return eos.GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, scratch,
-                                                             num, lambdas);
+          return eos.GruneisenParamFromDensityInternalEnergy(
+              std::forward<ConstRealIndexer>(rhos), std::forward<ConstRealIndexer>(sies),
+              std::forward<RealIndexer>(gm1s), scratch, num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -801,7 +906,10 @@ class Variant {
                       RealIndexer &&presses, RealIndexer &&cvs, RealIndexer &&bmods,
                       const int num, const unsigned long output) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return FillEos(rhos, temps, energies, presses, cvs, bmods, num, output, lambdas);
+    return FillEos(std::forward<RealIndexer>(rhos), std::forward<RealIndexer>(temps),
+                   std::forward<RealIndexer>(energies),
+                   std::forward<RealIndexer>(presses), std::forward<RealIndexer>(cvs),
+                   std::forward<RealIndexer>(bmods), num, output, lambdas);
   }
 
   template <typename RealIndexer, typename LambdaIndexer>
@@ -812,8 +920,11 @@ class Variant {
     return mpark::visit(
         [&rhos, &temps, &energies, &presses, &cvs, &bmods, &num, &output,
          &lambdas](const auto &eos) {
-          return eos.FillEos(rhos, temps, energies, presses, cvs, bmods, num, output,
-                             lambdas);
+          return eos.FillEos(
+              std::forward<RealIndexer>(rhos), std::forward<RealIndexer>(temps),
+              std::forward<RealIndexer>(energies), std::forward<RealIndexer>(presses),
+              std::forward<RealIndexer>(cvs), std::forward<RealIndexer>(bmods), num,
+              output, std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
@@ -823,7 +934,11 @@ class Variant {
                      RealIndexer &&temps, RealIndexer &&dpdrs, RealIndexer &&dpdes,
                      RealIndexer &&dtdrs, RealIndexer &&dtdes, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return PTofRE(rhos, sies, presses, temps, dpdrs, dpdes, dtdrs, dtdes, num, lambdas);
+    return PTofRE(std::forward<RealIndexer>(rhos), std::forward<RealIndexer>(sies),
+                  std::forward<RealIndexer>(presses), std::forward<RealIndexer>(temps),
+                  std::forward<RealIndexer>(dpdrs), std::forward<RealIndexer>(dpdes),
+                  std::forward<RealIndexer>(dtdrs), std::forward<RealIndexer>(dtdes), num,
+                  lambdas);
   }
 
   template <typename RealIndexer, typename LambdaIndexer>
@@ -834,8 +949,12 @@ class Variant {
     return mpark::visit(
         [&rhos, &sies, &presses, &temps, &dpdrs, &dpdes, &dtdrs, &dtdes, &num,
          &lambdas](const auto &eos) {
-          return eos.PTofRE(rhos, sies, presses, temps, dpdrs, dpdes, dtdrs, dtdes, num,
-                            lambdas);
+          return eos.PTofRE(
+              std::forward<RealIndexer>(rhos), std::forward<RealIndexer>(sies),
+              std::forward<RealIndexer>(presses), std::forward<RealIndexer>(temps),
+              std::forward<RealIndexer>(dpdrs), std::forward<RealIndexer>(dpdes),
+              std::forward<RealIndexer>(dtdrs), std::forward<RealIndexer>(dtdes), num,
+              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }

--- a/singularity-eos/eos/modifiers/ramps_eos.hpp
+++ b/singularity-eos/eos/modifiers/ramps_eos.hpp
@@ -225,17 +225,187 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
     return;
   }
 
+  // vector implementations
+  template <typename LambdaIndexer>
+  inline void TemperatureFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    t_.TemperatureFromDensityInternalEnergy(rhos, sies, temperatures, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                             Real *pressures, Real *scratch,
+                                             const int num, LambdaIndexer &&lambdas,
+                                             Transform &&transform = Transform()) const {
+    t_.PressureFromDensityTemperature(rhos, temperatures, pressures, scratch, num,
+                                      std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
+    static auto const name = singularity::mfuncname::member_func_name(
+        typeid(BilinearRampEOS<T>).name(), __func__);
+    static auto const cname = name.c_str();
+
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+          const Real p_ramp = get_ramp_pressure(rhos[i]);
+          pressures[i] = std::max(pressures[i], p_ramp);
+        });
+  }
+
+  template <typename LambdaIndexer>
+  inline void
+  PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
+                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
+                                    Transform &&transform = Transform()) const {
+    t_.PressureFromDensityInternalEnergy(rhos, sies, pressures, scratch, num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
+    static auto const name = singularity::mfuncname::member_func_name(
+        typeid(BilinearRampEOS<T>).name(), __func__);
+    static auto const cname = name.c_str();
+
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+          const Real p_ramp = get_ramp_pressure(rhos[i]);
+          pressures[i] = std::max(pressures[i], p_ramp);
+        });
+  }
+
+  template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    t_.SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, scratch, num,
+                                          std::forward<LambdaIndexer>(lambdas),
+                                          std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    t_.SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, scratch, num,
+                                             std::forward<LambdaIndexer>(lambdas),
+                                             std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *pressures = scratch;
+    t_.PressureFromDensityTemperature(rhos, temperatures, pressures, &scratch[num], num,
+                                      std::forward<LambdaIndexer>(lambdas),
+                                      Transform(transform));
+    t_.BulkModulusFromDensityTemperature(rhos, temperatures, bmods, &scratch[num], num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
+    static auto const name = singularity::mfuncname::member_func_name(
+        typeid(BilinearRampEOS<T>).name(), __func__);
+    static auto const cname = name.c_str();
+
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+          const Real p_ramp = get_ramp_pressure(rhos[i]);
+          if (pressures[i] < p_ramp) {
+            bmods[i] = rhos[i] * get_ramp_dpdrho(rhos[i]);
+          }
+        });
+  }
+
+  template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *pressures = scratch;
+    t_.PressureFromDensityInternalEnergy(rhos, sies, pressures, &scratch[num], num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         Transform(transform));
+    t_.BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, &scratch[num], num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+    static auto const name = singularity::mfuncname::member_func_name(
+        typeid(BilinearRampEOS<T>).name(), __func__);
+    static auto const cname = name.c_str();
+
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+          const Real p_ramp = get_ramp_pressure(rhos[i]);
+          if (pressures[i] < p_ramp) {
+            bmods[i] = rhos[i] * get_ramp_dpdrho(rhos[i]);
+          }
+        });
+  }
+
+  template <typename LambdaIndexer>
+  inline void GruneisenParamFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    t_.GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void GruneisenParamFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    t_.GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, scratch, num,
+                                               std::forward<LambdaIndexer>(lambdas),
+                                               std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void InternalEnergyFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    t_.InternalEnergyFromDensityTemperature(rhos, temperatures, sies, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                            Real *entropies, Real *scratch, const int num,
+                                            LambdaIndexer &&lambdas,
+                                            Transform &&transform = Transform()) const {
+    t_.EntropyFromDensityTemperature(rhos, temperatures, entropies, scratch, num,
+                                     std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void
+  EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
+                                   Real *scratch, const int num, LambdaIndexer &&lambdas,
+                                   Transform &&transform = Transform()) const {
+    t_.EntropyFromDensityInternalEnergy(rhos, sies, entropies, scratch, num,
+                                        std::forward<LambdaIndexer>(lambdas),
+                                        std::forward<Transform>(transform));
+  }
+
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return t_.nlambda(); }
 
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }
 
   static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
+    constexpr char prefix[] = "BulkModulusFrom";
+    if (method.rfind(prefix) == 0) {
+      return T::scratch_size(method, nelements) + (sizeof(Real) * nelements);
+    }
     return T::scratch_size(method, nelements);
   }
 
   static inline unsigned long max_scratch_size(unsigned int nelements) {
-    return T::max_scratch_size(nelements);
+    unsigned long m = T::max_scratch_size(nelements);
+    for (auto &&meth :
+         {"BulkModulusFromDensityInternalEnergy", "BulkModulusFromDensityTemperature"}) {
+      m = std::max(m, scratch_size(meth, nelements));
+    }
+    return m;
   }
 
   PORTABLE_FUNCTION void PrintParams() const {

--- a/singularity-eos/eos/modifiers/scaled_eos.hpp
+++ b/singularity-eos/eos/modifiers/scaled_eos.hpp
@@ -169,6 +169,139 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
     sie *= scale_;
   }
 
+  // vector implementations
+  template <typename LambdaIndexer>
+  inline void TemperatureFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    transform.y.apply(inv_scale_);
+    t_.TemperatureFromDensityInternalEnergy(rhos, sies, temperatures, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                             Real *pressures, Real *scratch,
+                                             const int num, LambdaIndexer &&lambdas,
+                                             Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    t_.PressureFromDensityTemperature(rhos, temperatures, pressures, scratch, num,
+                                      std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void
+  PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
+                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
+                                    Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    transform.y.apply(inv_scale_);
+    t_.PressureFromDensityInternalEnergy(rhos, sies, pressures, scratch, num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    t_.SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, scratch, num,
+                                          std::forward<LambdaIndexer>(lambdas),
+                                          std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    transform.y.apply(inv_scale_);
+    t_.SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, scratch, num,
+                                             std::forward<LambdaIndexer>(lambdas),
+                                             std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    t_.BulkModulusFromDensityTemperature(rhos, temperatures, bmods, scratch, num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    transform.y.apply(inv_scale_);
+    t_.BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void GruneisenParamFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    t_.GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void GruneisenParamFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    transform.y.apply(inv_scale_);
+    t_.GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, scratch, num,
+                                               std::forward<LambdaIndexer>(lambdas),
+                                               std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void InternalEnergyFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    transform.f.apply(scale_);
+    t_.InternalEnergyFromDensityTemperature(rhos, temperatures, sies, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                            Real *entropies, Real *scratch, const int num,
+                                            LambdaIndexer &&lambdas,
+                                            Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    transform.f.apply(scale_);
+    t_.EntropyFromDensityTemperature(rhos, temperatures, entropies, scratch, num,
+                                     std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
+  }
+
+  template <typename LambdaIndexer>
+  inline void
+  EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
+                                   Real *scratch, const int num, LambdaIndexer &&lambdas,
+                                   Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    transform.y.apply(inv_scale_);
+    transform.f.apply(scale_);
+    t_.EntropyFromDensityInternalEnergy(rhos, sies, entropies, scratch, num,
+                                        std::forward<LambdaIndexer>(lambdas),
+                                        std::forward<Transform>(transform));
+  }
+
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return t_.nlambda(); }
 

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -168,7 +168,7 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
 
   PORTABLE_FUNCTION void PrintParams() const {
     t_.PrintParams();
-    printf("scaling_ratio = %f\n", shift_);
+    printf("shift_value = %f\n", shift_);
   }
   PORTABLE_FUNCTION
   void DensityEnergyFromPressureTemperature(const Real press, const Real temp,

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -153,17 +153,166 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
     }
   }
 
+  // vector implementations
+  inline void shift_sies(const Real *sies, Real *shifted, const int num) const {
+    static auto const name =
+        singularity::mfuncname::member_func_name(typeid(ShiftedEOS<T>).name(), __func__);
+    static auto const cname = name.c_str();
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) { shifted[i] = sies[i] - shift_; });
+  }
+
+  inline void unshift_sies(Real *sies, const int num) const {
+    static auto const name =
+        singularity::mfuncname::member_func_name(typeid(ShiftedEOS<T>).name(), __func__);
+    static auto const cname = name.c_str();
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) { sies[i] += shift_; });
+  }
+
+  template <typename LambdaIndexer>
+  inline void TemperatureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                                   Real *temperatures, Real *scratch,
+                                                   const int num,
+                                                   LambdaIndexer &&lambdas) const {
+    Real *shifted_sies = scratch;
+    shift_sies(sies, shifted_sies, num);
+    t_.TemperatureFromDensityInternalEnergy(rhos, shifted_sies, temperatures,
+                                            &scratch[num], num,
+                                            std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <typename LambdaIndexer>
+  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                             Real *pressures, Real *scratch,
+                                             const int num,
+                                             LambdaIndexer &&lambdas) const {
+    t_.PressureFromDensityTemperature(rhos, temperatures, pressures, scratch, num,
+                                      std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <typename LambdaIndexer>
+  inline void PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                                Real *pressures, Real *scratch,
+                                                const int num,
+                                                LambdaIndexer &&lambdas) const {
+    Real *shifted_sies = scratch;
+    shift_sies(sies, shifted_sies, num);
+    t_.PressureFromDensityInternalEnergy(rhos, shifted_sies, pressures, &scratch[num],
+                                         num, std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityTemperature(const Real *rhos,
+                                                 const Real *temperatures, Real *cvs,
+                                                 Real *scratch, const int num,
+                                                 LambdaIndexer &&lambdas) const {
+    t_.SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, scratch, num,
+                                          std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                                    Real *cvs, Real *scratch,
+                                                    const int num,
+                                                    LambdaIndexer &&lambdas) const {
+    Real *shifted_sies = scratch;
+    shift_sies(sies, shifted_sies, num);
+    t_.SpecificHeatFromDensityInternalEnergy(rhos, shifted_sies, cvs, &scratch[num], num,
+                                             std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityTemperature(const Real *rhos,
+                                                const Real *temperatures, Real *bmods,
+                                                Real *scratch, const int num,
+                                                LambdaIndexer &&lambdas) const {
+    t_.BulkModulusFromDensityTemperature(rhos, temperatures, bmods, scratch, num,
+                                         std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                                   Real *bmods, Real *scratch,
+                                                   const int num,
+                                                   LambdaIndexer &&lambdas) const {
+    Real *shifted_sies = scratch;
+    shift_sies(sies, shifted_sies, num);
+    t_.BulkModulusFromDensityInternalEnergy(rhos, shifted_sies, bmods, &scratch[num], num,
+                                            std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <typename LambdaIndexer>
+  inline void GruneisenParamFromDensityTemperature(const Real *rhos,
+                                                   const Real *temperatures, Real *gm1s,
+                                                   Real *scratch, const int num,
+                                                   LambdaIndexer &&lambdas) const {
+    t_.GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <typename LambdaIndexer>
+  inline void GruneisenParamFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                                      Real *gm1s, Real *scratch,
+                                                      const int num,
+                                                      LambdaIndexer &&lambdas) const {
+    Real *shifted_sies = scratch;
+    shift_sies(sies, shifted_sies, num);
+    t_.GruneisenParamFromDensityInternalEnergy(rhos, shifted_sies, gm1s, &scratch[num],
+                                               num, std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <typename LambdaIndexer>
+  inline void InternalEnergyFromDensityTemperature(const Real *rhos,
+                                                   const Real *temperatures, Real *sies,
+                                                   Real *scratch, const int num,
+                                                   LambdaIndexer &&lambdas) const {
+    t_.InternalEnergyFromDensityTemperature(rhos, temperatures, sies, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas));
+    unshift_sies(sies, num);
+  }
+
+  template <typename LambdaIndexer>
+  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                            Real *entropies, Real *scratch, const int num,
+                                            LambdaIndexer &&lambdas) const {
+    t_.EntropyFromDensityTemperature(rhos, temperatures, entropies, scratch, num,
+                                     std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <typename LambdaIndexer>
+  inline void EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                               Real *entropies, Real *scratch,
+                                               const int num,
+                                               LambdaIndexer &&lambdas) const {
+    Real *shifted_sies = scratch;
+    shift_sies(sies, shifted_sies, num);
+    t_.EntropyFromDensityInternalEnergy(rhos, sies, entropies, &scratch[num], num,
+                                        std::forward<LambdaIndexer>(lambdas));
+  }
+
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return t_.nlambda(); }
 
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }
 
   static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
+    constexpr char suffix[] = "FromDensityInternalEnergy";
+    if (method.rfind(suffix) == method.length() - sizeof(suffix) + 1) {
+      return T::scratch_size(method, nelements) + (sizeof(Real) * nelements);
+    }
     return T::scratch_size(method, nelements);
   }
 
   static inline unsigned long max_scratch_size(unsigned int nelements) {
-    return T::max_scratch_size(nelements);
+    unsigned long m = T::max_scratch_size(nelements);
+    for (auto &&meth :
+         {"TemperatureFromDensityInternalEnergy", "PressureFromDensityInternalEnergy",
+          "SpecificHeatFromDensityInternalEnergy", "BulkModulusFromDensityInternalEnergy",
+          "GruneisenParamFromDensityInternalEnergy"}) {
+      m = std::max(m, scratch_size(meth, nelements));
+    }
+    return m;
   }
 
   PORTABLE_FUNCTION void PrintParams() const {

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -171,124 +171,128 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
   }
 
   template <typename LambdaIndexer>
-  inline void TemperatureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                                   Real *temperatures, Real *scratch,
-                                                   const int num,
-                                                   LambdaIndexer &&lambdas) const {
+  inline void TemperatureFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     Real *shifted_sies = scratch;
     shift_sies(sies, shifted_sies, num);
-    t_.TemperatureFromDensityInternalEnergy(rhos, shifted_sies, temperatures,
-                                            &scratch[num], num,
-                                            std::forward<LambdaIndexer>(lambdas));
+    t_.TemperatureFromDensityInternalEnergy(
+        rhos, shifted_sies, temperatures, &scratch[num], num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
                                              Real *pressures, Real *scratch,
-                                             const int num,
-                                             LambdaIndexer &&lambdas) const {
+                                             const int num, LambdaIndexer &&lambdas,
+                                             Transform &&transform = Transform()) const {
     t_.PressureFromDensityTemperature(rhos, temperatures, pressures, scratch, num,
-                                      std::forward<LambdaIndexer>(lambdas));
+                                      std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
-  inline void PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                                Real *pressures, Real *scratch,
-                                                const int num,
-                                                LambdaIndexer &&lambdas) const {
+  inline void
+  PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
+                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
+                                    Transform &&transform = Transform()) const {
     Real *shifted_sies = scratch;
     shift_sies(sies, shifted_sies, num);
     t_.PressureFromDensityInternalEnergy(rhos, shifted_sies, pressures, &scratch[num],
-                                         num, std::forward<LambdaIndexer>(lambdas));
+                                         num, std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityTemperature(const Real *rhos,
-                                                 const Real *temperatures, Real *cvs,
-                                                 Real *scratch, const int num,
-                                                 LambdaIndexer &&lambdas) const {
+  inline void SpecificHeatFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     t_.SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, scratch, num,
-                                          std::forward<LambdaIndexer>(lambdas));
+                                          std::forward<LambdaIndexer>(lambdas),
+                                          std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                                    Real *cvs, Real *scratch,
-                                                    const int num,
-                                                    LambdaIndexer &&lambdas) const {
+  inline void SpecificHeatFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     Real *shifted_sies = scratch;
     shift_sies(sies, shifted_sies, num);
     t_.SpecificHeatFromDensityInternalEnergy(rhos, shifted_sies, cvs, &scratch[num], num,
-                                             std::forward<LambdaIndexer>(lambdas));
+                                             std::forward<LambdaIndexer>(lambdas),
+                                             std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityTemperature(const Real *rhos,
-                                                const Real *temperatures, Real *bmods,
-                                                Real *scratch, const int num,
-                                                LambdaIndexer &&lambdas) const {
+  inline void BulkModulusFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     t_.BulkModulusFromDensityTemperature(rhos, temperatures, bmods, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas));
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                                   Real *bmods, Real *scratch,
-                                                   const int num,
-                                                   LambdaIndexer &&lambdas) const {
+  inline void BulkModulusFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     Real *shifted_sies = scratch;
     shift_sies(sies, shifted_sies, num);
     t_.BulkModulusFromDensityInternalEnergy(rhos, shifted_sies, bmods, &scratch[num], num,
-                                            std::forward<LambdaIndexer>(lambdas));
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityTemperature(const Real *rhos,
-                                                   const Real *temperatures, Real *gm1s,
-                                                   Real *scratch, const int num,
-                                                   LambdaIndexer &&lambdas) const {
+  inline void GruneisenParamFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     t_.GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas));
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                                      Real *gm1s, Real *scratch,
-                                                      const int num,
-                                                      LambdaIndexer &&lambdas) const {
+  inline void GruneisenParamFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     Real *shifted_sies = scratch;
     shift_sies(sies, shifted_sies, num);
     t_.GruneisenParamFromDensityInternalEnergy(rhos, shifted_sies, gm1s, &scratch[num],
-                                               num, std::forward<LambdaIndexer>(lambdas));
+                                               num, std::forward<LambdaIndexer>(lambdas),
+                                               std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
-  inline void InternalEnergyFromDensityTemperature(const Real *rhos,
-                                                   const Real *temperatures, Real *sies,
-                                                   Real *scratch, const int num,
-                                                   LambdaIndexer &&lambdas) const {
+  inline void InternalEnergyFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     t_.InternalEnergyFromDensityTemperature(rhos, temperatures, sies, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas));
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
     unshift_sies(sies, num);
   }
 
   template <typename LambdaIndexer>
   inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
                                             Real *entropies, Real *scratch, const int num,
-                                            LambdaIndexer &&lambdas) const {
+                                            LambdaIndexer &&lambdas,
+                                            Transform &&transform = Transform()) const {
     t_.EntropyFromDensityTemperature(rhos, temperatures, entropies, scratch, num,
-                                     std::forward<LambdaIndexer>(lambdas));
+                                     std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
-  inline void EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                               Real *entropies, Real *scratch,
-                                               const int num,
-                                               LambdaIndexer &&lambdas) const {
+  inline void
+  EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
+                                   Real *scratch, const int num, LambdaIndexer &&lambdas,
+                                   Transform &&transform = Transform()) const {
     Real *shifted_sies = scratch;
     shift_sies(sies, shifted_sies, num);
     t_.EntropyFromDensityInternalEnergy(rhos, sies, entropies, &scratch[num], num,
-                                        std::forward<LambdaIndexer>(lambdas));
+                                        std::forward<LambdaIndexer>(lambdas),
+                                        std::forward<Transform>(transform));
   }
 
   PORTABLE_INLINE_FUNCTION

--- a/test/profile_eospac.cpp
+++ b/test/profile_eospac.cpp
@@ -388,6 +388,22 @@ int main(int argc, char *argv[]) {
                            "ScaledEOS<ShiftedEOS<EOSPAC>>", eos) &&
                 success;
     }
+
+    {
+      auto eos = BilinearRampEOS<EOSPAC>(EOSPAC(airID), 1.0, 1.0, 0.0, 0.0);
+      success = get_timing(ncycles, ncells_1d, X_MIN, X_MAX, Y_MIN, Y_MAX,
+                           "BilinearRampEOS<EOSPAC>", eos) &&
+                success;
+    }
+
+    {
+      auto eos = BilinearRampEOS<ScaledEOS<EOSPAC>>(ScaledEOS<EOSPAC>(EOSPAC(airID), 2.0),
+                                                    1.0, 1.0, 0.0, 0.0);
+      success = get_timing(ncycles, ncells_1d, 0.5 * X_MIN, 0.5 * X_MAX, Y_MIN, Y_MAX,
+                           "BilinearRampEOS<ScaledEOS<EOSPAC>>", eos) &&
+                success;
+    }
+
     std::cout << "Done." << std::endl;
   }
 #ifdef PORTABILITY_STRATEGY_KOKKOS

--- a/test/profile_eospac.cpp
+++ b/test/profile_eospac.cpp
@@ -105,9 +105,12 @@ constexpr Real Y_MAX = E_MAX;
 #define xstr(s) str(s)
 #define str(s) #s
 
+template <typename T>
 inline bool get_timing(int ncycles, const ivec &ncells_1d, const double x_min,
                        const double x_max, const double y_min, const double y_max,
-                       const std::string &name, EOS &eos_h) {
+                       const std::string &name, T &eos) {
+  // use variant for testing
+  EOS eos_h = eos;
   bool success = true;
   std::cout << "\t...Profiling EOS: " << name << " (" << xstr(METHOD_UNDER_TEST)
             << ") ..." << std::endl;
@@ -141,7 +144,7 @@ inline bool get_timing(int ncycles, const ivec &ncells_1d, const double x_min,
 
     const int nc1d = ncells_1d[n];
     const int nc = ncells[n];
-    dvec scratch(EOSPAC::scratch_size(xstr(METHOD_UNDER_TEST), nc) / sizeof(double));
+    dvec scratch(T::scratch_size(xstr(METHOD_UNDER_TEST), nc) / sizeof(double));
     DataBox F_h(nc1d, nc1d, nc1d);
     DataBox F_hvec(nc1d, nc1d, nc1d);
     DataBox F_hscratch(nc1d, nc1d, nc1d);
@@ -358,8 +361,18 @@ int main(int argc, char *argv[]) {
               << "Beginning profiling..." << std::endl;
 
     constexpr int airID = 5030;
-    EOS eos = EOSPAC(airID);
-    success = get_timing(ncycles, ncells_1d, X_MIN, X_MAX, Y_MIN, Y_MAX, "EOSPAC", eos);
+
+    {
+      auto eos = EOSPAC(airID);
+      success = get_timing(ncycles, ncells_1d, X_MIN, X_MAX, Y_MIN, Y_MAX, "EOSPAC", eos);
+    }
+
+    {
+      auto eos = ShiftedEOS<EOSPAC>(EOSPAC(airID), 1.0);
+      success = get_timing(ncycles, ncells_1d, X_MIN, X_MAX, Y_MIN, Y_MAX,
+                           "ShiftedEOS<EOSPAC>", eos) &&
+                success;
+    }
 
     std::cout << "Done." << std::endl;
   }

--- a/test/profile_eospac.cpp
+++ b/test/profile_eospac.cpp
@@ -51,9 +51,9 @@ using RMirror = typename RView::HostMirror;
 #endif
 
 constexpr Real RHO_MIN = 1e-2; // g/cm^3
-constexpr Real RHO_MAX = 1e2;
-constexpr Real T_MIN = 1e2; // Kelvin
-constexpr Real T_MAX = 1e4;
+constexpr Real RHO_MAX = 1e0;
+constexpr Real T_MIN = 1.8e2; // Kelvin
+constexpr Real T_MAX = 1e3;
 constexpr Real E_MIN = 1e9;
 constexpr Real E_MAX = 1e13;
 
@@ -374,6 +374,20 @@ int main(int argc, char *argv[]) {
                 success;
     }
 
+    {
+      auto eos = ScaledEOS<EOSPAC>(EOSPAC(airID), 2.0);
+      success = get_timing(ncycles, ncells_1d, 0.5 * X_MIN, 0.5 * X_MAX, Y_MIN, Y_MAX,
+                           "ScaledEOS<EOSPAC>", eos) &&
+                success;
+    }
+
+    {
+      auto eos =
+          ScaledEOS<ShiftedEOS<EOSPAC>>(ShiftedEOS<EOSPAC>(EOSPAC(airID), 0.3), 2.0);
+      success = get_timing(ncycles, ncells_1d, 0.5 * X_MIN, 0.5 * X_MAX, Y_MIN, Y_MAX,
+                           "ScaledEOS<ShiftedEOS<EOSPAC>>", eos) &&
+                success;
+    }
     std::cout << "Done." << std::endl;
   }
 #ifdef PORTABILITY_STRATEGY_KOKKOS


### PR DESCRIPTION
## PR Summary

This is work-in-progress.

* [X] ShiftedEOS
* [x] ScaledEOS
* [ ] ~UnitSystem~ (not a variant for EOSPAC)
* [ ] ~RelativisticEOS~ (not a variant for EOSPAC)
* [x] BilinearRampEOS

### `EOSPAC` (Baseline)
![Screenshot 2023-05-22 at 5 09 15 PM](https://github.com/lanl/singularity-eos/assets/2828630/b219c8f3-2085-4813-98e0-a95154e6faa3)


### `ShiftedEOS<EOSPAC>`

![Screenshot 2023-05-22 at 5 09 24 PM](https://github.com/lanl/singularity-eos/assets/2828630/01d1c6f3-6258-416a-8b8c-8dd9b9689cb6)

### `ScaledEOS<EOSPAC>`
![Screenshot 2023-05-24 at 1 31 57 PM](https://github.com/lanl/singularity-eos/assets/2828630/c942c2d9-500d-4757-b513-b7df5230a51b)


### `ScaledEOS<ShiftedEOS<EOSPAC>>`
![Screenshot 2023-05-24 at 1 32 07 PM](https://github.com/lanl/singularity-eos/assets/2828630/b1dd5442-308d-45d1-a33a-d280857fa9ec)

### `BilinearRampEOS<EOSPAC>`
![Screenshot 2023-05-24 at 5 35 33 PM](https://github.com/lanl/singularity-eos/assets/2828630/20e1ae50-2f9b-4e8f-81f0-0345e9c3b408)


### `BilinearRampEOS<ScaledEOS<EOSPAC>>`
![Screenshot 2023-05-24 at 5 35 42 PM](https://github.com/lanl/singularity-eos/assets/2828630/5d6693e5-3243-46e1-9e60-d3bbfbe9fdeb)


<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
