### PR TITLE
fix interpolation of mass fractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Fixed (Repair bugs, etc)
+- [[PR263]](https://github.com/lanl/singularity-eos/pull/263) Fix stellar collapse mass fraction interpolation
 - [[PR258]](https://github.com/lanl/singularity-eos/pull/258) Fix EOSPAC vector performance and add warnings when slower version gets selected.
 - [[PR243]](https://github.com/lanl/singularity-eos/pull/243) Remove undefined behavior caused by diagnostic variables. Also fixed some compiler warnings.
 - [[PR239]](https://github.com/lanl/singularity-eos/pull/239#issuecomment-1473166925) Add JQuery to dependencies for docs to repair build

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -604,12 +604,12 @@ void StellarCollapse::MassFractionsFromDensityTemperature(
     Real &Abar, Real &Zbar, Real *lambda) const {
   Real lRho, lT, Ye;
   getLogsFromRhoT_(rho, temperature, lambda, lRho, lT, Ye);
-  Xa = Xa_.interpToReal(Ye, lRho, lT);
-  Xh = Xh_.interpToReal(Ye, lRho, lT);
-  Xn = Xn_.interpToReal(Ye, lRho, lT);
-  Xp = Xp_.interpToReal(Ye, lRho, lT);
-  Abar = Abar_.interpToReal(Ye, lRho, lT);
-  Zbar = Zbar_.interpToReal(Ye, lRho, lT);
+  Xa = Xa_.interpToReal(Ye, lT, lRho);
+  Xh = Xh_.interpToReal(Ye, lT, lRho);
+  Xn = Xn_.interpToReal(Ye, lT, lRho);
+  Xp = Xp_.interpToReal(Ye, lT, lRho);
+  Abar = Abar_.interpToReal(Ye, lT, lRho);
+  Zbar = Zbar_.interpToReal(Ye, lT, lRho);
 }
 
 PORTABLE_INLINE_FUNCTION


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

The Stellar Collapse EOS had a bug where the mass fraction interpolation had two indices swapped. This quick trivial fix remedies the issue.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
