### PR TITLE
Remove 'make install' to avoid confusion in build instructions

### DIFF
--- a/doc/sphinx/src/building.rst
+++ b/doc/sphinx/src/building.rst
@@ -95,7 +95,7 @@ At it's simplest, the cmake build process looks like this:
    mkdir bin
    cd bin
    cmake ..
-   make install
+   make
 
 You can set options on the cmake line via, e.g.,
 
@@ -192,7 +192,7 @@ Building ``singularity-eos`` with Python wrappers in a virtual environment:
    cd build
    cmake -DSINGULARITY_USE_HDF55=ON -DSINGULARITY_BUILD_PYTHON=ON -DCMAKE_INSTALL_PREFIX=$VIRTUAL_ENV ../..
    make -j
-   make install
+   make install  # Only install if you have the correct permissions
 
 
 Dependencies

--- a/doc/sphinx/src/getting-started.rst
+++ b/doc/sphinx/src/getting-started.rst
@@ -3,7 +3,7 @@
 Getting Started
 ===============
 
-At it's most basic, you can download and install ``singularity-eos`` with:
+At it's most basic, you can download and compile ``singularity-eos`` with:
 
 .. code-block:: bash
 
@@ -12,7 +12,7 @@ At it's most basic, you can download and install ``singularity-eos`` with:
   mkdir bin
   cd bin
   cmake ..
-  make install
+  make
 
 This will downloady singularity-eos with no optional dependencies and
 compile the capabilities available in that form.


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This is a very simple update to the documentation to remove `make install` since it seems to cause confusion.

I've left it in the python build instructions because I assume it's needed there to install the appropriate python bindings.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- N/A Adds a test for any bugs fixed. Adds tests for new features.
- N/A Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- N/A After creating a pull request, note it in the CHANGELOG.md file
- N/A If preparing for a new release, update the version in cmake.
