### PR TITLE
revert spiner release in spackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [[PR269]](https://github.com/lanl/singularity-eos/pull/269) Add SAP Polynomial EoS
 
 ### Fixed (Repair bugs, etc)
+- [[PR281]](https://github.com/lanl/singularity-eos/pull/281) Pin spiner in spackage to a specific, tested version
 - [[PR267]](https://github.com/lanl/singularity-eos/pull/267) Add missing eosSafeDestroy call in EOSPAC::Finalize
 - [[PR263]](https://github.com/lanl/singularity-eos/pull/263) Fix stellar collapse mass fraction interpolation
 - [[PR258]](https://github.com/lanl/singularity-eos/pull/258) Fix EOSPAC vector performance and add warnings when slower version gets selected.

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -63,7 +63,7 @@ class SingularityEos(CMakePackage, CudaPackage):
     depends_on("eigen@3.3.8", when="~cuda")
 
     depends_on("eospac", when="+eospac")
-    depends_on("spiner")
+    depends_on("spiner@1.6.0") # This should be removed 
     depends_on("ports-of-call@1.4.2:")
     depends_on("spiner +kokkos", when="+kokkos")
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

The bots did their job with the spiner spackage, but because singularity-eos wasn't pinned to a specific spiner release in its own spackage, this broke the CI since spiner is a bit ahead of singularity-eos, at least until @mauneyc-LANL 's PR #246 goes through. This pins singularity to a version of spiner that it works with.

@mauneyc-LANL when you merge PR #246 please make sure to update the spackage here.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
