### PR TITLE
Disable tests that use databox when spiner is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [[PR269]](https://github.com/lanl/singularity-eos/pull/269) Add SAP Polynomial EoS
 
 ### Fixed (Repair bugs, etc)
+- [[PR288]](https://github.com/lanl/singularity-eos/pull/288) Don't build tests that depend on spiner when spiner is disabled
 - [[PR287]](https://github.com/lanl/singularity-eos/pull/287) Fix testing logic with new HDF5 options
 - [[PR282]](https://github.com/lanl/singularity-eos/pull/282) Fix missing deep copy in sap polynomial tests
 - [[PR281]](https://github.com/lanl/singularity-eos/pull/281) Pin spiner in spackage to a specific, tested version

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,7 +40,7 @@ if(SINGULARITY_USE_EOSPAC AND SINGULARITY_TEST_SESAME)
                         PRIVATE Catch2::Catch2 singularity-eos::singularity-eos)
 endif()
 
-if(SINGULARITY_BUILD_CLOSURE)
+if(SINGULARITY_BUILD_CLOSURE AND SINGULARITY_USE_SPINER)
   add_executable(test_pte test_pte.cpp)
   target_link_libraries(test_pte PRIVATE Catch2::Catch2
                                          singularity-eos::singularity-eos)
@@ -85,8 +85,10 @@ if(SINGULARITY_BUILD_PYTHON AND SINGULARITY_TEST_PYTHON)
                                                  "${PYTHON_TEST_ENVIRONMENT}")
 endif()
 
-add_executable(profile_eos profile_eos.cpp)
-target_link_libraries(profile_eos singularity-eos::singularity-eos)
+if(SINGULARITY_USE_SPINER)
+  add_executable(profile_eos profile_eos.cpp)
+  target_link_libraries(profile_eos singularity-eos::singularity-eos)
+endif()
 
 if(SINGULARITY_USE_EOSPAC
    AND SINGULARITY_TEST_SESAME


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@jhp-lanl hit an issue where `SINGULARITY_USE_SPINER=OFF` would fail tests that used `spiner`. In a way, the tests worked!

This disables building those tests when `SINGULARITY_USE_SPINER=OFF`

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
