### PR TITLE
Fix configuration export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [[PR269]](https://github.com/lanl/singularity-eos/pull/269) Add SAP Polynomial EoS
 
 ### Fixed (Repair bugs, etc)
+- [[PR290]](https://github.com/lanl/singularity-eos/pull/290) Added target guards on export config
 - [[PR288]](https://github.com/lanl/singularity-eos/pull/288) Don't build tests that depend on spiner when spiner is disabled
 - [[PR287]](https://github.com/lanl/singularity-eos/pull/287) Fix testing logic with new HDF5 options
 - [[PR282]](https://github.com/lanl/singularity-eos/pull/282) Fix missing deep copy in sap polynomial tests

--- a/cmake/singularity-eos/hdf5.cmake
+++ b/cmake/singularity-eos/hdf5.cmake
@@ -79,7 +79,9 @@ macro(singularity_enable_hdf5 target)
       COMPONENTS C CXX
       REQUIRED)
     target_link_libraries(${target} PUBLIC MPI::MPI_CXX)
-    set(SINGLUARITY_USE_SPINER_WITH_PARALLEL_HDF5 TRUE)
+    set(SINGULARITY_USE_SPINER_WITH_PARALLEL_HDF5
+        ON
+        CACHE BOOL "" FORCE)
   endif()
 
   target_compile_definitions(${target} PUBLIC SINGULARITY_USE_HDF5)

--- a/config/singularity-eosConfig.cmake.in
+++ b/config/singularity-eosConfig.cmake.in
@@ -35,50 +35,41 @@ endif()
 # ------------------------------------------------------------------------------#
 # library dependencies
 # ------------------------------------------------------------------------------#
-if(NOT TARGET ports-of-call::ports-of-call)
-  find_package(ports-of-call REQUIRED)
-endif()
 
-if(NOT TARGET mpark_variant)
-  find_package(mpark_variant REQUIRED)
-endif()
+include(CMakeFindDependencyMacro)
 
-if(@SINGULARITY_USE_SPINER@ AND NOT TARGET spiner::spiner)
-  find_package(spiner REQUIRED)
+find_dependency(ports-of-call)
+
+find_dependency(mpark_variant)
+
+if(@SINGULARITY_USE_SPINER@)
+  find_dependency(spiner)
 endif()
 
 if(@SINGULARITY_USE_SPINER_WITH_HDF5@)
-  if(NOT TARGET HDF5::HDF5 OR NOT HDF5_LIBRARIES)
-    find_package(
-      HDF5
-      COMPONENTS C HL
-      REQUIRED)
-  endif()
+  find_dependency(HDF5 COMPONENTS C HL)
   set(SPINER_USE_HDF ON)
 endif()
 
-if(@SINGULARITY_USE_SPINER_WITH_PARALLEL_HDF5@ AND NOT TARGET MPI::MPI_CXX)
+if(@SINGULARITY_USE_SPINER_WITH_PARALLEL_HDF5@)
   # do i need enable_language here?
-  find_package(
-    MPI
-    COMPONENTS C CXX
-    REQUIRED)
+  find_dependency(MPI COMPONENTS C CXX)
 endif()
 
-if(@SINGULARITY_USE_KOKKOS@ AND NOT TARGET Kokkos::kokkos)
-  find_package(Kokkos REQUIRED)
+if(@SINGULARITY_USE_KOKKOS@)
+  find_dependency(Kokkos)
 endif()
 
-if(@SINGULARITY_USE_KOKKOSKERNELS@ AND NOT TARGET Kokkos::kokkoskernels)
-  find_package(KokkosKernels REQUIRED)
+if(@SINGULARITY_USE_KOKKOSKERNELS@)
+  find_dependency(KokkosKernels)
 endif()
 
-if(@SINGULARITY_USE_EIGEN@ AND NOT TARGET Eigen3::Eigen)
-  find_package(Eigen3 REQUIRED)
+if(@SINGULARITY_USE_EIGEN@)
+  find_dependency(Eigen3)
 endif()
 
-if(@SINGULARITY_USE_EOSPAC@ AND NOT TARGET EOSPAC::eospac)
-  find_package(EOSPAC REQUIRED)
+if(@SINGULARITY_USE_EOSPAC@)
+  find_dependency(EOSPAC)
 endif()
 
 # ------------------------------------------------------------------------------#

--- a/config/singularity-eosConfig.cmake.in
+++ b/config/singularity-eosConfig.cmake.in
@@ -69,7 +69,10 @@ if(@SINGULARITY_USE_EIGEN@)
 endif()
 
 if(@SINGULARITY_USE_EOSPAC@)
-  find_dependency(EOSPAC)
+  # needed for EOSPAC
+  if(NOT TARGET EOSPAC::eospac)
+    find_dependency(EOSPAC)
+  endif()
 endif()
 
 # ------------------------------------------------------------------------------#

--- a/config/singularity-eosConfig.cmake.in
+++ b/config/singularity-eosConfig.cmake.in
@@ -35,37 +35,49 @@ endif()
 # ------------------------------------------------------------------------------#
 # library dependencies
 # ------------------------------------------------------------------------------#
-find_package(ports-of-call REQUIRED)
-find_package(mpark_variant REQUIRED)
+if(NOT TARGET ports-of-call::ports-of-call)
+  find_package(ports-of-call REQUIRED)
+endif()
 
-if(@SINGULARITY_USE_SPINER@)
+if(NOT TARGET mpark_variant)
+  find_package(mpark_variant REQUIRED)
+endif()
+
+if(@SINGULARITY_USE_SPINER@ AND NOT TARGET spiner::spiner)
   find_package(spiner REQUIRED)
-  if(@SINGULARITY_USE_SPINER_WITH_HDF5@)
+endif()
+
+if(@SINGULARITY_USE_SPINER_WITH_HDF5@)
+  if(NOT TARGET HDF5::HDF5 OR NOT HDF5_LIBRARIES)
     find_package(
       HDF5
       COMPONENTS C HL
       REQUIRED)
-    if(@SINGULARITY_USE_SPINER_WITH_PARALLEL_HDF5@)
-      # do i need enable_language here?
-      find_package(
-        MPI
-        COMPONENTS C CXX
-        REQUIRED)
-    endif()
-    set(SPINER_USE_HDF ON)
   endif()
+  set(SPINER_USE_HDF ON)
 endif()
 
-if(@SINGULARITY_USE_KOKKOS@)
+if(@SINGULARITY_USE_SPINER_WITH_PARALLEL_HDF5@ AND NOT TARGET MPI::MPI_CXX)
+  # do i need enable_language here?
+  find_package(
+    MPI
+    COMPONENTS C CXX
+    REQUIRED)
+endif()
+
+if(@SINGULARITY_USE_KOKKOS@ AND NOT TARGET Kokkos::kokkos)
   find_package(Kokkos REQUIRED)
-  if(@SINGULARITY_USE_KOKKOSKERNELS@)
-    find_package(KokkosKernels REQUIRED)
-  endif()
-else()
+endif()
+
+if(@SINGULARITY_USE_KOKKOSKERNELS@ AND NOT TARGET Kokkos::kokkoskernels)
+  find_package(KokkosKernels REQUIRED)
+endif()
+
+if(@SINGULARITY_USE_EIGEN@ AND NOT TARGET Eigen3::Eigen)
   find_package(Eigen3 REQUIRED)
 endif()
 
-if(@SINGULARITY_USE_EOSPAC@)
+if(@SINGULARITY_USE_EOSPAC@ AND NOT TARGET EOSPAC::eospac)
   find_package(EOSPAC REQUIRED)
 endif()
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@jhp-lanl found an issue where the exported `singularity-eosConfig.cmake` didn't have guards to check if a target has already been created for dependencies. This would cause an issue with builds where there are common dependencies downstream.

This update includes those guards, and also simplifies the logic.


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
