### PR TITLE
Remove PTofRE implementations from source. Tests pass on my p9 darwin…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [[PR245]](https://github.com/lanl/singularity-eos/pull/245) Separating get_sg_eos to other files. Build/compilation improvements, warning fixes/suppression.
 
 ### Removed (removing behavior/API/varaibles/...)
+- [[PR293]](https://github.com/lanl/singularity-eos/pull/293) Removing PTofRE function. This will no longer be callable downstream.
 
 ## Release 1.7.0
 Date: 12/14/2022

--- a/doc/sphinx/src/contributing.rst
+++ b/doc/sphinx/src/contributing.rst
@@ -491,14 +491,13 @@ The CRTP slass structure and static polymorphism
 ````````````````````````````````````````````````
 
 Each of the EOS models in ``singularity-eos`` inherits from a base class in
-order to centralize default functionality and avoid code duplication. The two
-main examples of this are the vector overloads and the ``PTofRE`` scalar lookup
-function. In the vector overloads, a simple for loop is used to iterate over
+order to centralize default functionality and avoid code duplication. The
+main example of this are the vector overloads.
+In the vector overloads, a simple for loop is used to iterate over
 the set of states provided to the function and then call the scalar version on
-each state. The ``PTofRE`` function is designed to provide a common method for
-getting the needed information for a PTE solve from an EOS. Both of these
-features are general to all types of EOS, but are reliant on specific
-implementations of the EOS lookups. In both cases, these functions provide a
+each state. This feature is
+general to all types of EOS, but reliant on specific
+implementations of the EOS lookups. These functions provide a
 default behaviour that we might also want to override for a given equation of
 state.
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -549,10 +549,3 @@ returns the density at which pressure is minimized for a given
 temperature. This is again useful for root finds.
 
 Finally the method
-
-.. cpp:function:: void PTofRE(Real &rho, Real &sie, Real *lambda, Real &press, Real &temp, Real &dpdr, Real &dpde, Real &dtdr, Real &dtde) const;
-
-returns pressure and temperature, as well as the thermodynamic
-derivatives of pressure and temperature with respect to density and
-specific internal energy, as a function of density and specific
-internal energy.

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -547,5 +547,3 @@ root finder to meaningful bound the root search. Similarly,
 
 returns the density at which pressure is minimized for a given
 temperature. This is again useful for root finds.
-
-Finally the method

--- a/python/module.hpp
+++ b/python/module.hpp
@@ -344,44 +344,6 @@ py::class_<T> eos_class(py::module_ & m, std::string name) {
 
     .def("MinimumDensity", &T::MinimumDensity)
     .def("MinimumTemperature", &T::MinimumTemperature)
-
-    .def("PTofRE", [](const T & self, Real rho, Real sie, py::array_t<Real> lambda) {
-      EOSState s;
-      s.density = rho;
-      s.specific_internal_energy = sie;
-      self.PTofRE(s.density, s.specific_internal_energy, lambda.mutable_data(), s.pressure, s.temperature, s.dpdr, s.dpde, s.dtdr, s.dtde);
-      return s;
-    }, py::arg("rho"), py::arg("sie"), py::arg("lmbda"))
-    .def("PTofRE", [](const T & self, Real rho, Real sie) {
-      EOSState s;
-      s.density = rho;
-      s.specific_internal_energy = sie;
-      self.PTofRE(s.density, s.specific_internal_energy, nullptr, s.pressure, s.temperature, s.dpdr, s.dpde, s.dtdr, s.dtde);
-      return s;
-    }, py::arg("rho"), py::arg("sie"))
-    .def("PTofRE", [](const T & self, py::array_t<Real> rhos, py::array_t<Real> sies, py::array_t<Real> pressures, py::array_t<Real> temperatures, py::array_t<Real> dpdrs, py::array_t<Real> dpdes, py::array_t<Real> dtdrs, py::array_t<Real> dtdes,
-                      const int num, py::array_t<Real> lambdas) {
-      py::buffer_info lambdas_info = lambdas.request();
-      if (lambdas_info.ndim != 2)
-        throw std::runtime_error("lambdas dimension must be 2!");
-
-      if(lambdas_info.shape[1] > 0) {
-        self.PTofRE(rhos.mutable_data(), sies.mutable_data(),
-                    pressures.mutable_data(), temperatures.mutable_data(), dpdrs.mutable_data(),
-                    dpdes.mutable_data(), dtdrs.mutable_data(), dtdes.mutable_data(), num,
-                    LambdaHelper(lambdas));
-      } else {
-        self.PTofRE(rhos.mutable_data(), sies.mutable_data(),
-                    pressures.mutable_data(), temperatures.mutable_data(), dpdrs.mutable_data(),
-                    dpdes.mutable_data(), dtdrs.mutable_data(), dtdes.mutable_data(), num,
-                    NoLambdaHelper());
-      }
-    }, py::arg("rhos"), py::arg("sies"), py::arg("pressures"), py::arg("temperatures"), py::arg("dpdrs"), py::arg("dpdes"), py::arg("dtdrs"), py::arg("dtdes"), py::arg("num"), py::arg("lmbdas"))
-    .def("PTofRE", [](const T & self, py::array_t<Real> rhos, py::array_t<Real> sies, py::array_t<Real> pressures, py::array_t<Real> temperatures, py::array_t<Real> dpdrs, py::array_t<Real> dpdes, py::array_t<Real> dtdrs, py::array_t<Real> dtdes,
-                      const int num) {
-      self.PTofRE(rhos.mutable_data(), sies.mutable_data(), pressures.mutable_data(), temperatures.mutable_data(), dpdrs.mutable_data(), dpdes.mutable_data(), dtdrs.mutable_data(), dtdes.mutable_data(), num, NoLambdaHelper());
-    }, py::arg("rhos"), py::arg("sies"), py::arg("pressures"), py::arg("temperatures"), py::arg("dpdrs"), py::arg("dpdes"), py::arg("dtdrs"), py::arg("dtdes"), py::arg("num"))
-
     .def_property_readonly("nlambda", &T::nlambda)
     .def_property_readonly_static("PreferredInput", [](py::object) { return T::PreferredInput(); })
     .def("PrintParams", &T::PrintParams)

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -76,7 +76,6 @@ char *StrCat(char *destination, const char *source) {
   using EosBase<EOSDERIVED>::GruneisenParamFromDensityInternalEnergy;                    \
   using EosBase<EOSDERIVED>::MinimumDensity;                                             \
   using EosBase<EOSDERIVED>::MinimumTemperature;                                         \
-  using EosBase<EOSDERIVED>::PTofRE;                                                     \
   using EosBase<EOSDERIVED>::FillEos;                                                    \
   using EosBase<EOSDERIVED>::EntropyFromDensityTemperature;                              \
   using EosBase<EOSDERIVED>::EntropyFromDensityInternalEnergy;                           \
@@ -553,43 +552,6 @@ class EosBase {
   Real MinimumDensity() const { return 0; }
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumTemperature() const { return 0; }
-
-  template <typename RealIndexer, typename LambdaIndexer>
-  inline void PTofRE(RealIndexer &&rhos, RealIndexer &&sies, RealIndexer &&presses,
-                     RealIndexer &&temps, RealIndexer &&dpdrs, RealIndexer &&dpdes,
-                     RealIndexer &&dtdrs, RealIndexer &&dtdes, const int num,
-                     LambdaIndexer &&lambdas) const {
-    static auto const name = SG_MEMBER_FUNC_NAME();
-    static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          copy.PTofRE(rhos[i], sies[i], lambdas[i], presses[i], temps[i], dpdrs[i],
-                      dpdes[i], dtdrs[i], dtdes[i]);
-        });
-  }
-  // Scalar version of PTofRE
-  PORTABLE_INLINE_FUNCTION
-  void PTofRE(Real &rho, Real &sie, Real *lambda, Real &press, Real &temp, Real &dpdr,
-              Real &dpde, Real &dtdr, Real &dtde) const {
-    // Get the dervived class
-    auto eos = static_cast<CRTP const &>(*this);
-
-    press = eos.PressureFromDensityInternalEnergy(rho, sie, lambda);
-    temp = eos.TemperatureFromDensityInternalEnergy(rho, sie, lambda);
-    const Real drho = rho * 1.0e-6;
-    const Real de = sie * 1.0e-6;
-    const Real Pr = eos.PressureFromDensityInternalEnergy(rho + drho, sie, lambda);
-    const Real Pe = eos.PressureFromDensityInternalEnergy(rho, sie + de, lambda);
-    const Real Tr = eos.TemperatureFromDensityInternalEnergy(rho + drho, sie, lambda);
-    const Real Te = eos.TemperatureFromDensityInternalEnergy(rho, sie + de, lambda);
-    dpdr = (Pr - press) / drho;
-    dpde = (Pe - press) / de;
-    dtdr = (Tr - temp) / drho;
-    dtde = (Te - temp) /
-           de; // Would it be better to skip the calculation of Te and return 1/cv?
-    return;
-  }
 
   PORTABLE_INLINE_FUNCTION
   Real RhoPmin(const Real temp) const { return 0.0; }

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -436,30 +436,6 @@ void DavisProducts::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Rea
   Real gm1 = GruneisenParamFromDensityTemperature(rho, temp) * rho;
   dvdt = gm1 * cv / bmod;
 }
-#if 0
-PORTABLE_INLINE_FUNCTION void DavisProducts::PTofRE(const Real rho, const Real sie, Real * lambda, Real& press, Real& temp, Real & dpdr, Real & dpde, Real & dtdr, Real & dtde) const
-{
-  using namespace math_utils;
-    press = PressureFromDensityInternalEnergy(rho,sie,lambda);
-    temp = TemperatureFromDensityInternalEnergy(rho,sie,lambda);
-
-    const Real vvc = 1/(rho*_vc);
-    const Real Fx = -4*_a*std::pow(vvc,2*_n-1)/pow<2>(1+std::pow(vvc,2*_n));
-    const Real tmp = std::pow(0.5*(std::pow(vvc,_n)+std::pow(vvc,-_n)),_a/_n)/std::pow(vvc,_k+_a);
-    const Real tmp_x = 0.5*_a*(std::pow(vvc,_n-1)-std::pow(vvc,-_n-1))*std::pow(0.5*(std::pow(vvc,_n)+std::pow(vvc,-_n)),_a/_n-1)/std::pow(vvc,_k+_a)-(_k+_a)*tmp/vvc;
-    const Real psv = _pc/(_k-1+_a)*(tmp*Fx+(_k-1+F(rho))*tmp_x)/_vc;
-    //const Real esv = _pc*_vc/(_k-1+_a)*(tmp+vvc*tmp_x)/_vc;
-    const Real esv = _pc/(_k-1+_a)*(tmp+vvc*tmp_x);
-    const Real gamma = Gamma(rho);
-    const Real gammav = (1-_b)*Fx*_vc;
-    dpde = gamma*rho;
-    dpdr = (psv+(sie-Es(rho))*rho*(gammav-gamma*rho)-gamma*rho*esv)/pow<2>(rho);
-    dtde = 1.0/_Cv;
-    const Real tsv = Ts(rho)*rho*(_a*(1.0-_b)*(std::pow(vvc,2.0*_n)-1.0)/(std::pow(vvc,2.0*_n)+1.0)-(_k-1.0+_a*(1.0-_b)));
-    dtdr = -(tsv-esv/_Cv)/pow<2>(rho);
-}
-#endif
-
 } // namespace singularity
 
 #endif // _SINGULARITY_EOS_EOS_EOS_DAVIS_HPP_

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -326,7 +326,6 @@ class EOSPAC : public EosBase<EOSPAC> {
                                                              lambdas);
   }
 
-  using EosBase<EOSPAC>::PTofRE;
   using EosBase<EOSPAC>::FillEos;
   using EosBase<EOSPAC>::EntropyIsNotEnabled;
 
@@ -1067,77 +1066,6 @@ class EOSPAC : public EosBase<EOSPAC> {
         });
   }
 
-  template <typename LambdaIndexer>
-  inline void PTofRE(Real *rhos, Real *sies, Real *presses, Real *temps, Real *dpdrs,
-                     Real *dpdes, Real *dtdrs, Real *dtdes, Real *scratch, const int num,
-                     LambdaIndexer lambdas) const {
-    static auto const name =
-        singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
-    static auto const cname = name.c_str();
-
-    PressureFromDensityInternalEnergy(rhos, sies, presses, scratch, num, lambdas);
-    TemperatureFromDensityInternalEnergy(rhos, sies, temps, scratch, num, lambdas);
-
-    Real *drho = scratch;
-    Real *de = scratch + num;
-    Real *Pr = scratch + 2 * num;
-    Real *Pe = scratch + 3 * num;
-    Real *Tr = scratch + 4 * num;
-    Real *Te = scratch + 5 * num;
-    Real *rho_p_drho = scratch + 6 * num;
-    Real *sie_p_de = scratch + 7 * num;
-
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          drho[i] = rhos[i] * 1.0e-6;
-          de[i] = sies[i] * 1.0e-6;
-          rho_p_drho[i] = rhos[i] + drho[i];
-          sie_p_de[i] = sies[i] + de[i];
-        });
-
-    Real *R = &rhos[0];
-    Real *E = &sies[0];
-
-    Real *internal_scratch = scratch + 8 * num;
-
-    PressureFromDensityInternalEnergy(rho_p_drho, E, Pr, internal_scratch, num, lambdas);
-    PressureFromDensityInternalEnergy(R, sie_p_de, Pe, internal_scratch, num, lambdas);
-    TemperatureFromDensityInternalEnergy(rho_p_drho, E, Tr, internal_scratch, num,
-                                         lambdas);
-    TemperatureFromDensityInternalEnergy(R, sie_p_de, Te, internal_scratch, num, lambdas);
-
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          dpdrs[i] = (Pr[i] - presses[i]) / drho[i];
-          dpdes[i] = (Pe[i] - presses[i]) / de[i];
-          dtdrs[i] = (Tr[i] - temps[i]) / drho[i];
-          dtdes[i] =
-              (Te[i] - temps[i]) /
-              de[i]; // Would it be better to skip the calculation of Te and return 1/cv?
-        });
-  }
-
-  SG_PIF_NOWARN
-  PORTABLE_INLINE_FUNCTION void PTofRE(Real &rho, Real &sie, Real *lambda, Real &press,
-                                       Real &temp, Real &dpdr, Real &dpde, Real &dtdr,
-                                       Real &dtde) const {
-
-    press = PressureFromDensityInternalEnergy(rho, sie, lambda);
-    temp = TemperatureFromDensityInternalEnergy(rho, sie, lambda);
-    const Real drho = rho * 1.0e-6;
-    const Real de = sie * 1.0e-6;
-    const Real Pr = PressureFromDensityInternalEnergy(rho + drho, sie, lambda);
-    const Real Pe = PressureFromDensityInternalEnergy(rho, sie + de, lambda);
-    const Real Tr = TemperatureFromDensityInternalEnergy(rho + drho, sie, lambda);
-    const Real Te = TemperatureFromDensityInternalEnergy(rho, sie + de, lambda);
-    dpdr = (Pr - press) / drho;
-    dpde = (Pe - press) / de;
-    dtdr = (Tr - temp) / drho;
-    dtde = (Te - temp) /
-           de; // Would it be better to skip the calculation of Te and return 1/cv?
-    return;
-  }
-
   static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
     auto nbuffers = scratch_nbuffers();
     if (nbuffers.find(method) != nbuffers.end()) {
@@ -1204,8 +1132,7 @@ class EOSPAC : public EosBase<EOSPAC> {
         {"BulkModulusFromDensityTemperature", 6},
         {"BulkModulusFromDensityInternalEnergy", 6},
         {"GruneisenParamFromDensityTemperature", 4},
-        {"GruneisenParamFromDensityInternalEnergy", 5},
-        {"PTofRE", 11}};
+        {"GruneisenParamFromDensityInternalEnergy", 5}};
     return nbuffers;
   }
 };

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -88,7 +88,6 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   using EosBase<SpinerEOSDependsRhoT>::BulkModulusFromDensityInternalEnergy;
   using EosBase<SpinerEOSDependsRhoT>::GruneisenParamFromDensityTemperature;
   using EosBase<SpinerEOSDependsRhoT>::GruneisenParamFromDensityInternalEnergy;
-  using EosBase<SpinerEOSDependsRhoT>::PTofRE;
   using EosBase<SpinerEOSDependsRhoT>::FillEos;
   using EosBase<SpinerEOSDependsRhoT>::EntropyIsNotEnabled;
 
@@ -318,7 +317,6 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   using EosBase<SpinerEOSDependsRhoSie>::BulkModulusFromDensityInternalEnergy;
   using EosBase<SpinerEOSDependsRhoSie>::GruneisenParamFromDensityTemperature;
   using EosBase<SpinerEOSDependsRhoSie>::GruneisenParamFromDensityInternalEnergy;
-  using EosBase<SpinerEOSDependsRhoSie>::PTofRE;
   using EosBase<SpinerEOSDependsRhoSie>::FillEos;
   using EosBase<SpinerEOSDependsRhoSie>::EntropyIsNotEnabled;
 

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -82,7 +82,6 @@ class StellarCollapse : public EosBase<StellarCollapse> {
   using EosBase<StellarCollapse>::BulkModulusFromDensityInternalEnergy;
   using EosBase<StellarCollapse>::GruneisenParamFromDensityTemperature;
   using EosBase<StellarCollapse>::GruneisenParamFromDensityInternalEnergy;
-  using EosBase<StellarCollapse>::PTofRE;
   using EosBase<StellarCollapse>::FillEos;
 
   inline StellarCollapse(const std::string &filename, bool use_sp5 = false,

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -223,17 +223,6 @@ class Variant {
   }
 
   PORTABLE_INLINE_FUNCTION
-  void PTofRE(Real &rho, Real &sie, Real *lambda, Real &press, Real &temp, Real &dpdr,
-              Real &dpde, Real &dtdr, Real &dtde) const {
-    return mpark::visit(
-        [&rho, &sie, &lambda, &press, &temp, &dpdr, &dpde, &dtdr,
-         &dtde](const auto &eos) {
-          return eos.PTofRE(rho, sie, lambda, press, temp, dpdr, dpde, dtdr, dtde);
-        },
-        eos_);
-  }
-
-  PORTABLE_INLINE_FUNCTION
   void DensityEnergyFromPressureTemperature(const Real press, const Real temp,
                                             Real *lambda, Real &rho, Real &sie) const {
     return mpark::visit(
@@ -925,36 +914,6 @@ class Variant {
               std::forward<RealIndexer>(energies), std::forward<RealIndexer>(presses),
               std::forward<RealIndexer>(cvs), std::forward<RealIndexer>(bmods), num,
               output, std::forward<LambdaIndexer>(lambdas));
-        },
-        eos_);
-  }
-
-  template <typename RealIndexer>
-  inline void PTofRE(RealIndexer &&rhos, RealIndexer &&sies, RealIndexer &&presses,
-                     RealIndexer &&temps, RealIndexer &&dpdrs, RealIndexer &&dpdes,
-                     RealIndexer &&dtdrs, RealIndexer &&dtdes, const int num) const {
-    NullIndexer lambdas{}; // Returns null pointer for every index
-    return PTofRE(std::forward<RealIndexer>(rhos), std::forward<RealIndexer>(sies),
-                  std::forward<RealIndexer>(presses), std::forward<RealIndexer>(temps),
-                  std::forward<RealIndexer>(dpdrs), std::forward<RealIndexer>(dpdes),
-                  std::forward<RealIndexer>(dtdrs), std::forward<RealIndexer>(dtdes), num,
-                  lambdas);
-  }
-
-  template <typename RealIndexer, typename LambdaIndexer>
-  inline void PTofRE(RealIndexer &&rhos, RealIndexer &&sies, RealIndexer &&presses,
-                     RealIndexer &&temps, RealIndexer &&dpdrs, RealIndexer &&dpdes,
-                     RealIndexer &&dtdrs, RealIndexer &&dtdes, const int num,
-                     LambdaIndexer &&lambdas) const {
-    return mpark::visit(
-        [&rhos, &sies, &presses, &temps, &dpdrs, &dpdes, &dtdrs, &dtdes, &num,
-         &lambdas](const auto &eos) {
-          return eos.PTofRE(
-              std::forward<RealIndexer>(rhos), std::forward<RealIndexer>(sies),
-              std::forward<RealIndexer>(presses), std::forward<RealIndexer>(temps),
-              std::forward<RealIndexer>(dpdrs), std::forward<RealIndexer>(dpdes),
-              std::forward<RealIndexer>(dtdrs), std::forward<RealIndexer>(dtdes), num,
-              std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }

--- a/singularity-eos/eos/modifiers/eos_unitsystem.hpp
+++ b/singularity-eos/eos/modifiers/eos_unitsystem.hpp
@@ -63,7 +63,6 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
   using EosBase<UnitSystem<T>>::BulkModulusFromDensityInternalEnergy;
   using EosBase<UnitSystem<T>>::GruneisenParamFromDensityTemperature;
   using EosBase<UnitSystem<T>>::GruneisenParamFromDensityInternalEnergy;
-  using EosBase<UnitSystem<T>>::PTofRE;
   using EosBase<UnitSystem<T>>::FillEos;
 
   using BaseType = T;

--- a/singularity-eos/eos/modifiers/relativistic_eos.hpp
+++ b/singularity-eos/eos/modifiers/relativistic_eos.hpp
@@ -55,7 +55,6 @@ class RelativisticEOS : public EosBase<RelativisticEOS<T>> {
   using EosBase<RelativisticEOS<T>>::BulkModulusFromDensityInternalEnergy;
   using EosBase<RelativisticEOS<T>>::GruneisenParamFromDensityTemperature;
   using EosBase<RelativisticEOS<T>>::GruneisenParamFromDensityInternalEnergy;
-  using EosBase<RelativisticEOS<T>>::PTofRE;
   using EosBase<RelativisticEOS<T>>::FillEos;
 
   using BaseType = T;

--- a/singularity-eos/eos/modifiers/scaled_eos.hpp
+++ b/singularity-eos/eos/modifiers/scaled_eos.hpp
@@ -55,7 +55,6 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
   using EosBase<ScaledEOS<T>>::BulkModulusFromDensityInternalEnergy;
   using EosBase<ScaledEOS<T>>::GruneisenParamFromDensityTemperature;
   using EosBase<ScaledEOS<T>>::GruneisenParamFromDensityInternalEnergy;
-  using EosBase<ScaledEOS<T>>::PTofRE;
   using EosBase<ScaledEOS<T>>::FillEos;
 
   using BaseType = T;

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -55,7 +55,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
   using EosBase<ShiftedEOS<T>>::BulkModulusFromDensityInternalEnergy;
   using EosBase<ShiftedEOS<T>>::GruneisenParamFromDensityTemperature;
   using EosBase<ShiftedEOS<T>>::GruneisenParamFromDensityInternalEnergy;
-  using EosBase<ShiftedEOS<T>>::PTofRE;
   using EosBase<ShiftedEOS<T>>::FillEos;
 
   using BaseType = T;


### PR DESCRIPTION
… node.

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
As discussed with @Yurlungur, this function was the sole reason for very excessive GPU compile times. The singular place it was used was replaced with an equivalent functionality. It does not appear to be used anywhere else. 

This PR removes `PTofRE` function. I'd like to hear from folks downstream, @jdolence @jhp-lanl do you foresee issues with the removal of this function to downstream use cases and/or future use cases (PT table equivalent for example @jhp-lanl?)

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [x] If preparing for a new release, update the version in cmake.
