### PR TITLE
Draft: mess with cmake until submodule build works downstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,14 +110,6 @@ option(SINGULARITY_PATCH_MPARK_VARIANT
 # singularity-eos Library
 # ------------------------------------------------------------------------------#
 
-include(singularity-eos/mpark_variant)
-include(singularity-eos/Eigen3)
-include(singularity-eos/eospac)
-include(singularity-eos/hdf5)
-include(singularity-eos/kokkos)
-include(singularity-eos/spiner)
-include(singularity-eos/ports-of-call)
-
 add_library(singularity-eos)
 add_library(singularity-eos::singularity-eos ALIAS singularity-eos)
 
@@ -162,6 +154,16 @@ endif()
 if(SINGULARITY_FORCE_SUBMODULE_MODE)
   message(STATUS "Building as though project was a submodule.")
   set(SINGULARITY_SUBMODULE_MODE ON)
+endif()
+
+if (NOT SINGULARITY_SUBMODULE_MODE)
+  include(singularity-eos/mpark_variant)
+  include(singularity-eos/Eigen3)
+  include(singularity-eos/eospac)
+  include(singularity-eos/hdf5)
+  include(singularity-eos/kokkos)
+  include(singularity-eos/spiner)
+  include(singularity-eos/ports-of-call)
 endif()
 
 # Use to determine if Eigen is used or not
@@ -261,12 +263,16 @@ endif()
 if(SINGULARITY_SUBMODULE_MODE)
   # add all submodules
   message(STATUS "singularity-eos configuring in submodule mode.")
+  include(cmake/singularity-eos/mpark_variant.cmake)
+  include(cmake/singularity-eos/ports-of-call.cmake)
   singularity_import_mpark_variant()
   singularity_import_ports_of_call()
   if(SINGULARITY_USE_SPINER)
+    include(cmake/singularity-eos/spiner.cmake)
     singularity_import_spiner()
   endif()
   if(SINGULARITY_USE_KOKKOS)
+    include(cmake/singularity-eos/kokkos.cmake)
     singularity_import_kokkos()
     if(SINGULARITY_USE_KOKKOSKERNELS)
       singularity_import_kokkoskernels()
@@ -274,6 +280,7 @@ if(SINGULARITY_SUBMODULE_MODE)
   endif()
 
   if(SINGULARITY_USE_EIGEN)
+    include(cmake/singularity-eos/Eigen3.cmake)
     singularity_import_eigen()
   endif()
 else()


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Tried to use singularity-eos in a downstream code as a submodule and the cmake seems broken.  Here, I just hacked at it until I got it to work.  Haven't tested basically anything, but I am at least building successfully now.

I'm not the right person to fix this properly, but I wanted to bring it to somebody's attention.  @mauneyc-LANL @jonahm-LANL @Yurlungur 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
