### PR TITLE
Simplify logic for defining the nowarn macro.

### DIFF
--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -41,13 +41,17 @@ using namespace eos_base;
 
 // Only really works in serial
 // Not really supported on device
-#ifndef PORTABILITY_STRATEGY_NONE
+
+// SG_PIF_NOWARN
+// this pragma disables host-device warnings when cuda enabled
 #if defined(__CUDACC__)
 #define SG_PIF_NOWARN #pragma nv_exec_check_disable
 #endif // __CUDACC__
-#else
+
+// force this macro to be defined regardless of complexity of logic above
+#ifndef SG_PIF_NOWARN
 #define SG_PIF_NOWARN
-#endif // PORTABILITY_STRATEGY_NONE
+#endif // !defind SG_PIF_NOWARN
 
 class EOSPAC : public EosBase<EOSPAC> {
  public:


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I am unable to install singularity-eos from spack. This may be a combination of new ports-of-call and overly complicated logic for defining the SG_PIF_NOWARN macro. This simplifies that preprocessor logic that I believe was overly complex. 

If this passes tests, I think we should merge it quickly @Yurlungur @jhp-lanl @rbberger 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [x] If preparing for a new release, update the version in cmake.
