### PR TITLE
Add a generic evaluator function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [[PR232]](https://github.com/lanl/singularity-eos/pull/228) Fixed uninitialized cmake path variables
 
 ### Added (new features/APIs/variables/...)
+- [[PR306]](https://github.com/lanl/singularity-eos/pull/306) Added generic Evaluate method
 - [[PR304]](https://github.com/lanl/singularity-eos/pull/304) added a Newton-Raphson root find for use with the Helmholtz EoS
 - [[PR265]](https://github.com/lanl/singularity-eos/pull/265) Add missing UnitSystem modifier combinations to variant and EOSPAC
 - [[PR279]](https://github.com/lanl/singularity-eos/pull/279) added noble-abel EoS

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -248,6 +248,13 @@ desired use-case.
   support templates, and the ``operator()`` call must be
   templated.
 
+.. warning::
+
+  It can be dangerous to use functors with side-effects. Especially
+  with GPUs it can produce very unintuitive behaviour. We recommend
+  you only make the ``operator()`` non-const if you really know what
+  you're doing.
+
 To see the utlity of the ``Evaluate`` function, it's probably just
 easiest to provide an example. The following code evaluates the EOS on
 device and compares against a tabulated pressure. The total difference

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -35,6 +35,10 @@ conditions. The type of parallelism used depends on how
 ``singularity-eos`` is compiled. If the ``Kokkos`` backend is used,
 any parallel dispatch supported by ``Kokkos`` is supported.
 
+A more generic version of the vector calls exists in the ``Evaluate``
+method, which allows the user to specify arbitrary parallel dispatch
+models by writing their own loops. See the relevant section below.
+
 .. _variant section:
 
 Variants

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -216,6 +216,92 @@ available member function.
    eos.TemperatureFromDensityInternalEnergy(density.data(), energy.data(), temperature.data(),
                                             scratch.data(), density.size());
 
+The Evaluate Method
+~~~~~~~~~~~~~~~~~~~
+
+A special call related to the vector calls is the ``Evaluate``
+method. The ``Evaluate`` method requests the EOS object to evaluate
+almost arbitrary code, but in a way where the type of the underlying
+EOS object is resolved *before* this arbitrary code is evaluated. This
+means the code required to resolve the type of the variant is only
+executed *once* per ``Evaluate`` call. This can enable composite EOS
+calls, non-standard vector calls, and vector calls with non-standard
+loop structure.
+
+The ``Evaluate`` call has the signature
+
+.. code-block:: cpp
+
+  template<typename Functor_t>
+  PORTABLE_INLINE_FUNCTION
+  void Evaluate(Functor_t f);
+
+where a ``Functor_t`` is a class that *must* provide a ``void
+operator() const`` method templated on EOS type. ``Evaluate`` is decorated
+so that it may be evaluated on either host or device, depending on
+desired use-case.
+
+.. note::
+
+  Note that for C++ versions less than C++20, the functor must be
+  defined as a class. Anonymous functions won't do, as they do not
+  support templates, and the ``operator()`` call must be
+  templated.
+
+To see the utlity of the ``Evaluate`` function, it's probably just
+easiest to provide an example. The following code evaluates the EOS on
+device and compares against a tabulated pressure. The total difference
+is summed using the ``Kokkos::parallel_reduce`` functionality in the
+``Kokkos`` performance portability library.
+
+.. code-block:: cpp
+
+  // The functor we use is defined here.
+  // This class definition needs to be of appropriately global scope.
+  class CheckPofRE {
+   public:
+    CheckPofRE(Real *P, Real *rho, Real *sie, int N) : P_(P), rho_(rho), sie_(sie), N_(N) {}
+    template <typename T>
+    // this is a host-only call, but if you wanted to write
+    // a function that you wanted to evaluate on device
+    // you could add the
+    // PORTABLE_INLINE_FUNCTION
+    // decorator here.
+    void operator()(const T &eos) const {
+      Real *P = P_; // gets around warnings regarding capture of "this" pointer
+      Real *rho = rho_;
+      Real *sie = sie_;
+      Kokkos::parallel_reduce(
+          "MyCheckPofRE", N_,
+          KOKKOS_LAMBDA(const int i, Real &diff) {
+            diff += std::abs(P[i] - eos.PressureFromDensityInternalEnergy(rho[i], sie[i]));
+          },
+          tot_diff);
+      std::cout << "Total difference = " << tot_diff << std::endl;
+    }
+  
+   private:
+    int N_;
+    Real *P_;
+    Real *rho_;
+    Real *sie_;
+  };
+
+  // Here we construct our functor
+  // it is assumed the pointers to device memory P, rho, sie, are defined elsewhere.
+  CheckPofRE my_op(P, rho, sie, N);
+
+  // Here we call the evaluate function
+  eos.Evaluate(my_op);
+
+  // The above two lines could have been called "in-one" with:
+  // eos.Evaluate(CheckPofRE(P, rho, sie, N));
+
+This is not functionality that would be available with the standard
+vector calls provided by ``singularity-eos``, at least not without
+chaining multiple parallel dispatch calls. Here we can do it in a
+single call.
+
 Lambdas and Optional Parameters
 --------------------------------
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -244,7 +244,8 @@ function with an `auto` argument as the input, e.g.,
 
 .. code-block::
 
-   eos.Evaluate([=](auto eos) { /* my code snippet */ });
+   // equivalent to [=], but with device markings
+   eos.Evaluate(PORTABLE_LAMBDA(auto eos) { /* my code snippet */ });
 
 .. warning::
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -278,6 +278,9 @@ is summed using the ``Kokkos::parallel_reduce`` functionality in the
       Real *P = P_; // gets around warnings regarding capture of "this" pointer
       Real *rho = rho_;
       Real *sie = sie_;
+      // reduction target
+      Real tot_diff;
+      // reduction op
       Kokkos::parallel_reduce(
           "MyCheckPofRE", N_,
           KOKKOS_LAMBDA(const int i, Real &diff) {

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -275,16 +275,13 @@ is summed using the ``Kokkos::parallel_reduce`` functionality in the
     // PORTABLE_INLINE_FUNCTION
     // decorator here.
     void operator()(const T &eos) const {
-      Real *P = P_; // gets around warnings regarding capture of "this" pointer
-      Real *rho = rho_;
-      Real *sie = sie_;
       // reduction target
       Real tot_diff;
       // reduction op
       Kokkos::parallel_reduce(
           "MyCheckPofRE", N_,
           KOKKOS_LAMBDA(const int i, Real &diff) {
-            diff += std::abs(P[i] - eos.PressureFromDensityInternalEnergy(rho[i], sie[i]));
+            diff += std::abs(P_[i] - eos.PressureFromDensityInternalEnergy(rho_[i], sie_[i]));
           },
           tot_diff);
       std::cout << "Total difference = " << tot_diff << std::endl;

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -130,7 +130,7 @@ class EosBase {
 
   // Generic evaluator
   template <typename Functor_t>
-  PORTABLE_INLINE_FUNCTION void Evaluate(const Functor_t &f) const {
+  PORTABLE_INLINE_FUNCTION void Evaluate(Functor_t &f) const {
     CRTP copy = *(static_cast<CRTP const *>(this));
     f(copy);
   }

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -130,8 +130,7 @@ class EosBase {
 
   // Generic evaluator
   template <typename Functor_t>
-  PORTABLE_INLINE_FUNCTION
-  void Evaluate(const Functor_t &f) const {
+  PORTABLE_INLINE_FUNCTION void Evaluate(const Functor_t &f) const {
     CRTP copy = *(static_cast<CRTP const *>(this));
     f(copy);
   }

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -129,21 +129,8 @@ class EosBase {
       : std::is_same<std::remove_reference_t<std::remove_cv_t<T>>, R *> {};
 
   // Generic evaluator
-  // JMM: These macros disable checks that the functor called by evaluate
-  // is __host__ __device__
-  // This is desirable, because you may want to call device-side batched
-  // evaluations (or inner loop dispatch with hierarchical parallelism)
-  // or you may want to call Evaluate from the host to, e.g., launch
-  // a reduction operation or somesuch.
-  // Note that this is a little dangerous as the compiler won't tell you
-  // if you messed up and ACTUALLY called a host-side function from
-  // device. The code will just segfault.
-#if defined(__CUDACC__)
-#pragma nv_exec_check_disable
-#pragma hd_warning_disable
-#endif // __CUDACC__
   template <typename Functor_t>
-  PORTABLE_INLINE_FUNCTION void Evaluate(Functor_t &f) const {
+  constexpr void Evaluate(Functor_t &f) const {
     CRTP copy = *(static_cast<CRTP const *>(this));
     f(copy);
   }

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -128,6 +128,14 @@ class EosBase {
   struct is_raw_pointer
       : std::is_same<std::remove_reference_t<std::remove_cv_t<T>>, R *> {};
 
+  // Generic evaluator
+  template <typename Functor_t>
+  PORTABLE_INLINE_FUNCTION
+  void Evaluate(const Functor_t &f) const {
+    CRTP copy = *(static_cast<CRTP const *>(this));
+    f(copy);
+  }
+
   // Vector member functions
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -73,7 +73,7 @@ class Variant {
 
   // Place member functions here
   template <typename Functor_t>
-  PORTABLE_INLINE_FUNCTION void Evaluate(const Functor_t &f) const {
+  PORTABLE_INLINE_FUNCTION void Evaluate(Functor_t &f) const {
     return mpark::visit([&f](const auto &eos) { return eos.Evaluate(f); }, eos_);
   }
 

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -73,7 +73,7 @@ class Variant {
 
   // Place member functions here
   template <typename Functor_t>
-  PORTABLE_INLINE_FUNCTION void Evaluate(Functor_t &f) const {
+  constexpr void Evaluate(Functor_t &f) const {
     return mpark::visit([&f](const auto &eos) { return eos.Evaluate(f); }, eos_);
   }
 

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -73,13 +73,8 @@ class Variant {
 
   // Place member functions here
   template <typename Functor_t>
-  PORTABLE_INLINE_FUNCTION
-  void Evaluate(const Functor_t &f) const {
-    return mpark::visit(
-      [&f](const auto &eos) {
-        return eos.Evaluate(f);
-      },
-      eos_);
+  PORTABLE_INLINE_FUNCTION void Evaluate(const Functor_t &f) const {
+    return mpark::visit([&f](const auto &eos) { return eos.Evaluate(f); }, eos_);
   }
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -72,6 +72,16 @@ class Variant {
   }
 
   // Place member functions here
+  template <typename Functor_t>
+  PORTABLE_INLINE_FUNCTION
+  void Evaluate(const Functor_t &f) const {
+    return mpark::visit(
+      [&f](const auto &eos) {
+        return eos.Evaluate(f);
+      },
+      eos_);
+  }
+
   PORTABLE_INLINE_FUNCTION
   Real TemperatureFromDensityInternalEnergy(const Real rho, const Real sie,
                                             Real *lambda = nullptr) const {

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -518,11 +518,14 @@ class CheckPofRE {
   template <typename T>
   PORTABLE_FUNCTION
   void operator()(const T &eos) {
+    int *P = P_;
+    int *rho = rho_;
+    int *sie = sie_;
     portableReduce(
         "MyCheckPofRE", 0, N_,
         PORTABLE_LAMBDA(const int i, int &nw) {
           nw += !(isClose(
-              P_[i], eos.PressureFromDensityInternalEnergy(rho_[i], sie_[i], nullptr),
+              P[i], eos.PressureFromDensityInternalEnergy(rho[i], sie[i], nullptr),
               1e-15));
         },
         nwrong);

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -513,10 +513,8 @@ SCENARIO("Ideal gas entropy", "[IdealGas][Entropy]") {
 class CheckPofRE {
  public:
   CheckPofRE(Real *P, Real *rho, Real *sie, int N) : P_(P), rho_(rho), sie_(sie), N_(N) {}
-#pragma nv_exec_check_disable
-#pragma hd_warning_disable
   template <typename T>
-  PORTABLE_FUNCTION void operator()(const T &eos) {
+  void operator()(const T &eos) {
     Real *P = P_;
     Real *rho = rho_;
     Real *sie = sie_;

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -516,17 +516,16 @@ class CheckPofRE {
 #pragma nv_exec_check_disable
 #pragma hd_warning_disable
   template <typename T>
-  PORTABLE_FUNCTION
-  void operator()(const T &eos) {
+  PORTABLE_FUNCTION void operator()(const T &eos) {
     Real *P = P_;
     Real *rho = rho_;
     Real *sie = sie_;
     portableReduce(
         "MyCheckPofRE", 0, N_,
         PORTABLE_LAMBDA(const int i, int &nw) {
-          nw += !(isClose(
-              P[i], eos.PressureFromDensityInternalEnergy(rho[i], sie[i], nullptr),
-              1e-15));
+          nw += !(isClose(P[i],
+                          eos.PressureFromDensityInternalEnergy(rho[i], sie[i], nullptr),
+                          1e-15));
         },
         nwrong);
   }

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -518,9 +518,9 @@ class CheckPofRE {
   template <typename T>
   PORTABLE_FUNCTION
   void operator()(const T &eos) {
-    int *P = P_;
-    int *rho = rho_;
-    int *sie = sie_;
+    Real *P = P_;
+    Real *rho = rho_;
+    Real *sie = sie_;
     portableReduce(
         "MyCheckPofRE", 0, N_,
         PORTABLE_LAMBDA(const int i, int &nw) {

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -518,9 +518,9 @@ class CheckPofRE {
     portableReduce(
         "MyCheckPofRE", 0, N_,
         PORTABLE_LAMBDA(const int i, int &nw) {
-          nw += !(isClose(P_[i],
-                          eos.PressureFromDensityInternalEnergy(rho_[i], sie_[i], nullptr),
-                          1e-15));
+          nw += !(isClose(
+              P_[i], eos.PressureFromDensityInternalEnergy(rho_[i], sie_[i], nullptr),
+              1e-15));
         },
         nwrong);
   }

--- a/test/test_eos_unit.cpp
+++ b/test/test_eos_unit.cpp
@@ -513,7 +513,10 @@ SCENARIO("Ideal gas entropy", "[IdealGas][Entropy]") {
 class CheckPofRE {
  public:
   CheckPofRE(Real *P, Real *rho, Real *sie, int N) : P_(P), rho_(rho), sie_(sie), N_(N) {}
+#pragma nv_exec_check_disable
+#pragma hd_warning_disable
   template <typename T>
+  PORTABLE_FUNCTION
   void operator()(const T &eos) {
     portableReduce(
         "MyCheckPofRE", 0, N_,


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
As discussed with @Yurlungur...

This is a tiny PR that adds a fair bit more flexibility to how downstream codes interact with singularity-eos.  The new functionality is a new `Evaluate` template function for both `EosBase` and `Variant` that can take in a downstream-defined functor and evaluate it with the underlying eos object.  This allows one to, for example, express a parallel loop that calls several EOS functions at once in the downstream code, and then have singularity execute that parallel loop with one of the basic EOSs (as opposed to having to visit the variant in every call).

The current vector interface is quite constraining.  For example, if you're running on GPU, it assumes you're calling from the host and that you want to launch a new kernel to make the eos call.  In our downstream code, we use hierarchical parallelism where what we really want is to have an inner loop inside our kernel that calls the EOSs.  This new feature allows us to write our inner loop as we do all our other inner loops, pass it in to singularity, and have it execute as we expressed but using the CRTP stuff to avoid many calls to `mpark::visit`.

I think the python interface requires something like the existing vector interface, otherwise I would argue that this is much more flexible and may be preferred in general for interfacing with downstream codes.  The only downside is that it requires the downstream code to write a functor (or some number of functors to capture all the EOS calling patterns).

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
