### PR TITLE
Place fortran modules in unique directory, copy dir on install into c…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,10 +376,6 @@ foreach(_header ${EOS_HEADERS})
   list(APPEND _headers singularity-eos/${_header})
 endforeach()
 
-foreach(_mod ${EOS_MODS})
-  list(APPEND _install_mods ${CMAKE_CURRENT_BINARY_DIR}/${_mod})
-endforeach()
-
 foreach(_src ${EOS_SRCS})
   list(APPEND _srcs singularity-eos/${_src})
 endforeach()
@@ -389,9 +385,9 @@ target_sources(singularity-eos PRIVATE ${_srcs} ${_headers})
 # make sure .mods are placed in build path, and installed along with includes
 if(SINGULARITY_USE_FORTRAN)
   set_target_properties(singularity-eos PROPERTIES Fortran_MODULE_DIRECTORY
-                                                   ${CMAKE_CURRENT_BINARY_DIR})
+                                                   ${CMAKE_CURRENT_BINARY_DIR}/fortran)
   target_include_directories(
-    singularity-eos INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    singularity-eos INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/fortran>
                               $<INSTALL_INTERFACE:include/singularity-eos/eos>)
   set_target_properties(singularity-eos PROPERTIES Fortran_PREPROCESS ON)
 endif() # SINGULARITY_USE_FORTRAN

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -77,9 +77,10 @@ foreach(file ${_install_headers})
 endforeach() # file
 
 # install the fortran modules NB: cmake doesn't provide a clean way to handle
-# mods
-install(FILES ${_install_mods}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/singularity-eos/eos)
+if(SINGULARITY_USE_FORTRAN)
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fortran/
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/singularity-eos/eos)
+endif()
 
 # ----------------------------------------------------------------------------#
 # local export

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -72,11 +72,8 @@ if (SINGULARITY_USE_FORTRAN)
   list(APPEND EOS_SRCS eos/singularity_eos.f90)
   list(APPEND EOS_SRCS eos/singularity_eos.cpp)
   list(APPEND EOS_HEADERS eos/singularity_eos.hpp)
-  # would rather handle this more robustly, being sloppy for now
-  list(APPEND EOS_MODS singularity_eos.mod singularity_eos_types.mod)
 endif()
 
 # export to parent scope
 set(EOS_HEADERS ${EOS_HEADERS} PARENT_SCOPE)
 set(EOS_SRCS ${EOS_SRCS} PARENT_SCOPE)
-set(EOS_MODS ${EOS_MODS} PARENT_SCOPE)


### PR DESCRIPTION
…orrect install dir. No longer need to know module names a priori.

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This PR makes the installation of fortran modules more robust in that module naming conventions need not be known. This is an issues on cray machines under certain conditions. This will serve as a template for how to handle this in related projects. 

@rbberger @mauneyc-LANL 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file
- [x] If preparing for a new release, update the version in cmake.
