### PR TITLE
Add error check after 'eosCreateTables()' in the 'eosSafeLoad()' function

### DIFF
--- a/eospac-wrapper/eospac_wrapper.cpp
+++ b/eospac-wrapper/eospac_wrapper.cpp
@@ -77,24 +77,26 @@ void eosGetMetadata(int matid, SesameMetadata &metadata, Verbosity eospacWarn) {
   EOS_INTEGER errorCode =
       eosSafeLoad(1, matid, commentsType, commentsHandle, {"EOS_Comments"}, eospacWarn);
   EOS_INTEGER eospacComments = commentsHandle[0];
+  bool commentTableCreated = (errorCode == EOS_OK);
 
-  if (errorCode == EOS_OK) {
-    std::vector<EOS_CHAR> comments;
-    EOS_REAL commentLen;
+  EOS_REAL commentLen = -1;
+  if (commentTableCreated) {
     EOS_INTEGER commentItem = EOS_Cmnt_Len;
     eosSafeTableInfo(commentsHandle, 1, &commentItem, &commentLen, eospacWarn);
+  }
 
+  if (commentLen > 0) {
+    std::vector<EOS_CHAR> comments;
     comments.resize(static_cast<int>(commentLen));
     metadata.comments.resize(comments.size());
 
-    if (comments.size() > 0)
+    if (comments.size() > 0) {
       eosSafeTableCmnts(&eospacComments, comments.data(), eospacWarn);
+    }
     for (size_t i = 0; i < comments.size(); i++) {
       metadata.comments[i] = comments[i];
     }
     metadata.name = getName(metadata.comments);
-
-    eosSafeDestroy(1, commentsHandle, eospacWarn);
   } else {
     std::string matid_str = std::to_string(matid);
     if (eospacWarn != Verbosity::Quiet) {
@@ -103,6 +105,12 @@ void eosGetMetadata(int matid, SesameMetadata &metadata, Verbosity eospacWarn) {
     }
     metadata.name = "No name for matid " + matid_str;
     metadata.comments = "Comment unavailable for matid " + matid_str;
+  }
+
+  // Note: table could be created even if the commentLen is nonsense, so we
+  // need to separate this block from the above logic
+  if (commentTableCreated) {
+    eosSafeDestroy(1, commentsHandle, eospacWarn);
   }
 }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Fixes a bug when the comment table wasn't available. The `eosCreateTables()` function would return an error code, but the code wouldn't be handled. This change adds an early return to skip the `eosLoadTables()` call if `eosCreateTables()` fails.

EDIT - An additional check was needed for when the comment table is created but when the error code returned is okay. The comments table could still be invalid and so the length needs to be checked before trying to extract comments.

I _think_ this should help address a bug found by @annapiegra where a comments table length would be negative when a comments table didn't exist, and would cause issues for the comments vector later on when the `resize()` member is called.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file
- [ ] If preparing for a new release, update the version in cmake.
