### PR TITLE
Spackage with Plugin support

### DIFF
--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -5,7 +5,25 @@
 
 import os
 
+from spack.error import SpackError
 from spack.package import *
+from spack.directives import directive
+
+
+@directive("singularity_eos_plugins")
+def singularity_eos_plugin(name, path):
+    def _execute_register(pkg):
+        pkg.plugins[name] = path
+
+    return _execute_register
+
+
+def plugin_validator(pkg_name, variant_name, values):
+    if values == ("none",):
+        return
+    for v in values:
+        if v not in SingularityEos.plugins:
+            raise SpackError(f"Unknown Singularity-EOS plugin '{v}'")
 
 
 class SingularityEos(CMakePackage, CudaPackage):
@@ -62,6 +80,19 @@ class SingularityEos(CMakePackage, CudaPackage):
     variant("spiner", default=True, description="Use Spiner")
 
     variant("closure", default=True, description="Build closure module")
+
+    plugins = {}
+
+    singularity_eos_plugin("dust", "example/plugin")
+
+    variant(
+        "plugins",
+        multi=True,
+        default="none",
+        validator=plugin_validator,
+        description="list of plugins to build",
+    )
+    variant("variant", default="default", description="include path used for variant header")
 
     # building/testing/docs
     depends_on("cmake@3.19:")
@@ -182,6 +213,15 @@ class SingularityEos(CMakePackage, CudaPackage):
             self.define("SINGULARITY_USE_HDF5", "^hdf5" in self.spec),
             self.define("SINGULARITY_USE_EOSPAC", "^eospac" in self.spec),
         ]
+
+        if "none" not in self.spec.variants["plugins"].value:
+            pdirs = []
+            for p in self.spec.variants["plugins"].value:
+                pdirs.append(join_path(self.stage.source_path, self.plugins[p]))
+            args.append(self.define("SINGULARITY_PLUGINS", ";".join(pdirs)))
+
+        if self.spec.variants["variant"].value != "default":
+            args.append(self.define_from_variant("SINGULARITY_VARIANT", "variant"))
 
         #TODO: do we need this?
         if "+kokkos+cuda" in self.spec:

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -91,8 +91,9 @@ class SingularityEos(CMakePackage, CudaPackage):
         default="none",
         validator=plugin_validator,
         description="list of plugins to build",
+        when="@main"
     )
-    variant("variant", default="default", description="include path used for variant header")
+    variant("variant", default="default", description="include path used for variant header", when="@main")
 
     # building/testing/docs
     depends_on("cmake@3.19:")
@@ -214,12 +215,13 @@ class SingularityEos(CMakePackage, CudaPackage):
             self.define("SINGULARITY_USE_EOSPAC", "^eospac" in self.spec),
         ]
 
-        if "none" not in self.spec.variants["plugins"].value:
-            pdirs = [join_path(self.stage.source_path, self.plugins[p]) for p in self.spec.variants["plugins"].value]
-            args.append(self.define("SINGULARITY_PLUGINS", ";".join(pdirs)))
+        if self.spec.satisfies("@main"):
+            if "none" not in self.spec.variants["plugins"].value:
+                pdirs = [join_path(self.stage.source_path, self.plugins[p]) for p in self.spec.variants["plugins"].value]
+                args.append(self.define("SINGULARITY_PLUGINS", ";".join(pdirs)))
 
-        if self.spec.variants["variant"].value != "default":
-            args.append(self.define_from_variant("SINGULARITY_VARIANT", "variant"))
+            if self.spec.variants["variant"].value != "default":
+                args.append(self.define_from_variant("SINGULARITY_VARIANT", "variant"))
 
         #TODO: do we need this?
         if "+kokkos+cuda" in self.spec:

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -215,9 +215,7 @@ class SingularityEos(CMakePackage, CudaPackage):
         ]
 
         if "none" not in self.spec.variants["plugins"].value:
-            pdirs = []
-            for p in self.spec.variants["plugins"].value:
-                pdirs.append(join_path(self.stage.source_path, self.plugins[p]))
+            pdirs = [join_path(self.stage.source_path, self.plugins[p]) for p in self.spec.variants["plugins"].value]
             args.append(self.define("SINGULARITY_PLUGINS", ";".join(pdirs)))
 
         if self.spec.variants["variant"].value != "default":

--- a/spack-repo/repo.yaml
+++ b/spack-repo/repo.yaml
@@ -3,4 +3,4 @@
 # ###
 
 repo:
-  namespace: singularity-eos
+  namespace: singularity_eos


### PR DESCRIPTION
## PR Summary

This updates the Singularity-EOS spackage to support plugins. It introduces a new directive `singularity_eos_plugin` which is used to register a plugin with a relative plugin path. While convenient, we still have to see if spack upstream would accept such a spackage change.

The `plugins` variant can then choose one or more of these plugins to be used. Unknown plugin names will result in an error.

`variant` can be used to set the variant header location.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
