### PR TITLE
move the singularity_eos cpp files back into the fortran build only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   GIT_SUBMODULE_STRATEGY: normal
   SINGULARITY_GOLDFILES_VERSION: "goldfiles-1.8.0"
   SINGULARITY_EOS_GCC_VERSION: "10.3.0"
-  SINGULARITY_EOS_OPENMPI_VERSION: "4.1.3"
+  SINGULARITY_EOS_OPENMPI_VERSION: "4.1.1"
   SINGULARITY_EOS_CUDA_VERSION: "11.6.0"
   SINGULARITY_EOS_BUILD_TYPE: "RelWithDebInfo"
   SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+spiner+hdf5+python+tests%gcc@${SINGULARITY_EOS_GCC_VERSION} ^openmpi@${SINGULARITY_EOS_OPENMPI_VERSION}"
@@ -37,29 +37,6 @@ default:
   id_tokens:
     SITE_ID_TOKEN:
       aud: https://asc-git.lanl.gov
-  before_script:
-    - echo "Running on $(hostname)"
-    - section() { echo $'\e[0K'"section_$1:$(date +%s):$2"$'\r\e[0K'"${3+${COLOR_CYAN}$3${COLOR_PLAIN}}"; }
-    - export PYTHONNOUSERSITE=1
-    - export SPACK_DISABLE_LOCAL_CONFIG=true
-    - export SPACK_USER_CACHE_PATH=${SPACK_USER_CACHE_PATH:-/tmp/spack-local}
-    - export DEVEL_SPACK_CHECKOUT=${DEVEL_SPACK_CHECKOUT:-/tmp/spack}
-    - export SINGULARITY_EOS_SPACK_DIR=${SINGULARITY_EOS_TEMP_SPACK_DIR:=$XCAP_OSS_SPACK_DIR}
-    - section start "spack_init[collapsed=true]" "Creating Spack instance at ${DEVEL_SPACK_CHECKOUT}"
-    - echo "Upstream ${SINGULARITY_EOS_SPACK_DIR}"
-    - |
-      rsync -rpl \
-          --exclude=".git" \
-          --exclude="etc/spack/repos.yaml" \
-          --exclude="etc/spack/packages.yaml" \
-          --include="etc/spack/**" \
-          --include="lib/spack/**" \
-          --exclude-from=${SINGULARITY_EOS_SPACK_DIR}/.gitignore \
-          ${SINGULARITY_EOS_SPACK_DIR}/ ${DEVEL_SPACK_CHECKOUT}/
-    - source ${DEVEL_SPACK_CHECKOUT}/share/spack/setup-env.sh
-    - spack --version
-    - spack compiler list
-    - section end spack_init
 
 ##########################
 # Build Matrix Variables #
@@ -104,7 +81,7 @@ default:
     CLUSTER: rocinante
     SINGULARITY_EOS_GCC_VERSION: "12.2.0"
     SINGULARITY_EOS_SPACK_SPEC: "singularity-eos@main+mpi+spiner+hdf5+python+tests%gcc@${SINGULARITY_EOS_GCC_VERSION} ^cray-mpich"
-    SCHEDULER_PARAMETERS: "-N 1 -t 30 -A asc-ci --partition=ci --qos=ci --reservation=ci"
+    SCHEDULER_PARAMETERS: "--nodes=1 --time 2:00:00 -L none@slurmdb --account=asc-ci --qos=ci --reservation=ci --partition=ci"
 
 .skylake: &skylake
   SCHEDULER_PARAMETERS: "--nodes=1 -p skylake-gold,skylake-platinum"
@@ -131,6 +108,29 @@ default:
 
 .test:
   stage: build_n_test
+  before_script:
+    - echo "Running on $(hostname)"
+    - section() { echo $'\e[0K'"section_$1:$(date +%s):$2"$'\r\e[0K'"${3+${COLOR_CYAN}$3${COLOR_PLAIN}}"; }
+    - export PYTHONNOUSERSITE=1
+    - export SPACK_DISABLE_LOCAL_CONFIG=true
+    - export SPACK_USER_CACHE_PATH=${SPACK_USER_CACHE_PATH:-/tmp/spack-local}
+    - export DEVEL_SPACK_CHECKOUT=${DEVEL_SPACK_CHECKOUT:-/tmp/spack}
+    - export SINGULARITY_EOS_SPACK_DIR=${SINGULARITY_EOS_TEMP_SPACK_DIR:=$XCAP_OSS_SPACK_DIR}
+    - section start "spack_init[collapsed=true]" "Creating Spack instance at ${DEVEL_SPACK_CHECKOUT}"
+    - echo "Upstream ${SINGULARITY_EOS_SPACK_DIR}"
+    - |
+      rsync -rpl \
+          --exclude=".git" \
+          --exclude="etc/spack/repos.yaml" \
+          --exclude="etc/spack/packages.yaml" \
+          --include="etc/spack/**" \
+          --include="lib/spack/**" \
+          --exclude-from=${SINGULARITY_EOS_SPACK_DIR}/.gitignore \
+          ${SINGULARITY_EOS_SPACK_DIR}/ ${DEVEL_SPACK_CHECKOUT}/
+    - source ${DEVEL_SPACK_CHECKOUT}/share/spack/setup-env.sh
+    - spack --version
+    - spack compiler list
+    - section end spack_init
   script:
     - |
       if [[ "${CLUSTER}" = "rocinante" ]]; then
@@ -139,6 +139,7 @@ default:
       else
         module load gcc/${SINGULARITY_EOS_GCC_VERSION}
         module load cuda/${SINGULARITY_EOS_CUDA_VERSION}
+        module load openmpi/${SINGULARITY_EOS_OPENMPI_VERSION}-gcc_${SINGULARITY_EOS_GCC_VERSION}
       fi
     - |
       if [[ "${CI_COMMIT_BRANCH}" == "${CI_DEFAULT_BRANCH}" ]];

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,14 +147,6 @@ add_library(singularity-eos::singularity-eos_Interface ALIAS singularity-eos_Int
 target_link_libraries(singularity-eos_Interface INTERFACE singularity-eos_Common)
 target_link_libraries(singularity-eos INTERFACE singularity-eos_Interface)
 
-if(SINGULARITY_BUILD_CLOSURE)
-  add_library(singularity-eos_Library)
-  set_target_properties(singularity-eos_Library PROPERTIES OUTPUT_NAME singularity-eos)
-  add_library(singularity-eos::singularity-eos_Library ALIAS singularity-eos_Library)
-  target_link_libraries(singularity-eos_Library INTERFACE singularity-eos_Common)
-  target_link_libraries(singularity-eos INTERFACE singularity-eos_Library)
-endif()
-
 # ------------------------------------------------------------------------------#
 # Compiler & language setup
 # ------------------------------------------------------------------------------#
@@ -405,11 +397,19 @@ message(VERBOSE "EOS Headers:\n\t${eos_headers}")
 
 if(SINGULARITY_BUILD_CLOSURE)
   get_property(eos_srcs GLOBAL PROPERTY EOS_SRCS)
-  target_sources(singularity-eos_Library PRIVATE ${eos_srcs})
-  message(VERBOSE "EOS Library Sources:\n\t${eos_srcs}")
+
+  if(eos_srcs)
+    add_library(singularity-eos_Library)
+    set_target_properties(singularity-eos_Library PROPERTIES OUTPUT_NAME singularity-eos)
+    add_library(singularity-eos::singularity-eos_Library ALIAS singularity-eos_Library)
+    target_link_libraries(singularity-eos_Library INTERFACE singularity-eos_Common)
+    target_link_libraries(singularity-eos INTERFACE singularity-eos_Library)
+    target_sources(singularity-eos_Library PRIVATE ${eos_srcs})
+    message(VERBOSE "EOS Library Sources:\n\t${eos_srcs}")
+  endif()
 endif()
 
-if(SINGULARITY_USE_FORTRAN)
+if(TARGET singularity-eos_Library AND SINGULARITY_USE_FORTRAN)
   # Turn on preprocessor for fortran files
   set_target_properties(singularity-eos_Library PROPERTIES Fortran_PREPROCESS ON)
   # make sure .mods are placed in build path, and installed along with includes
@@ -482,7 +482,7 @@ target_compile_options(
          > # cuda
 )
 
-if(SINGULARITY_BUILD_CLOSURE)
+if(TARGET singularity-eos_Library)
   target_compile_options(singularity-eos_Library PRIVATE ${xlfix})
   target_link_options(singularity-eos_Library PRIVATE ${xlfix})
 

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -77,7 +77,7 @@ install(
   COMPONENT singularity-eos_Interface
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/singularity-eos)
 
-if(SINGULARITY_BUILD_CLOSURE)
+if(TARGET singularity-eos_Library)
   install(
     TARGETS singularity-eos_Library
     EXPORT singularity-eos_Library
@@ -128,7 +128,7 @@ export(
   FILE ${CMAKE_CURRENT_BINARY_DIR}/singularity-eos_Interface.cmake
   NAMESPACE singularity-eos::)
 
-if(SINGULARITY_BUILD_CLOSURE)
+if(TARGET singularity-eos_Library)
   export(
     EXPORT singularity-eos_Library
     FILE ${CMAKE_CURRENT_BINARY_DIR}/singularity-eos_Library.cmake

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -59,10 +59,12 @@ register_headers(
 
 if (SINGULARITY_BUILD_CLOSURE)
   register_headers(closure/mixed_cell_models.hpp)
-  register_headers(eos/singularity_eos.hpp)
-  register_srcs(eos/singularity_eos.cpp)
   if (SINGULARITY_USE_FORTRAN)
+    # while these are C++ files, they
+    # are only needed for the fortran backend
     register_srcs(eos/get_sg_eos.cpp)
+    register_srcs(eos/singularity_eos.cpp)
+    register_headers(eos/singularity_eos.hpp)
     if (SINGULARITY_USE_KOKKOS)
       register_srcs(
            eos/get_sg_eos_p_t.cpp

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -59,12 +59,14 @@ register_headers(
 
 if (SINGULARITY_BUILD_CLOSURE)
   register_headers(closure/mixed_cell_models.hpp)
-  if (SINGULARITY_USE_FORTRAN)
+  if (SINGULARITY_USE_FORTRAN OR SINGULARITY_BUILD_TESTS)
     # while these are C++ files, they
-    # are only needed for the fortran backend
-    register_srcs(eos/get_sg_eos.cpp)
+    # are only needed for the fortran backend or unit testing
     register_srcs(eos/singularity_eos.cpp)
     register_headers(eos/singularity_eos.hpp)
+  endif()
+  if (SINGULARITY_USE_FORTRAN)
+    register_srcs(eos/get_sg_eos.cpp)
     if (SINGULARITY_USE_KOKKOS)
       register_srcs(
            eos/get_sg_eos_p_t.cpp


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As @dholladay00 commented in PR #348 , the `singularity_eos.{cpp,hpp}` files should only be built when fortran is on to minimize build times for C++ codes. This reverts that change. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
