### PR TITLE
Add lambda thermalq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR#362]](https://github.com/lanl/singularity-eos/pull/362) Add lambda to thermalqs
 - [[PR#339]](https://github.com/lanl/singularity-eos/pull/339) Added COMPONENTS to singularity-eos CMake install, allowing to select a minimal subset needed e.g. for Fortran bindings only
 - [[PR#336]](https://github.com/lanl/singularity-eos/pull/336) Included code and documentation for a full, temperature consistent, Mie-Gruneisen EOS based on a pressure power law expansion in eta = 1-V/V0. PowerMG.
 - [[PR#357]](https://github.com/lanl/singularity-eos/pull/357) Added support for C++17 (e.g., needed when using newer Kokkos).

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -104,21 +104,6 @@ Similarly the method
 prints relevant parameters that the EOS object was created with, such
 as the Gruneisen coefficient and specific heat for an ideal gas model.
 
-If you would like to create your own custom variant with additional
-models (or a subset of models), you may do so by using the
-``eos_variant`` class. For example,
-
-.. code-block:: cpp
-
-  #include <singularity-eos/eos.hpp>
-  using namespace singularity;
-  
-  using MyEOS_t = eos_variant<IdealGas, Gruneisen>;
-
-This will create a new type, ``MyEOS_t`` which contains only the
-``IdealGas`` and ``Gruneisen`` classes. (All of these live under the
-``singularity`` namespace.)
-
 Reference Semantics and ``GetOnDevice``
 -----------------------------------------
 
@@ -488,10 +473,17 @@ currently:
 * ``thermalqs::temperature``
 * ``thermalqs::specific_heat``
 * ``thermalqs::bulk_modulus``
+* ``thermalqs::lambda``
 * ``thermalqs::all_values``
 
 however, most EOS models only specify that they prefer density and
 temperature or density and specific internal energy.
+
+.. note::
+
+   The ``thermalqs::lambda`` flag is a bit special. It specifies that
+   eos-specific operations are to be performed on the additional
+   quantities passed in through the ``lambda`` variable.
 
 .. _eos builder section:
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -104,6 +104,19 @@ Similarly the method
 prints relevant parameters that the EOS object was created with, such
 as the Gruneisen coefficient and specific heat for an ideal gas model.
 
+If you would like to create your own custom variant with additional
+models (or a subset of models), you may do so by using the
+``eos_variant`` class. For example,
+
+.. code-block:: cpp
+  #include <singularity-eos/eos.hpp>
+  using namespace singularity;
+  
+  using MyEOS_t = eos_variant<IdealGas, Gruneisen>;
+This will create a new type, ``MyEOS_t`` which contains only the
+``IdealGas`` and ``Gruneisen`` classes. (All of these live under the
+``singularity`` namespace.)
+
 Reference Semantics and ``GetOnDevice``
 -----------------------------------------
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -109,10 +109,12 @@ models (or a subset of models), you may do so by using the
 ``eos_variant`` class. For example,
 
 .. code-block:: cpp
+
   #include <singularity-eos/eos.hpp>
   using namespace singularity;
   
   using MyEOS_t = eos_variant<IdealGas, Gruneisen>;
+
 This will create a new type, ``MyEOS_t`` which contains only the
 ``IdealGas`` and ``Gruneisen`` classes. (All of these live under the
 ``singularity`` namespace.)

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -488,7 +488,7 @@ currently:
 * ``thermalqs::temperature``
 * ``thermalqs::specific_heat``
 * ``thermalqs::bulk_modulus``
-* ``thermalqs::lambda``
+* ``thermalqs::do_lambda``
 * ``thermalqs::all_values``
 
 however, most EOS models only specify that they prefer density and
@@ -496,7 +496,7 @@ temperature or density and specific internal energy.
 
 .. note::
 
-   The ``thermalqs::lambda`` flag is a bit special. It specifies that
+   The ``thermalqs::do_lambda`` flag is a bit special. It specifies that
    eos-specific operations are to be performed on the additional
    quantities passed in through the ``lambda`` variable.
 

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -141,7 +141,7 @@ PYBIND11_MODULE(singularity_eos, m) {
   thermalqs.attr("temperature") = pybind11::int_(thermalqs::temperature);
   thermalqs.attr("specific_heat") = pybind11::int_(thermalqs::specific_heat);
   thermalqs.attr("bulk_modulus") = pybind11::int_(thermalqs::bulk_modulus);
-  thermalqs.attr("lambda") = pybind11::int_(thermalqs::lambda);
+  thermalqs.attr("do_lambda") = pybind11::int_(thermalqs::do_lambda);
   thermalqs.attr("all_values") = pybind11::int_(thermalqs::all_values);
 
   py::module eos_units = m.def_submodule("eos_units");

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -141,6 +141,7 @@ PYBIND11_MODULE(singularity_eos, m) {
   thermalqs.attr("temperature") = pybind11::int_(thermalqs::temperature);
   thermalqs.attr("specific_heat") = pybind11::int_(thermalqs::specific_heat);
   thermalqs.attr("bulk_modulus") = pybind11::int_(thermalqs::bulk_modulus);
+  thermalqs.attr("lambda") = pybind11::int_(thermalqs::lambda);
   thermalqs.attr("all_values") = pybind11::int_(thermalqs::all_values);
 
   py::module eos_units = m.def_submodule("eos_units");

--- a/singularity-eos/base/constants.hpp
+++ b/singularity-eos/base/constants.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/base/constants.hpp
+++ b/singularity-eos/base/constants.hpp
@@ -27,7 +27,7 @@ constexpr unsigned long pressure = (1 << 2);
 constexpr unsigned long temperature = (1 << 3);
 constexpr unsigned long specific_heat = (1 << 4);
 constexpr unsigned long bulk_modulus = (1 << 5);
-constexpr unsigned long lambda = (1 << 6);
+constexpr unsigned long do_lambda = (1 << 6);
 constexpr unsigned long all_values = (1 << 7) - 1;
 } // namespace thermalqs
 

--- a/singularity-eos/base/constants.hpp
+++ b/singularity-eos/base/constants.hpp
@@ -27,7 +27,8 @@ constexpr unsigned long pressure = (1 << 2);
 constexpr unsigned long temperature = (1 << 3);
 constexpr unsigned long specific_heat = (1 << 4);
 constexpr unsigned long bulk_modulus = (1 << 5);
-constexpr unsigned long all_values = (1 << 6) - 1;
+constexpr unsigned long lambda = (1 << 6);
+constexpr unsigned long all_values = (1 << 7) - 1;
 } // namespace thermalqs
 
 constexpr size_t MAX_NUM_LAMBDAS = 3;

--- a/test/python_bindings.py
+++ b/test/python_bindings.py
@@ -61,7 +61,8 @@ class EOS(unittest.TestCase):
                                                thermalqs.pressure      |
                                                thermalqs.temperature   |
                                                thermalqs.specific_heat |
-                                               thermalqs.bulk_modulus)
+                                               thermalqs.bulk_modulus  |
+                                               thermalqs.lambda)
 
     def testIdealGas(self):
         eos = singularity_eos.IdealGas(1,1)

--- a/test/python_bindings.py
+++ b/test/python_bindings.py
@@ -62,7 +62,7 @@ class EOS(unittest.TestCase):
                                                thermalqs.temperature   |
                                                thermalqs.specific_heat |
                                                thermalqs.bulk_modulus  |
-                                               thermalqs.lambda)
+                                               thermalqs.do_lambda)
 
     def testIdealGas(self):
         eos = singularity_eos.IdealGas(1,1)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As discussed with @dholladay00 and @gopsub , this adds `lambda` to the `thermalq`s list, allowing, on a per-EOS basis, users to request `FillEos` to do something with input lambdas.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
