### PR TITLE
Fix bulk modulus calculation in spiner EOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [[PR#357]](https://github.com/lanl/singularity-eos/pull/357) Added support for C++17 (e.g., needed when using newer Kokkos).
 
 ### Fixed (Repair bugs, etc)
+- [[PR370]](https://github.com/lanl/singularity-eos/pull/370) Fix bulk modulus calculation in spiner EOS
 - [[PR343]](https://github.com/lanl/singularity-eos/pull/343) Add chemical potentials to stellar collapse gold files
 - [[PR342]](https://github.com/lanl/singularity-eos/pull/342) Fix missing using statement in stellar collapse root finding routines
 - [[PR341]](https://github.com/lanl/singularity-eos/pull/341) Short-circuit HDF5 machinery when cray-wrappers used in-tree
@@ -36,7 +37,7 @@ Date: 11/28/2023
 - [[PR278]](https://github.com/lanl/singularity-eos/pull/278) Fixed EOSPAC unit conversion errors for scalar lookups
 - [[PR316]](https://github.com/lanl/singularity-eos/pull/316) removed `fmax-errors=3` from `singularity-eos` compile flags
 - [[PR296]](https://github.com/lanl/singularity-eos/pull/296) changed `CMAKE_SOURCE_DIR` to `PROJECT_SOURCE_DIR` to fix downstream submodule build
-- [[PR291]](https://github.com/lanl/singularity-eos/pull/291) package.py updates to reflect new CMake options 
+- [[PR291]](https://github.com/lanl/singularity-eos/pull/291) package.py updates to reflect new CMake options
 - [[PR290]](https://github.com/lanl/singularity-eos/pull/290) Added target guards on export config
 - [[PR288]](https://github.com/lanl/singularity-eos/pull/288) Don't build tests that depend on spiner when spiner is disabled
 - [[PR287]](https://github.com/lanl/singularity-eos/pull/287) Fix testing logic with new HDF5 options

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -873,12 +873,12 @@ inline void SpinerEOSDependsRhoT::fixBulkModulus_() {
       Real DPDR = dPdRho_.interpToReal(lRho, lT);
       Real DPDE = dPdE_.interpToReal(lRho, lT);
       Real DEDR = dEdRho_.interpToReal(lRho, lT);
-      Real DTDE = dTdE_.interpToReal(lRho, lT);
+      Real DPDR_T = DPDR + DPDE * DEDR;
       Real bMod;
       if (DPDE > 0.0 && rho > 0.0) {
-        bMod = rho * DPDR + DPDE * (press / rho - rho * DEDR);
+        bMod = rho * DPDR + DPDE * (press / rho);
       } else if (rho > 0.0) {
-        bMod = std::max(rho * DPDR, 0.0);
+        bMod = std::max(rho * DPDR_T, 0.0);
       } else {
         bMod = 0.0;
       }
@@ -1640,12 +1640,12 @@ inline void SpinerEOSDependsRhoSie::calcBMod_(SP5Tables &tables) {
       Real DPDR = tables.dPdRho(j, i);
       Real DPDE = tables.dPdE(j, i);
       Real DEDR = tables.dEdRho(j, i);
-      Real DTDE = tables.dTdE(j, i);
+      Real DPDR_T = DPDR + DPDE * DEDR;
       Real bMod;
       if (DPDE > 0.0 && rho > 0.0) {
-        bMod = rho * DPDR + DPDE * (press / rho - rho * DEDR);
+        bMod = rho * DPDR + DPDE * (press / rho);
       } else if (rho > 0.0) {
-        bMod = std::max(rho * DPDR, 0.0);
+        bMod = std::max(rho * DPDR_T, 0.0);
       } else {
         bMod = 0.0;
       }

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -875,7 +875,7 @@ inline void SpinerEOSDependsRhoT::fixBulkModulus_() {
       Real DEDR_T = dEdRho_.interpToReal(lRho, lT);
       Real DPDR_T = DPDR_E + DPDE_R * DEDR_T;
       Real bMod;
-      if (DPDE > 0.0 && rho > 0.0) {
+      if (DPDE_R > 0.0 && rho > 0.0) {
         bMod = rho * DPDR_E + DPDE_R * (press / rho);
       } else if (rho > 0.0) {
         bMod = std::max(rho * DPDR_T, 0.0);
@@ -1642,7 +1642,7 @@ inline void SpinerEOSDependsRhoSie::calcBMod_(SP5Tables &tables) {
       Real DEDR_T = tables.dEdRho(j, i);
       Real DPDR_T = DPDR_E + DPDE_R * DEDR_T;
       Real bMod;
-      if (DPDE > 0.0 && rho > 0.0) {
+      if (DPDE_R > 0.0 && rho > 0.0) {
         bMod = rho * DPDR_E + DPDE_R * (press / rho);
       } else if (rho > 0.0) {
         bMod = std::max(rho * DPDR_T, 0.0);

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -870,13 +870,13 @@ inline void SpinerEOSDependsRhoT::fixBulkModulus_() {
     for (int i = 0; i < numT_; i++) {
       Real lT = bMod_.range(0).x(i);
       Real press = P_.interpToReal(lRho, lT);
-      Real DPDR = dPdRho_.interpToReal(lRho, lT);
-      Real DPDE = dPdE_.interpToReal(lRho, lT);
-      Real DEDR = dEdRho_.interpToReal(lRho, lT);
-      Real DPDR_T = DPDR + DPDE * DEDR;
+      Real DPDR_E = dPdRho_.interpToReal(lRho, lT);
+      Real DPDE_R = dPdE_.interpToReal(lRho, lT);
+      Real DEDR_T = dEdRho_.interpToReal(lRho, lT);
+      Real DPDR_T = DPDR_E + DPDE_R * DEDR_T;
       Real bMod;
       if (DPDE > 0.0 && rho > 0.0) {
-        bMod = rho * DPDR + DPDE * (press / rho);
+        bMod = rho * DPDR_E + DPDE_R * (press / rho);
       } else if (rho > 0.0) {
         bMod = std::max(rho * DPDR_T, 0.0);
       } else {
@@ -1637,13 +1637,13 @@ inline void SpinerEOSDependsRhoSie::calcBMod_(SP5Tables &tables) {
     Real rho = fromLog_(lRho, lRhoOffset_);
     for (int i = 0; i < tables.bMod.dim(1); i++) {
       Real press = tables.P(j, i);
-      Real DPDR = tables.dPdRho(j, i);
-      Real DPDE = tables.dPdE(j, i);
-      Real DEDR = tables.dEdRho(j, i);
-      Real DPDR_T = DPDR + DPDE * DEDR;
+      Real DPDR_E = tables.dPdRho(j, i);
+      Real DPDE_R = tables.dPdE(j, i);
+      Real DEDR_T = tables.dEdRho(j, i);
+      Real DPDR_T = DPDR_E + DPDE_R * DEDR_T;
       Real bMod;
       if (DPDE > 0.0 && rho > 0.0) {
-        bMod = rho * DPDR + DPDE * (press / rho);
+        bMod = rho * DPDR_E + DPDE_R * (press / rho);
       } else if (rho > 0.0) {
         bMod = std::max(rho * DPDR_T, 0.0);
       } else {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->
Fixes a (potential) bug in Spiner EOS bulk modulus calculation.


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Despite the bulk modulus being a required table in a SpinerDependsRhoT or SpinerDependsRhoSie EOS file, it is overwritten by functions `fixBulkModulus_` and `calcBMod_`, respectively.  Inside these functions, the bulk modulus formulae assume `dpdrho` to be $\partial P / \partial \rho \\; \vert_{T}$.  However, I believe (please check me) that spiner expects that the tables provided correspond to $\partial P / \partial \rho \\; \vert_{e}$.  This PR changes the bulk modulus formula to reflect this.  There is this trick that `eos_spiner` plays wherein if $\partial P / \partial e \\; \vert_{\rho} < 0$, it modifies the bulk modulus calculation.  I tried to preserve this behavior by defining $\partial P / \partial \rho \\; \vert_{T}$ in terms of thermodynamic derivatives (please double check me...).

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
