### PR TITLE
Robustness additions to `get_sg_eos*()` functions and PTE solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [[PR356]](https://github.com/lanl/singularity-eos/pull/356) Guard against FPEs in the PTE solver
 - [[PR356]](https://github.com/lanl/singularity-eos/pull/356) Update CMake for proper Kokkos linking in Fortran interface
 - [[PR372]](https://github.com/lanl/singularity-eos/pull/372) Fix missing utilization of E0 in Davis Products EOS
+- [[PR373]](https://github.com/lanl/singularity-eos/pull/373) Initialize cache in `get_sg_eos*` functions
 
 ### Changed (changing behavior/API/variables/...)
 - [[PR363]](https://github.com/lanl/singularity-eos/pull/363) Template lambda values for scalar calls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [[PR335]](https://github.com/lanl/singularity-eos/pull/335) Fix missing hermite.hpp in CMake install required for Helmholtz EOS
 - [[PR356]](https://github.com/lanl/singularity-eos/pull/356) Guard against FPEs in the PTE solver
 - [[PR356]](https://github.com/lanl/singularity-eos/pull/356) Update CMake for proper Kokkos linking in Fortran interface
+- [[PR372]](https://github.com/lanl/singularity-eos/pull/372) Fix missing utilization of E0 in Davis Products EOS
 
 ### Changed (changing behavior/API/variables/...)
 - [[PR363]](https://github.com/lanl/singularity-eos/pull/363) Template lambda values for scalar calls

--- a/doc/sphinx/src/models.rst
+++ b/doc/sphinx/src/models.rst
@@ -11,6 +11,8 @@
 
 .. _DavisReactants: https://doi.org/10.1016/S0010-2180(99)00112-1
 
+.. _DavisProducts: https://doi.org/10.1063/1.2035310
+
 .. _ProbingOffHugoniotStates: https://doi.org/10.1063/1.4939675
 
 .. _WillsThermo: https://www.osti.gov/biblio/1561015
@@ -1194,10 +1196,11 @@ Davis Products EOS
 .. warning::
     Entropy is not yet available for this EOS
 
-The Davis products EOS is created from the reference isentrope passing through
-the CJ state of the high explosive along with a constant heat capacity. The
-constant heat capacity leads to the energy being a simple funciton of the
-temperature deviation from the reference isentrope such that
+The `Davis products EOS <DavisProducts_>`_ is created from the reference
+isentrope passing through the CJ state of the high explosive along with a
+constant heat capacity. The constant heat capacity leads to the energy being a
+simple funciton of the temperature deviation from the reference isentrope such
+that
 
 .. math::
     
@@ -1228,7 +1231,7 @@ Finally, the pressure, energy, and temperature along the isentrope are given by
 
 .. math::
 
-    e_S(\rho) = e_{\mathrm{C}} G(\rho) \frac{1}{\rho V_{\mathrm{C}}}
+    e_S(\rho) = e_{\mathrm{C}} G(\rho) \frac{1}{\rho V_{\mathrm{C}}} - e_0
 
 .. math::
 
@@ -1253,6 +1256,29 @@ Here, there are four dimensionless parameters that are settable by the user,
 :math:`a`, :math:`b`, :math:`k`, and :math:`n`, while :math:`P_\mathrm{C}`,
 :math:`e_\mathrm{C}`, :math:`V_\mathrm{C}` and :math:`T_\mathrm{C}` are tuning
 parameters with units related to their non-subscripted counterparts.
+
+Note that the energy zero (i.e. the reference energy) for the Davis products EOS
+is arbitrary. For the isentrope to properly pass through the CJ state of a
+reacting material, the energy release of the reaction needs to be accounted for
+properly. If done external to the EOS, an energy source term is required in the
+Euler equations. However, a common convention is to specify the reactants and
+product EOS in a consistent way such that the reference energy corresponds to
+the rest state of the material *before* it reacts.
+
+The energy at the CJ state can be calculated as
+
+.. math::
+
+    e_\mathrm{CJ} = \frac{P_0 + P_\mathrm{CJ}}{2(V_0 - V_\mathrm{CJ})},
+
+relative to :math:`e = 0` at the reference state of the *reactants*. Therefore
+the :math:`e_0` energy offset of the products EOS is given by
+
+.. math::
+
+    e_0 = e_S(V_\mathrm{CJ}) - e_\mathrm{CJ}.
+
+Practically, this means :math:`e_0` should be positive for any energetic material.
 
 The constructor for the Davis Products EOS is
 

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -182,6 +182,7 @@ class PTESolverBase {
   void Finalize() {
     for (int m = 0; m < nmat; m++) {
       temp[m] *= Tnorm;
+      PORTABLE_REQUIRE(temp[m] > 0., "Non-positive temperature returned");
       u[m] *= uscale;
       press[m] *= uscale;
     }

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -314,7 +314,8 @@ class DavisProducts : public EosBase<DavisProducts> {
     const Real ec = _pc * _vc / (_k - 1.0 + _a);
     // const Real de = ecj-(Es(rho0)-_E0);
     return ec * std::pow(0.5 * (std::pow(vvc, _n) + std::pow(vvc, -_n)), _a / _n) /
-           std::pow(vvc, _k - 1.0 + _a) - _E0;
+               std::pow(vvc, _k - 1.0 + _a) -
+           _E0;
   }
   PORTABLE_INLINE_FUNCTION Real Ts(const Real rho) const {
     const Real vvc = 1 / (rho * _vc);

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -313,7 +313,7 @@ class DavisProducts : public EosBase<DavisProducts> {
     const Real ec = _pc * _vc / (_k - 1.0 + _a);
     // const Real de = ecj-(Es(rho0)-_E0);
     return ec * std::pow(0.5 * (std::pow(vvc, _n) + std::pow(vvc, -_n)), _a / _n) /
-           std::pow(vvc, _k - 1.0 + _a);
+           std::pow(vvc, _k - 1.0 + _a) - _E0;
   }
   PORTABLE_INLINE_FUNCTION Real Ts(const Real rho) const {
     const Real vvc = 1 / (rho * _vc);

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -292,6 +292,7 @@ class DavisProducts : public EosBase<DavisProducts> {
   inline void Finalize() {}
   static std::string EosType() { return std::string("DavisProducts"); }
   static std::string EosPyType() { return EosType(); }
+  // TODO (JHP): Create helper function to find the CJ state given the reference state
 
  private:
   static constexpr Real onethird = 1.0 / 3.0;

--- a/singularity-eos/eos/get_sg_eos_p_t.cpp
+++ b/singularity-eos/eos/get_sg_eos_p_t.cpp
@@ -39,6 +39,10 @@ void get_sg_eos_p_t(const char *name, int ncell, int nmat, indirection_v &offset
         // for small loops
         const int32_t token{tokens.acquire()};
         const int32_t tid{small_loop ? iloop : token};
+        // need to initialize the scratch before it's used to avoid undefined behavior
+        for (int idx = 0; idx < solver_scratch.extent(1); ++idx) {
+          solver_scratch(tid, idx) = 0.0;
+        }
         // caching mechanism
         singularity::mix_impl::CacheAccessor cache(&solver_scratch(tid, 0));
         double mass_sum{0.0};

--- a/singularity-eos/eos/get_sg_eos_rho_e.cpp
+++ b/singularity-eos/eos/get_sg_eos_rho_e.cpp
@@ -39,6 +39,10 @@ void get_sg_eos_rho_e(const char *name, int ncell, indirection_v &offsets_v,
         int npte{0};
         // initialize values for solver / lookup
         i_func(i, tid, mass_sum, npte, 0.0, 1.0, 0.0);
+        // need to initialize the scratch before it's used to avoid undefined behavior
+        for (int idx = 0; idx < solver_scratch.extent(1); ++idx) {
+          solver_scratch(tid, idx) = 0.0;
+        }
         // get cache from offsets into scratch
         const int neq = npte + 1;
         singularity::mix_impl::CacheAccessor cache(&solver_scratch(tid, 0) +

--- a/singularity-eos/eos/get_sg_eos_rho_p.cpp
+++ b/singularity-eos/eos/get_sg_eos_rho_p.cpp
@@ -41,6 +41,10 @@ void get_sg_eos_rho_p(const char *name, int ncell, indirection_v &offsets_v,
         // initialize values for solver / lookup
         i_func(i, tid, mass_sum, npte, 0.0, 0.0, 1.0);
         Real sie_tot_true{0.0};
+        // need to initialize the scratch before it's used to avoid undefined behavior
+        for (int idx = 0; idx < solver_scratch.extent(1); ++idx) {
+          solver_scratch(tid, idx) = 0.0;
+        }
         const int neq = npte + 1;
         singularity::mix_impl::CacheAccessor cache(&solver_scratch(tid, 0) +
                                                    neq * (neq + 4) + 2 * npte);

--- a/singularity-eos/eos/get_sg_eos_rho_t.cpp
+++ b/singularity-eos/eos/get_sg_eos_rho_t.cpp
@@ -42,6 +42,10 @@ void get_sg_eos_rho_t(const char *name, int ncell, indirection_v &offsets_v,
         i_func(i, tid, mass_sum, npte, 1.0, 0.0, 0.0);
         // calculate pte condition (lookup for 1 mat cell)
         Real sie_tot_true{0.0};
+        // need to initialize the scratch before it's used to avoid undefined behavior
+        for (int idx = 0; idx < solver_scratch.extent(1); ++idx) {
+          solver_scratch(tid, idx) = 0.0;
+        }
         const int neq = npte;
         singularity::mix_impl::CacheAccessor cache(&solver_scratch(tid, 0) +
                                                    neq * (neq + 4) + 2 * npte);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

1. **Adds initialization of the scratch space for the PTE solvers and EOS in the `get_sg_eos()` functions.
    This is needed because these can sometimes initialize to `-nan` and trigger an FPE in the spiner EOS when it tries to check whether the values are garbage or not. Comparing to a NaN is an FPE in the GNU compiler.
2. **Adds a debug check to make sure the PTE solver is outputting a positive temperature**
    This was more of a sanity check than anything, but since it only exists in debug builds, I don't think it's much of an issue.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- N/A Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

@dholladay00 can you review?
