### PR TITLE
Various robustness additions to the Davis EOS

### DIFF
--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -379,12 +379,14 @@ PORTABLE_INLINE_FUNCTION Real DavisReactants::Es(const Real rho) const {
   } else {
     e_s = -y - (1.0 - std::exp(b4y)) / (4.0 * _B);
   }
-  return _e0 + _P0 * (1.0 / _rho0 - robust::ratio(1.0, std::max(rho, 0.))) + phat / _rho0 * e_s;
+  return _e0 + _P0 * (1.0 / _rho0 - robust::ratio(1.0, std::max(rho, 0.))) +
+         phat / _rho0 * e_s;
 }
 PORTABLE_INLINE_FUNCTION Real DavisReactants::Ts(const Real rho) const {
   if (rho >= _rho0) {
     const Real y = 1 - robust::ratio(_rho0, std::max(rho, 0.));
-    return _T0 * std::exp(-_Z * y) * std::pow(robust::ratio(_rho0, std::max(rho, 0.)), -_G0 - _Z);
+    return _T0 * std::exp(-_Z * y) *
+           std::pow(robust::ratio(_rho0, std::max(rho, 0.)), -_G0 - _Z);
   } else {
     return _T0 * std::pow(robust::ratio(_rho0, rho), -_G0);
   }
@@ -414,8 +416,9 @@ PORTABLE_INLINE_FUNCTION Real DavisReactants::BulkModulusFromDensityInternalEner
                  3 * y / pow<4>(1 - y) + 4 * pow<2>(y) / pow<5>(1 - y))
           : -phat * 4 * _B * _rho0 * std::exp(b4y);
   const Real gammav = (rho >= _rho0) ? _Z * _rho0 : 0.0;
-  return -(psv + (sie - Es(rho)) * rho * (gammav - gamma * std::max(rho, 0.)) - robust::ratio(gamma * std::max(rho, 0.) * esv),
-         rho);
+  return -(psv + (sie - Es(rho)) * rho * (gammav - gamma * std::max(rho, 0.)) -
+               robust::ratio(gamma * std::max(rho, 0.) * esv),
+           rho);
 }
 
 template <typename Indexer_t>

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -22,6 +22,7 @@
 #include <singularity-eos/base/constants.hpp>
 #include <singularity-eos/base/math_utils.hpp>
 #include <singularity-eos/base/root-finding-1d/root_finding.hpp>
+#include <singularity-eos/base/robust_utils.hpp>
 #include <singularity-eos/eos/eos_base.hpp>
 
 namespace singularity {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
Three primary additions to the Davis Reactants and Products EOS to make them more robust:
1. Added the `robust::ratio` function when dividing by density
2. Added early returns for non-positive densities. Since the products EOS should exhibit ideal gas behavior at zero density, it makes sense to return zeros for the reference values.
3. Maxed the density with zero in the reactants EOS. With the robust ratio this basically just returns a low density limit. I don't think there's an overflow issue, but I could be wrong.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- N/A Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
