### PR TITLE
Separate out potentially useful type lists and variant utility functi…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,8 +40,6 @@ default:
   id_tokens:
     SITE_ID_TOKEN:
       aud: https://asc-git.lanl.gov
-    CI_JOB_JWT:
-      aud: https://asc-git.lanl.gov
 
 ##########################
 # Build Matrix Variables #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,8 @@ default:
   id_tokens:
     SITE_ID_TOKEN:
       aud: https://asc-git.lanl.gov
+    CI_JOB_JWT:
+      aud: https://asc-git.lanl.gov
 
 ##########################
 # Build Matrix Variables #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR377]](https://github.com/lanl/singularity-eos/pull/377) Moved much of the variant creating machinery and initialization machinery into separate header files. This is useful for downstream codes that use custom variants and helps with producing plugins.
 - [[PR292]](https://github.com/lanl/singularity-eos/pull/292) Added Carnahan-Starling EoS
 - [[PR#362]](https://github.com/lanl/singularity-eos/pull/362) Add lambda to thermalqs
 - [[PR#339]](https://github.com/lanl/singularity-eos/pull/339) Added COMPONENTS to singularity-eos CMake install, allowing to select a minimal subset needed e.g. for Fortran bindings only

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -56,6 +56,7 @@ register_headers(
     eos/eos_eospac.hpp
     eos/eos_noble_abel.hpp
     eos/eos_stiff.hpp
+    eos/singularity_eos_init_utils.hpp
     eos/variant_utils.hpp
 )
 

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------#
-# © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+# © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 # program was produced under U.S. Government contract 89233218CNA000001
 # for Los Alamos National Laboratory (LANL), which is operated by Triad
 # National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -46,6 +46,7 @@ register_headers(
     eos/eos_jwl.hpp
     eos/eos_helmholtz.hpp
     eos/eos_sap_polynomial.hpp
+    eos/eos_type_lists.hpp
     eos/modifiers/relativistic_eos.hpp
     eos/modifiers/scaled_eos.hpp
     eos/modifiers/ramps_eos.hpp
@@ -55,6 +56,7 @@ register_headers(
     eos/eos_eospac.hpp
     eos/eos_noble_abel.hpp
     eos/eos_stiff.hpp
+    eos/variant_utils.hpp
 )
 
 if (SINGULARITY_BUILD_CLOSURE)

--- a/singularity-eos/eos/default_variant.hpp
+++ b/singularity-eos/eos/default_variant.hpp
@@ -39,8 +39,7 @@
 namespace singularity {
 
 // create the alias
-using EOS =
-  typename decltype(singularity::tl_to_Variant(singularity::combined_list))::vt;
+using EOS = typename decltype(singularity::tl_to_Variant(singularity::combined_list))::vt;
 
 } // namespace singularity
 

--- a/singularity-eos/eos/eos_mgusup.hpp
+++ b/singularity-eos/eos/eos_mgusup.hpp
@@ -386,7 +386,7 @@ MGUsup::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Re
                                Real &bmod, Real &dpde, Real &dvdt,
                                Indexer_t &&lambda) const {
   // AEM: Added all variables I think should be output eventually
-  //Real tbmod;
+  // Real tbmod;
   // Real entropy, alpha, Gamma;
 
   rho = _rho0;
@@ -395,7 +395,7 @@ MGUsup::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Re
   press = PressureFromDensityTemperature(rho, temp, lambda);
   // entropy = _S0;
   cv = _Cv0;
-  //tbmod = _Cs * _Cs * _rho0 - _G0 * _G0 * _Cv0 * _rho0 * _T0;
+  // tbmod = _Cs * _Cs * _rho0 - _G0 * _G0 * _Cv0 * _rho0 * _T0;
   // alpha = _A0;
   bmod = _Cs * _Cs * _rho0;
   // Gamma = _G0;

--- a/singularity-eos/eos/eos_mgusup.hpp
+++ b/singularity-eos/eos/eos_mgusup.hpp
@@ -386,7 +386,7 @@ MGUsup::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Re
                                Real &bmod, Real &dpde, Real &dvdt,
                                Indexer_t &&lambda) const {
   // AEM: Added all variables I think should be output eventually
-  Real tbmod;
+  //Real tbmod;
   // Real entropy, alpha, Gamma;
 
   rho = _rho0;
@@ -395,7 +395,7 @@ MGUsup::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Re
   press = PressureFromDensityTemperature(rho, temp, lambda);
   // entropy = _S0;
   cv = _Cv0;
-  tbmod = _Cs * _Cs * _rho0 - _G0 * _G0 * _Cv0 * _rho0 * _T0;
+  //tbmod = _Cs * _Cs * _rho0 - _G0 * _G0 * _Cv0 * _rho0 * _T0;
   // alpha = _A0;
   bmod = _Cs * _Cs * _rho0;
   // Gamma = _G0;

--- a/singularity-eos/eos/eos_powermg.hpp
+++ b/singularity-eos/eos/eos_powermg.hpp
@@ -469,7 +469,7 @@ PowerMG::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, R
                                 Real &bmod, Real &dpde, Real &dvdt,
                                 Indexer_t &&lambda) const {
   // AEM: Added all variables I think should be output eventually
-  //Real tbmod;
+  // Real tbmod;
   // Real entropy, alpha, Gamma;
 
   rho = _rho0;
@@ -478,7 +478,7 @@ PowerMG::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, R
   press = PressureFromDensityTemperature(rho, temp, lambda);
   // entropy = _S0;
   cv = _Cv0;
-  //tbmod = _K0toK40[0] - _G0 * _G0 * _Cv0 * _rho0 * _T0;
+  // tbmod = _K0toK40[0] - _G0 * _G0 * _Cv0 * _rho0 * _T0;
   // alpha = _A0;
   bmod = _K0toK40[0];
   // Gamma = _G0;

--- a/singularity-eos/eos/eos_powermg.hpp
+++ b/singularity-eos/eos/eos_powermg.hpp
@@ -469,7 +469,7 @@ PowerMG::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, R
                                 Real &bmod, Real &dpde, Real &dvdt,
                                 Indexer_t &&lambda) const {
   // AEM: Added all variables I think should be output eventually
-  Real tbmod;
+  //Real tbmod;
   // Real entropy, alpha, Gamma;
 
   rho = _rho0;
@@ -478,7 +478,7 @@ PowerMG::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, R
   press = PressureFromDensityTemperature(rho, temp, lambda);
   // entropy = _S0;
   cv = _Cv0;
-  tbmod = _K0toK40[0] - _G0 * _G0 * _Cv0 * _rho0 * _T0;
+  //tbmod = _K0toK40[0] - _G0 * _G0 * _Cv0 * _rho0 * _T0;
   // alpha = _A0;
   bmod = _K0toK40[0];
   // Gamma = _G0;

--- a/singularity-eos/eos/eos_type_lists.hpp
+++ b/singularity-eos/eos/eos_type_lists.hpp
@@ -1,0 +1,130 @@
+//------------------------------------------------------------------------------
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//------------------------------------------------------------------------------
+
+#ifndef _SINGULARITY_EOS_EOS_EOS_TYPE_LISTS_HPP_
+#define _SINGULARITY_EOS_EOS_EOS_TYPE_LISTS_HPP_
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <utility>
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-eos/eos/eos_base.hpp>
+#include <singularity-eos/eos/eos_variant.hpp>
+
+// Base stuff
+#include <singularity-eos/base/constants.hpp>
+#include <singularity-eos/base/eos_error.hpp>
+#include <singularity-eos/base/variadic_utils.hpp>
+
+// EOS models
+#include <singularity-eos/eos/eos_models.hpp>
+
+namespace singularity {
+
+// recreate variadic list
+template <typename... Ts>
+using tl = singularity::variadic_utils::type_list<Ts...>;
+
+template <template <typename> class... Ts>
+using al = singularity::variadic_utils::adapt_list<Ts...>;
+
+// transform variadic list: applies modifiers to eos's
+using singularity::variadic_utils::transform_variadic_list;
+
+// all eos's
+static constexpr const auto full_eos_list =
+    tl<IdealGas, Gruneisen, Vinet, MGUsup, PowerMG, JWL, DavisReactants, DavisProducts,
+       StiffGas, SAP_Polynomial, NobleAbel
+#ifdef SINGULARITY_USE_SPINER_WITH_HDF5
+#ifdef SINGULARITY_USE_HELMHOLTZ
+       ,
+       Helmholtz
+#endif // SINGULARITY_USE_HELMHOLTZ
+       ,
+       SpinerEOSDependsRhoT, SpinerEOSDependsRhoSie, StellarCollapse
+#endif // SINGULARITY_USE_SPINER_WITH_HDF5
+#ifdef SINGULARITY_USE_EOSPAC
+       ,
+       EOSPAC
+#endif // SINGULARITY_USE_EOSPAC
+       >{};
+// eos's that get relativistic modifier
+static constexpr const auto relativistic_eos_list =
+    tl<IdealGas
+#ifdef SINGULARITY_USE_SPINER_WITH_HDF5
+       ,
+       SpinerEOSDependsRhoT, SpinerEOSDependsRhoSie, StellarCollapse
+#endif // SINGULAIRTY_USE_SPINER_WITH_HDF5
+       >{};
+// eos's that get unit system modifier
+static constexpr const auto unit_system_eos_list =
+    tl<IdealGas
+#ifdef SPINER_USE_HDF
+       ,
+       SpinerEOSDependsRhoT, SpinerEOSDependsRhoSie, StellarCollapse
+#endif // SPINER_USE_HDF
+#ifdef SINGULARITY_USE_EOSPAC
+       ,
+       EOSPAC
+#endif // SINGULARITY_USE_EOSPAC
+       >{};
+// modifiers that get applied to all eos's
+static constexpr const auto apply_to_all = al<ScaledEOS, ShiftedEOS>{};
+// variadic list of UnitSystem<T>'s
+static constexpr const auto unit_system =
+    transform_variadic_list(unit_system_eos_list, al<UnitSystem>{});
+// variadic list of Relativistic<T>'s
+static constexpr const auto relativistic =
+    transform_variadic_list(relativistic_eos_list, al<RelativisticEOS>{});
+// variadic list of eos's with shifted or scaled modifiers
+static constexpr const auto shifted_1 =
+    transform_variadic_list(full_eos_list, al<ShiftedEOS>{});
+static constexpr const auto scaled_1 =
+    transform_variadic_list(full_eos_list, al<ScaledEOS>{});
+// relativistic and unit system modifiers
+static constexpr const auto unit_or_rel =
+    singularity::variadic_utils::concat(unit_system, relativistic);
+// variadic list of eos with shifted, relativistic or unit system modifiers
+static constexpr const auto shifted_of_unit_or_rel =
+    transform_variadic_list(unit_or_rel, al<ShiftedEOS>{});
+// combined list of all shifted EOS
+static constexpr const auto shifted =
+    singularity::variadic_utils::concat(shifted_1, shifted_of_unit_or_rel);
+// variadic list of eos with scaled, relativistic or unit system modifiers
+static constexpr const auto scaled_of_unit_or_rel =
+    transform_variadic_list(unit_or_rel, al<ScaledEOS>{});
+// variadic list of Scaled<Shifted<T>>'s
+static constexpr const auto scaled_of_shifted =
+    transform_variadic_list(shifted, al<ScaledEOS>{});
+// combined list of all scaled EOS
+static constexpr const auto scaled = singularity::variadic_utils::concat(
+    scaled_1, scaled_of_unit_or_rel, scaled_of_shifted);
+// create combined list
+static constexpr const auto combined_list_1 =
+    singularity::variadic_utils::concat(full_eos_list, shifted, scaled, unit_or_rel);
+// make a ramped eos of everything
+static constexpr const auto ramped_all =
+    transform_variadic_list(combined_list_1, al<BilinearRampEOS>{});
+// final combined list
+static constexpr const auto combined_list =
+    singularity::variadic_utils::concat(combined_list_1, ramped_all);
+
+} // namespace singularity
+
+#endif // _SINGULARITY_EOS_EOS_EOS_TYPE_LISTS_HPP_

--- a/singularity-eos/eos/singularity_eos.cpp
+++ b/singularity-eos/eos/singularity_eos.cpp
@@ -21,6 +21,15 @@
 
 using namespace singularity;
 
+int init_sg_eos(const int nmat, EOS *&eos) {
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  if (!Kokkos::is_initialized()) Kokkos::initialize();
+#endif // PORTABILITY_STRATEGY_KOKKOS
+  EOS *eos_p = new EOS[nmat];
+  eos = eos_p;
+  return 0;
+}
+
 int init_sg_IdealGas(const int matindex, EOS *eos, const double gm1, const double Cv,
                      int const *const enabled, double *const vals) {
   assert(matindex >= 0);

--- a/singularity-eos/eos/singularity_eos.cpp
+++ b/singularity-eos/eos/singularity_eos.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -17,80 +17,9 @@
 #include <singularity-eos/eos/eos.hpp>
 #include <singularity-eos/eos/eos_builder.hpp>
 #include <singularity-eos/eos/singularity_eos.hpp>
+#include <singularity-eos/eos/singularity_eos_init_utils.hpp>
 
 using namespace singularity;
-
-// TODO: Replace these with the new Modify method in EOSBuilder.
-// NOTE: The new EOSBuilder machinery will likely be slower than these.
-template <typename T>
-EOS applyShiftAndScale(T &&eos, bool scaled, bool shifted, Real scale, Real shift) {
-  if (shifted && scaled) {
-    ShiftedEOS<T> a(std::forward<T>(eos), shift);
-    ScaledEOS<ShiftedEOS<T>> b(std::move(a), scale);
-    return b;
-  }
-  if (shifted) {
-    return ShiftedEOS<T>(std::forward<T>(eos), shift);
-  }
-  if (scaled) {
-    return ScaledEOS<T>(std::forward<T>(eos), scale);
-  }
-  return eos;
-}
-
-template <typename T, template <typename> class W, typename... ARGS>
-EOS applyWrappedShiftAndScale(T &&eos, bool scaled, bool shifted, Real scale, Real shift,
-                              ARGS... args) {
-  if (shifted && scaled) {
-    ShiftedEOS<T> a(std::forward<T>(eos), shift);
-    ScaledEOS<ShiftedEOS<T>> b(std::move(a), scale);
-    W<ScaledEOS<ShiftedEOS<T>>> c(std::move(b), args...);
-    return c;
-  }
-  if (shifted) {
-    ShiftedEOS<T> sh_eos(std::forward<T>(eos), shift);
-    return W<ShiftedEOS<T>>(std::move(sh_eos), args...);
-  }
-  if (scaled) {
-    ScaledEOS<T> sc_eos(std::forward<T>(eos), scale);
-    return W<ScaledEOS<T>>(std::move(sc_eos), args...);
-  }
-  return W<T>(std::forward<T>(eos), args...);
-}
-
-template <typename T>
-EOS applyShiftAndScaleAndBilinearRamp(T &&eos, bool scaled, bool shifted, bool ramped,
-                                      Real scale, Real shift, Real r0, Real a, Real b,
-                                      Real c) {
-  if (ramped) {
-    return applyWrappedShiftAndScale<T, BilinearRampEOS>(
-        std::forward<T>(eos), scaled, shifted, scale, shift, r0, a, b, c);
-  } else {
-    return applyShiftAndScale(std::forward<T>(eos), scaled, shifted, scale, shift);
-  }
-}
-
-int init_sg_eos(const int nmat, EOS *&eos) {
-#ifdef PORTABILITY_STRATEGY_KOKKOS
-  if (!Kokkos::is_initialized()) Kokkos::initialize();
-#endif // PORTABILITY_STRATEGY_KOKKOS
-  EOS *eos_p = new EOS[nmat];
-  eos = eos_p;
-  return 0;
-}
-
-// apply everything but ramp in order to possibly calculate the
-// SAP ramp parameters from p-alhpa ramp parameters
-#define SGAPPLYMODSIMPLE(A)                                                              \
-  applyShiftAndScale(A, enabled[0] == 1, enabled[1] == 1, vals[0], vals[1])
-
-#define SGAPPLYMOD(A)                                                                    \
-  applyShiftAndScaleAndBilinearRamp(A, enabled[0] == 1, enabled[1] == 1,                 \
-                                    enabled[2] == 1 || enabled[3] == 1, vals[0],         \
-                                    vals[1], vals[2], vals[3], vals[4], vals[5])
-
-int def_en[4] = {0, 0, 0, 0};
-double def_v[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
 int init_sg_IdealGas(const int matindex, EOS *eos, const double gm1, const double Cv,
                      int const *const enabled, double *const vals) {

--- a/singularity-eos/eos/singularity_eos_init_utils.hpp
+++ b/singularity-eos/eos/singularity_eos_init_utils.hpp
@@ -22,7 +22,8 @@ namespace singularity {
 // TODO: Replace these with the new Modify method in EOSBuilder.
 // NOTE: The new EOSBuilder machinery will likely be slower than these.
 template <typename T>
-inline EOS applyShiftAndScale(T &&eos, bool scaled, bool shifted, Real scale, Real shift) {
+inline EOS applyShiftAndScale(T &&eos, bool scaled, bool shifted, Real scale,
+                              Real shift) {
   if (shifted && scaled) {
     ShiftedEOS<T> a(std::forward<T>(eos), shift);
     ScaledEOS<ShiftedEOS<T>> b(std::move(a), scale);
@@ -38,8 +39,8 @@ inline EOS applyShiftAndScale(T &&eos, bool scaled, bool shifted, Real scale, Re
 }
 
 template <typename T, template <typename> class W, typename... ARGS>
-inline EOS applyWrappedShiftAndScale(T &&eos, bool scaled, bool shifted, Real scale, Real shift,
-                              ARGS... args) {
+inline EOS applyWrappedShiftAndScale(T &&eos, bool scaled, bool shifted, Real scale,
+                                     Real shift, ARGS... args) {
   if (shifted && scaled) {
     ShiftedEOS<T> a(std::forward<T>(eos), shift);
     ScaledEOS<ShiftedEOS<T>> b(std::move(a), scale);
@@ -58,9 +59,9 @@ inline EOS applyWrappedShiftAndScale(T &&eos, bool scaled, bool shifted, Real sc
 }
 
 template <typename T>
-inline EOS applyShiftAndScaleAndBilinearRamp(T &&eos, bool scaled, bool shifted, bool ramped,
-                                      Real scale, Real shift, Real r0, Real a, Real b,
-                                      Real c) {
+inline EOS applyShiftAndScaleAndBilinearRamp(T &&eos, bool scaled, bool shifted,
+                                             bool ramped, Real scale, Real shift, Real r0,
+                                             Real a, Real b, Real c) {
   if (ramped) {
     return applyWrappedShiftAndScale<T, BilinearRampEOS>(
         std::forward<T>(eos), scaled, shifted, scale, shift, r0, a, b, c);

--- a/singularity-eos/eos/singularity_eos_init_utils.hpp
+++ b/singularity-eos/eos/singularity_eos_init_utils.hpp
@@ -1,0 +1,86 @@
+//------------------------------------------------------------------------------
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//------------------------------------------------------------------------------
+
+#ifndef _SINGULARITY_EOS_EOS_SINGULARITY_EOS_INIT_UTILS_HPP_
+#define _SINGULARITY_EOS_EOS_SINGULARITY_EOS_INIT_UTILS_HPP_
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-eos/eos/eos.hpp>
+
+namespace singularity {
+// TODO: Replace these with the new Modify method in EOSBuilder.
+// NOTE: The new EOSBuilder machinery will likely be slower than these.
+template <typename T>
+inline EOS applyShiftAndScale(T &&eos, bool scaled, bool shifted, Real scale, Real shift) {
+  if (shifted && scaled) {
+    ShiftedEOS<T> a(std::forward<T>(eos), shift);
+    ScaledEOS<ShiftedEOS<T>> b(std::move(a), scale);
+    return b;
+  }
+  if (shifted) {
+    return ShiftedEOS<T>(std::forward<T>(eos), shift);
+  }
+  if (scaled) {
+    return ScaledEOS<T>(std::forward<T>(eos), scale);
+  }
+  return eos;
+}
+
+template <typename T, template <typename> class W, typename... ARGS>
+inline EOS applyWrappedShiftAndScale(T &&eos, bool scaled, bool shifted, Real scale, Real shift,
+                              ARGS... args) {
+  if (shifted && scaled) {
+    ShiftedEOS<T> a(std::forward<T>(eos), shift);
+    ScaledEOS<ShiftedEOS<T>> b(std::move(a), scale);
+    W<ScaledEOS<ShiftedEOS<T>>> c(std::move(b), args...);
+    return c;
+  }
+  if (shifted) {
+    ShiftedEOS<T> sh_eos(std::forward<T>(eos), shift);
+    return W<ShiftedEOS<T>>(std::move(sh_eos), args...);
+  }
+  if (scaled) {
+    ScaledEOS<T> sc_eos(std::forward<T>(eos), scale);
+    return W<ScaledEOS<T>>(std::move(sc_eos), args...);
+  }
+  return W<T>(std::forward<T>(eos), args...);
+}
+
+template <typename T>
+inline EOS applyShiftAndScaleAndBilinearRamp(T &&eos, bool scaled, bool shifted, bool ramped,
+                                      Real scale, Real shift, Real r0, Real a, Real b,
+                                      Real c) {
+  if (ramped) {
+    return applyWrappedShiftAndScale<T, BilinearRampEOS>(
+        std::forward<T>(eos), scaled, shifted, scale, shift, r0, a, b, c);
+  } else {
+    return applyShiftAndScale(std::forward<T>(eos), scaled, shifted, scale, shift);
+  }
+}
+
+// apply everything but ramp in order to possibly calculate the
+// SAP ramp parameters from p-alhpa ramp parameters
+#define SGAPPLYMODSIMPLE(A)                                                              \
+  applyShiftAndScale(A, enabled[0] == 1, enabled[1] == 1, vals[0], vals[1])
+
+#define SGAPPLYMOD(A)                                                                    \
+  applyShiftAndScaleAndBilinearRamp(A, enabled[0] == 1, enabled[1] == 1,                 \
+                                    enabled[2] == 1 || enabled[3] == 1, vals[0],         \
+                                    vals[1], vals[2], vals[3], vals[4], vals[5])
+
+int def_en[4] = {0, 0, 0, 0};
+double def_v[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+} // namespace singularity
+#endif // _SINGULARITY_EOS_EOS_SINGULARITY_EOS_INIT_UTILS_HPP_

--- a/singularity-eos/eos/variant_utils.hpp
+++ b/singularity-eos/eos/variant_utils.hpp
@@ -12,8 +12,8 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
-#ifndef _SINGULARITY_EOS_EOS_DEFAULT_VARIANT_HPP_
-#define _SINGULARITY_EOS_EOS_DEFAULT_VARIANT_HPP_
+#ifndef _SINGULARITY_EOS_EOS_VARIANT_UTILS_HPP_
+#define _SINGULARITY_EOS_EOS_VARIANT_UTILS_HPP_
 
 #include <cassert>
 #include <cmath>
@@ -24,24 +24,21 @@
 #include <utility>
 
 #include <ports-of-call/portability.hpp>
-#include <singularity-eos/eos/eos_base.hpp>
 #include <singularity-eos/eos/eos_variant.hpp>
-
-// Base stuff
-#include <singularity-eos/base/constants.hpp>
-#include <singularity-eos/base/eos_error.hpp>
-#include <singularity-eos/base/variadic_utils.hpp>
-
-// EOS models
-#include <singularity-eos/eos/eos_type_lists.hpp>
-#include <singularity-eos/eos/variant_utils.hpp>
 
 namespace singularity {
 
-// create the alias
-using EOS =
-  typename decltype(singularity::tl_to_Variant(singularity::combined_list))::vt;
+// a function that returns a Variant from a typelist
+template <typename... Ts>
+struct tl_to_Variant_struct {
+  using vt = Variant<Ts...>;
+};
+
+template <typename... Ts>
+constexpr auto tl_to_Variant(tl<Ts...>) {
+  return tl_to_Variant_struct<Ts...>{};
+}
 
 } // namespace singularity
 
-#endif // _SINGULARITY_EOS_EOS_DEFAULT_VARIANT_HPP_
+#endif // _SINGULARITY_EOS_EOS_VARIANT_UTILS_HPP_

--- a/test/test_eos_carnahan_starling.cpp
+++ b/test/test_eos_carnahan_starling.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/test/test_eos_carnahan_starling.cpp
+++ b/test/test_eos_carnahan_starling.cpp
@@ -535,7 +535,7 @@ SCENARIO("Test C-S Entropy Calls", "[CarnahanStarling][CarnahanStarling5]") {
 #endif // PORTABILITY_STRATEGY_KOKKOS
 
       // Gold standard values for a subset of lookups
-      constexpr std::array<Real, num> temperature_true{4.0000000000000000e+03};
+      //constexpr std::array<Real, num> temperature_true{4.0000000000000000e+03};
       constexpr std::array<Real, num> entropy_true{-2.2983150752058342e+10};
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS

--- a/test/test_eos_carnahan_starling.cpp
+++ b/test/test_eos_carnahan_starling.cpp
@@ -535,7 +535,7 @@ SCENARIO("Test C-S Entropy Calls", "[CarnahanStarling][CarnahanStarling5]") {
 #endif // PORTABILITY_STRATEGY_KOKKOS
 
       // Gold standard values for a subset of lookups
-      //constexpr std::array<Real, num> temperature_true{4.0000000000000000e+03};
+      // constexpr std::array<Real, num> temperature_true{4.0000000000000000e+03};
       constexpr std::array<Real, num> entropy_true{-2.2983150752058342e+10};
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS

--- a/test/test_eos_powermg.cpp
+++ b/test/test_eos_powermg.cpp
@@ -575,7 +575,7 @@ SCENARIO("PowerMG EOS SetUp", "[VectorEOS][PowerMGEOS]") {
     Real rho0 = 7.285;
     Real T0 = 298.0;
     constexpr Real Cs = 2766.0e2;
-    constexpr Real s = 1.5344;
+    //constexpr Real s = 1.5344;
     constexpr Real G0 = 2.4659;
     Real Cv0 = 0.2149e-05 * Mbcc_per_g;
     constexpr Real E0 = 0.658e-03 * Mbcc_per_g;

--- a/test/test_eos_powermg.cpp
+++ b/test/test_eos_powermg.cpp
@@ -575,7 +575,7 @@ SCENARIO("PowerMG EOS SetUp", "[VectorEOS][PowerMGEOS]") {
     Real rho0 = 7.285;
     Real T0 = 298.0;
     constexpr Real Cs = 2766.0e2;
-    //constexpr Real s = 1.5344;
+    // constexpr Real s = 1.5344;
     constexpr Real G0 = 2.4659;
     Real Cv0 = 0.2149e-05 * Mbcc_per_g;
     constexpr Real E0 = 0.658e-03 * Mbcc_per_g;


### PR DESCRIPTION
…ons to separate header files that could be used downstream w/o needing the variant definition itself.

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@Yurlungur @jhp-lanl @gopsub @jdolence 

This PR includes changes that separates potentially useful type lists and variant utility functions into separate header files that could be used by downstream codes without needing to include the variant type itself. It allows one to start with the final monolithic list of eos types (or any of the intermediate type lists) and build from there using concat, transform etc. Then the final variant's type can be constructed using the variant utility functions. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [x] Update the version in cmake.
- [x] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
