### PR TITLE
Add zeroing out of material internal energy if its mass fraction is s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [[PR#357]](https://github.com/lanl/singularity-eos/pull/357) Added support for C++17 (e.g., needed when using newer Kokkos).
 
 ### Fixed (Repair bugs, etc)
+- [[PR380]](https://github.com/lanl/singularity-eos/pull/380) Set material internal energy to 0 if not participating in the pte solve to make sure potentially uninitialized data is set.
 - [[PR370]](https://github.com/lanl/singularity-eos/pull/370) Fix bulk modulus calculation in spiner EOS
 - [[PR343]](https://github.com/lanl/singularity-eos/pull/343) Add chemical potentials to stellar collapse gold files
 - [[PR342]](https://github.com/lanl/singularity-eos/pull/342) Fix missing using statement in stellar collapse root finding routines

--- a/singularity-eos/eos/get_sg_eos.cpp
+++ b/singularity-eos/eos/get_sg_eos.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/eos/get_sg_eos.cpp
+++ b/singularity-eos/eos/get_sg_eos.cpp
@@ -151,9 +151,9 @@ int get_sg_eos( // sizing information
                        frac_dpde_v, nmat, do_frac_bmod, do_frac_cv, do_frac_dpde);
   // only initialize init functor when needed
   if (input_int_enum != input_condition::P_T_INPUT) {
-    i_func = init_functor(frac_mass_v, pte_idxs, eos_offsets_v, frac_vol_v, pte_mats,
-                          vfrac_pte, sie_pte, temp_pte, press_pte, rho_pte, spvol_v,
-                          temp_v, press_v, sie_v, nmat);
+    i_func = init_functor(frac_mass_v, pte_idxs, eos_offsets_v, frac_vol_v, frac_ie_v,
+                          pte_mats, vfrac_pte, sie_pte, temp_pte, press_pte, rho_pte,
+                          spvol_v, temp_v, press_v, sie_v, nmat);
   }
 
   // create helper lambdas to reduce code duplication

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -48,14 +48,13 @@ struct init_functor {
                dev_frac_v frac_ie_v_, ScratchV<int> &pte_mats_,
                ScratchV<double> &vfrac_pte_, ScratchV<double> &sie_pte_,
                ScratchV<double> &temp_pte_, ScratchV<double> &press_pte_,
-               ScratchV<double> &rho_pte_, dev_v &spvol_v_,
-               dev_v &temp_v_, dev_v &press_v_, dev_v &sie_v_, int &nmat)
+               ScratchV<double> &rho_pte_, dev_v &spvol_v_, dev_v &temp_v_,
+               dev_v &press_v_, dev_v &sie_v_, int &nmat)
       : frac_mass_v{frac_mass_v_}, pte_idxs{pte_idxs_}, eos_offsets_v{eos_offsets_v_},
         frac_vol_v{frac_vol_v_}, frac_ie_v{frac_ie_v_}, pte_mats{pte_mats_},
         vfrac_pte{vfrac_pte_}, sie_pte{sie_pte_}, temp_pte{temp_pte_},
         press_pte{press_pte_}, rho_pte{rho_pte_}, spvol_v{spvol_v_}, temp_v{temp_v_},
-        press_v{press_v_}, sie_v{sie_v_}, nmat{nmat} {
-  }
+        press_v{press_v_}, sie_v{sie_v_}, nmat{nmat} {}
 
   PORTABLE_INLINE_FUNCTION
   void operator()(const int i, const int tid, double &mass_sum, int &npte,
@@ -79,8 +78,7 @@ struct init_functor {
         pte_idxs(tid, npte) = eos_offsets_v(m) - 1;
         pte_mats(tid, npte) = m;
         npte += 1;
-      }
-      else {
+      } else {
         frac_ie_v(i, m) = 0.0;
       }
       vfrac_pte(tid, m) = 0.0;

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -28,6 +28,7 @@ struct init_functor {
   ScratchV<int> pte_idxs;
   indirection_v eos_offsets_v;
   dev_frac_v frac_vol_v;
+  dev_frac_v frac_ie_v;
   ScratchV<int> pte_mats;
   ScratchV<double> vfrac_pte;
   ScratchV<double> sie_pte;
@@ -44,14 +45,16 @@ struct init_functor {
   init_functor() = default;
   init_functor(dev_frac_v &frac_mass_v_, ScratchV<int> &pte_idxs_,
                indirection_v &eos_offsets_v_, dev_frac_v &frac_vol_v_,
-               ScratchV<int> &pte_mats_, ScratchV<double> &vfrac_pte_,
-               ScratchV<double> &sie_pte_, ScratchV<double> &temp_pte_,
-               ScratchV<double> &press_pte_, ScratchV<double> &rho_pte_, dev_v &spvol_v_,
+               dev_frac_v frac_ie_v_, ScratchV<int> &pte_mats_,
+               ScratchV<double> &vfrac_pte_, ScratchV<double> &sie_pte_,
+               ScratchV<double> &temp_pte_, ScratchV<double> &press_pte_,
+               ScratchV<double> &rho_pte_, dev_v &spvol_v_,
                dev_v &temp_v_, dev_v &press_v_, dev_v &sie_v_, int &nmat)
       : frac_mass_v{frac_mass_v_}, pte_idxs{pte_idxs_}, eos_offsets_v{eos_offsets_v_},
-        frac_vol_v{frac_vol_v_}, pte_mats{pte_mats_}, vfrac_pte{vfrac_pte_},
-        sie_pte{sie_pte_}, temp_pte{temp_pte_}, press_pte{press_pte_}, rho_pte{rho_pte_},
-        spvol_v{spvol_v_}, temp_v{temp_v_}, press_v{press_v_}, sie_v{sie_v_}, nmat{nmat} {
+        frac_vol_v{frac_vol_v_}, frac_ie_v{frac_ie_v_}, pte_mats{pte_mats_},
+        vfrac_pte{vfrac_pte_}, sie_pte{sie_pte_}, temp_pte{temp_pte_},
+        press_pte{press_pte_}, rho_pte{rho_pte_}, spvol_v{spvol_v_}, temp_v{temp_v_},
+        press_v{press_v_}, sie_v{sie_v_}, nmat{nmat} {
   }
 
   PORTABLE_INLINE_FUNCTION
@@ -76,6 +79,9 @@ struct init_functor {
         pte_idxs(tid, npte) = eos_offsets_v(m) - 1;
         pte_mats(tid, npte) = m;
         npte += 1;
+      }
+      else {
+        frac_ie_v(i, m) = 0.0;
       }
       vfrac_pte(tid, m) = 0.0;
       sie_pte(tid, m) = 0.0;


### PR DESCRIPTION
…ufficiently low so as not to be participating in the solve. This fixes issues in the event the passed in internal energies are uninitialized.

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This PR fixes issues seen with uninitialized data. If internal energies that are passed are uninitialized coming into the get_sg_eos_function, they may be remain so and cause downstream checks to fail. 

This is not the full changeset I had for debugging. As of now, the get_sg_eos function will always return 0. In the past, the value passed back was the number of failed PTE solves, though this should not necessarily result in a crash. That said, I had also added checks for nans in outputs, and if that occurs we may want to cause a hard stop on execution. 

Should that be part of a different PR @jhp-lanl ? Thoughts? This should be enough to get you going again though if you want to continue with debugging / vetting efforts. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [x] Update the version in cmake.
- [x] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
