### PR TITLE
Add introspection to `get_sg_eos` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Changed (changing behavior/API/variables/...)
 - [[PR363]](https://github.com/lanl/singularity-eos/pull/363) Template lambda values for scalar calls
 - [[PR372]](https://github.com/lanl/singularity-eos/pull/372) Removed E0 from Davis Products EOS in favor of using the shifted EOS modifier. CHANGES API!
+- [[PR#382]](https://github.com/lanl/singularity-eos/pull/382) Changed `get_sg_eos()` API to allow optionally specifying the mass fraction cutoff for materials to participate in the PTE solver 
 
 ### Infrastructure (changes irrelevant to downstream codes)
 - [[PR329]](https://github.com/lanl/singularity-eos/pull/329) Move vinet tests into analytic test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [[PR331]](https://github.com/lanl/singularity-eos/pull/331) Included code and documentation for a full, temperature consistent, Mie-Gruneisen EOS based on a linear Us-up relation. MGUsup.
 - [[PR326]](https://github.com/lanl/singularity-eos/pull/326) Document how to do a release
 - [[PR#357]](https://github.com/lanl/singularity-eos/pull/357) Added support for C++17 (e.g., needed when using newer Kokkos).
+- [[PR#382]](https://github.com/lanl/singularity-eos/pull/382) Added debug checks to the `get_sg_eos()` interface to ensure sane values are returned
 
 ### Fixed (Repair bugs, etc)
 - [[PR380]](https://github.com/lanl/singularity-eos/pull/380) Set material internal energy to 0 if not participating in the pte solve to make sure potentially uninitialized data is set.

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -31,6 +31,7 @@ register_headers(
     base/math_utils.hpp
     base/constants.hpp
     base/eos_error.hpp
+    base/error_utils.hpp
     base/sp5/singularity_eos_sp5.hpp
     eos/default_variant.hpp
     base/hermite.hpp

--- a/singularity-eos/base/error_utils.hpp
+++ b/singularity-eos/base/error_utils.hpp
@@ -1,8 +1,8 @@
 #ifndef SINGULARITY_EOS_BASE_ERROR_UTILS_HPP_
 #define SINGULARITY_EOS_BASE_ERROR_UTILS_HPP_
 
-#include <type_traits>
 #include <cmath>
+#include <type_traits>
 
 #include <ports-of-call/portability.hpp>
 
@@ -17,8 +17,8 @@ struct is_normal_or_zero {
   template <typename valT>
   bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
     static_assert(std::is_floating_point_v<valT>);
-    return (value == valT{0}) || (std::isnormal(_NORMAL_FACTOR * value) 
-                                   && std::isnormal(value));
+    return (value == valT{0}) ||
+           (std::isnormal(_NORMAL_FACTOR * value) && std::isnormal(value));
   }
 };
 
@@ -53,17 +53,17 @@ PORTABLE_FORCEINLINE_FUNCTION bool violates_condition(valT&& value, condT&& cond
 
 // Create specialized functions using the above conditions
 template <typename valT, typename nameT>
-PORTABLE_FORCEINLINE_FUNCTION bool bad_value(valT&& value, nameT&& var_name) {
+PORTABLE_FORCEINLINE_FUNCTION bool bad_value(valT &&value, nameT&& var_name) {
   return violates_condition(std::forward<valT>(value), is_normal_or_zero{},
                             std::forward<nameT>(var_name));
 }
 template <typename valT, typename nameT>
-PORTABLE_FORCEINLINE_FUNCTION bool non_positive_value(valT&& value, nameT&& var_name) {
+PORTABLE_FORCEINLINE_FUNCTION bool non_positive_value(valT &&value, nameT&& var_name) {
   return violates_condition(std::forward<valT>(value), is_strictly_positive{},
                             std::forward<nameT>(var_name));
 }
 template <typename valT, typename nameT>
-PORTABLE_FORCEINLINE_FUNCTION bool negative_value(valT&& value, nameT&& var_name) {
+PORTABLE_FORCEINLINE_FUNCTION bool negative_value(valT &&value, nameT&& var_name) {
   return violates_condition(std::forward<valT>(value), is_strictly_positive{},
                             std::forward<nameT>(var_name));
 }

--- a/singularity-eos/base/error_utils.hpp
+++ b/singularity-eos/base/error_utils.hpp
@@ -1,0 +1,74 @@
+#ifndef SINGULARITY_EOS_BASE_ERROR_UTILS_HPP_
+#define SINGULARITY_EOS_BASE_ERROR_UTILS_HPP_
+
+#include <type_traits>
+#include <cmath>
+
+#include <ports-of-call/portability.hpp>
+
+namespace singularity {
+namespace error_utils {
+
+using PortsOfCall::printf;
+
+constexpr double _NORMAL_FACTOR = 1.0e10;
+
+struct is_normal_or_zero {
+    template <typename valT>
+    bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
+        static_assert(std::is_floating_point_v<valT>);
+        return (value == valT{0}) || (std::isnormal(_NORMAL_FACTOR * value) 
+                                       && std::isnormal(value));
+    }
+};
+
+struct is_strictly_positive {
+    template <typename valT>
+    bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
+        static_assert(std::is_arithmetic_v<valT>);
+        return value > valT{0};
+    }
+};
+
+struct is_non_negative {
+    template <typename valT>
+    bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
+        static_assert(std::is_arithmetic_v<valT>);
+        return value >= valT{0};
+    }
+};
+
+// Checks whether a value obeys some sort of provided condition. If not, returns true and
+// prints the provided error message, variable name, and value (but does not abort!)
+template <typename valT, typename condT, typename nameT>
+PORTABLE_FORCEINLINE_FUNCTION bool violates_condition(valT&& value, condT&& condition,
+                                                      nameT&& var_name) {
+    const bool good = condition(std::forward<valT>(value));
+    if (!good) {
+        printf("### ERROR: Bad singularity-eos value\n  Var: %s\n Value: %.15e\n",
+               var_name, value);
+    }
+    return !good;
+}
+
+// Create specialized functions using the above conditions
+template <typename valT, typename nameT>
+PORTABLE_FORCEINLINE_FUNCTION bool bad_value(valT&& value, nameT&& var_name) {
+    return violates_condition(std::forward<valT>(value), is_normal_or_zero{},
+                              std::forward<nameT>(var_name));
+}
+template <typename valT, typename nameT>
+PORTABLE_FORCEINLINE_FUNCTION bool non_positive_value(valT&& value, nameT&& var_name) {
+    return violates_condition(std::forward<valT>(value), is_strictly_positive{},
+                              std::forward<nameT>(var_name));
+}
+template <typename valT, typename nameT>
+PORTABLE_FORCEINLINE_FUNCTION bool negative_value(valT&& value, nameT&& var_name) {
+    return violates_condition(std::forward<valT>(value), is_strictly_positive{},
+                              std::forward<nameT>(var_name));
+}
+
+} // namespace error_utils
+} // namesapce singularity
+
+#endif // #ifndef SINGULARITY_EOS_BASE_ERROR_UTILS_HPP_

--- a/singularity-eos/base/error_utils.hpp
+++ b/singularity-eos/base/error_utils.hpp
@@ -41,34 +41,34 @@ struct is_non_negative {
 // Checks whether a value obeys some sort of provided condition. If not, returns true and
 // prints the provided error message, variable name, and value (but does not abort!)
 template <typename valT, typename condT, typename nameT>
-PORTABLE_FORCEINLINE_FUNCTION bool violates_condition(valT&& value, condT&& condition,
-                                                    nameT&& var_name) {
+PORTABLE_FORCEINLINE_FUNCTION bool violates_condition(valT &&value, condT &&condition,
+                                                      nameT &&var_name) {
   const bool good = condition(std::forward<valT>(value));
   if (!good) {
-    printf("### ERROR: Bad singularity-eos value\n  Var: %s\n Value: %.15e\n",
-           var_name, value);
+    printf("### ERROR: Bad singularity-eos value\n  Var: %s\n Value: %.15e\n", var_name,
+           value);
   }
   return !good;
 }
 
 // Create specialized functions using the above conditions
 template <typename valT, typename nameT>
-PORTABLE_FORCEINLINE_FUNCTION bool bad_value(valT &&value, nameT&& var_name) {
+PORTABLE_FORCEINLINE_FUNCTION bool bad_value(valT &&value, nameT &&var_name) {
   return violates_condition(std::forward<valT>(value), is_normal_or_zero{},
                             std::forward<nameT>(var_name));
 }
 template <typename valT, typename nameT>
-PORTABLE_FORCEINLINE_FUNCTION bool non_positive_value(valT &&value, nameT&& var_name) {
+PORTABLE_FORCEINLINE_FUNCTION bool non_positive_value(valT &&value, nameT &&var_name) {
   return violates_condition(std::forward<valT>(value), is_strictly_positive{},
                             std::forward<nameT>(var_name));
 }
 template <typename valT, typename nameT>
-PORTABLE_FORCEINLINE_FUNCTION bool negative_value(valT &&value, nameT&& var_name) {
+PORTABLE_FORCEINLINE_FUNCTION bool negative_value(valT &&value, nameT &&var_name) {
   return violates_condition(std::forward<valT>(value), is_strictly_positive{},
                             std::forward<nameT>(var_name));
 }
 
 } // namespace error_utils
-} // namesapce singularity
+} // namespace singularity
 
 #endif // #ifndef SINGULARITY_EOS_BASE_ERROR_UTILS_HPP_

--- a/singularity-eos/base/error_utils.hpp
+++ b/singularity-eos/base/error_utils.hpp
@@ -1,3 +1,17 @@
+//------------------------------------------------------------------------------
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//------------------------------------------------------------------------------
+
 #ifndef SINGULARITY_EOS_BASE_ERROR_UTILS_HPP_
 #define SINGULARITY_EOS_BASE_ERROR_UTILS_HPP_
 
@@ -45,8 +59,8 @@ PORTABLE_FORCEINLINE_FUNCTION bool violates_condition(valT &&value, condT &&cond
                                                       nameT &&var_name) {
   const bool good = condition(std::forward<valT>(value));
   if (!good) {
-    printf("### ERROR: Bad singularity-eos value\n  Var: %s\n Value: %.15e\n", var_name,
-           value);
+    printf("### ERROR: Bad singularity-eos value\n  Var:   %s\n  Value: %.15e\n",
+           var_name, value);
   }
   return !good;
 }

--- a/singularity-eos/base/error_utils.hpp
+++ b/singularity-eos/base/error_utils.hpp
@@ -14,58 +14,58 @@ using PortsOfCall::printf;
 constexpr double _NORMAL_FACTOR = 1.0e10;
 
 struct is_normal_or_zero {
-    template <typename valT>
-    bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
-        static_assert(std::is_floating_point_v<valT>);
-        return (value == valT{0}) || (std::isnormal(_NORMAL_FACTOR * value) 
-                                       && std::isnormal(value));
-    }
+  template <typename valT>
+  bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
+    static_assert(std::is_floating_point_v<valT>);
+    return (value == valT{0}) || (std::isnormal(_NORMAL_FACTOR * value) 
+                                   && std::isnormal(value));
+  }
 };
 
 struct is_strictly_positive {
-    template <typename valT>
-    bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
-        static_assert(std::is_arithmetic_v<valT>);
-        return value > valT{0};
-    }
+  template <typename valT>
+  bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
+    static_assert(std::is_arithmetic_v<valT>);
+    return value > valT{0};
+  }
 };
 
 struct is_non_negative {
-    template <typename valT>
-    bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
-        static_assert(std::is_arithmetic_v<valT>);
-        return value >= valT{0};
-    }
+  template <typename valT>
+  bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
+    static_assert(std::is_arithmetic_v<valT>);
+    return value >= valT{0};
+  }
 };
 
 // Checks whether a value obeys some sort of provided condition. If not, returns true and
 // prints the provided error message, variable name, and value (but does not abort!)
 template <typename valT, typename condT, typename nameT>
 PORTABLE_FORCEINLINE_FUNCTION bool violates_condition(valT&& value, condT&& condition,
-                                                      nameT&& var_name) {
-    const bool good = condition(std::forward<valT>(value));
-    if (!good) {
-        printf("### ERROR: Bad singularity-eos value\n  Var: %s\n Value: %.15e\n",
-               var_name, value);
-    }
-    return !good;
+                                                    nameT&& var_name) {
+  const bool good = condition(std::forward<valT>(value));
+  if (!good) {
+    printf("### ERROR: Bad singularity-eos value\n  Var: %s\n Value: %.15e\n",
+           var_name, value);
+  }
+  return !good;
 }
 
 // Create specialized functions using the above conditions
 template <typename valT, typename nameT>
 PORTABLE_FORCEINLINE_FUNCTION bool bad_value(valT&& value, nameT&& var_name) {
-    return violates_condition(std::forward<valT>(value), is_normal_or_zero{},
-                              std::forward<nameT>(var_name));
+  return violates_condition(std::forward<valT>(value), is_normal_or_zero{},
+                            std::forward<nameT>(var_name));
 }
 template <typename valT, typename nameT>
 PORTABLE_FORCEINLINE_FUNCTION bool non_positive_value(valT&& value, nameT&& var_name) {
-    return violates_condition(std::forward<valT>(value), is_strictly_positive{},
-                              std::forward<nameT>(var_name));
+  return violates_condition(std::forward<valT>(value), is_strictly_positive{},
+                            std::forward<nameT>(var_name));
 }
 template <typename valT, typename nameT>
 PORTABLE_FORCEINLINE_FUNCTION bool negative_value(valT&& value, nameT&& var_name) {
-    return violates_condition(std::forward<valT>(value), is_strictly_positive{},
-                              std::forward<nameT>(var_name));
+  return violates_condition(std::forward<valT>(value), is_strictly_positive{},
+                            std::forward<nameT>(var_name));
 }
 
 } // namespace error_utils

--- a/singularity-eos/base/error_utils.hpp
+++ b/singularity-eos/base/error_utils.hpp
@@ -30,7 +30,7 @@ constexpr double _NORMAL_FACTOR = 1.0e10;
 struct is_normal_or_zero {
   template <typename valT>
   bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
-    static_assert(std::is_floating_point_v<valT>);
+    static_assert(std::is_floating_point<valT>::value);
     return (value == valT{0}) ||
            (std::isnormal(_NORMAL_FACTOR * value) && std::isnormal(value));
   }
@@ -39,7 +39,7 @@ struct is_normal_or_zero {
 struct is_strictly_positive {
   template <typename valT>
   bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
-    static_assert(std::is_arithmetic_v<valT>);
+    static_assert(std::is_arithmetic<valT>::value);
     return value > valT{0};
   }
 };
@@ -47,7 +47,7 @@ struct is_strictly_positive {
 struct is_non_negative {
   template <typename valT>
   bool PORTABLE_FORCEINLINE_FUNCTION operator()(valT value) const {
-    static_assert(std::is_arithmetic_v<valT>);
+    static_assert(std::is_arithmetic<valT>::value);
     return value >= valT{0};
   }
 };

--- a/singularity-eos/eos/get_sg_eos.cpp
+++ b/singularity-eos/eos/get_sg_eos.cpp
@@ -147,7 +147,7 @@ int get_sg_eos( // sizing information
   // declare init and final functors
   auto input_int_enum = static_cast<input_condition>(input_int);
   init_functor i_func;
-  final_functor f_func(temp_v, press_v, sie_v, bmod_v, cv_v, dpde_v, pte_mats, press_pte,
+  final_functor f_func(spvol_v, temp_v, press_v, sie_v, bmod_v, cv_v, dpde_v, pte_mats, press_pte,
                        vfrac_pte, temp_pte, sie_pte, frac_mass_v, frac_ie_v, frac_vol_v,
                        vol_v, eos_v, pte_idxs, rho_pte, frac_bmod_v, frac_cv_v,
                        frac_dpde_v, nmat, do_frac_bmod, do_frac_cv, do_frac_dpde);

--- a/singularity-eos/eos/get_sg_eos.cpp
+++ b/singularity-eos/eos/get_sg_eos.cpp
@@ -147,10 +147,11 @@ int get_sg_eos( // sizing information
   // declare init and final functors
   auto input_int_enum = static_cast<input_condition>(input_int);
   init_functor i_func;
-  final_functor f_func(spvol_v, temp_v, press_v, sie_v, bmod_v, cv_v, dpde_v, pte_mats, press_pte,
-                       vfrac_pte, temp_pte, sie_pte, frac_mass_v, frac_ie_v, frac_vol_v,
-                       vol_v, eos_v, pte_idxs, rho_pte, frac_bmod_v, frac_cv_v,
-                       frac_dpde_v, nmat, do_frac_bmod, do_frac_cv, do_frac_dpde);
+  final_functor f_func(spvol_v, temp_v, press_v, sie_v, bmod_v, cv_v, dpde_v, pte_mats,
+                       press_pte, vfrac_pte, temp_pte, sie_pte, frac_mass_v, frac_ie_v,
+                       frac_vol_v, vol_v, eos_v, pte_idxs, rho_pte, frac_bmod_v,
+                       frac_cv_v, frac_dpde_v, nmat, do_frac_bmod, do_frac_cv,
+                       do_frac_dpde);
   // only initialize init functor when needed
   if (input_int_enum != input_condition::P_T_INPUT) {
     i_func = init_functor(frac_mass_v, pte_idxs, eos_offsets_v, frac_vol_v, frac_ie_v,

--- a/singularity-eos/eos/get_sg_eos.cpp
+++ b/singularity-eos/eos/get_sg_eos.cpp
@@ -48,7 +48,9 @@ int get_sg_eos( // sizing information
     // per material quantities
     double *frac_mass, double *frac_vol, double *frac_ie,
     // optional per material quantities
-    double *frac_bmod, double *frac_dpde, double *frac_cv) {
+    double *frac_bmod, double *frac_dpde, double *frac_cv,
+    // Mass fraction cutoff for PTE
+    double mass_frac_cutoff) {
   // printBacktrace();
   // kernel return value will be the number of failures
   int ret{0};
@@ -153,7 +155,7 @@ int get_sg_eos( // sizing information
   if (input_int_enum != input_condition::P_T_INPUT) {
     i_func = init_functor(frac_mass_v, pte_idxs, eos_offsets_v, frac_vol_v, frac_ie_v,
                           pte_mats, vfrac_pte, sie_pte, temp_pte, press_pte, rho_pte,
-                          spvol_v, temp_v, press_v, sie_v, nmat);
+                          spvol_v, temp_v, press_v, sie_v, nmat, mass_frac_cutoff);
   }
 
   // create helper lambdas to reduce code duplication

--- a/singularity-eos/eos/get_sg_eos.hpp
+++ b/singularity-eos/eos/get_sg_eos.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -114,7 +114,7 @@ struct init_functor {
   PORTABLE_FORCEINLINE_FUNCTION int bad_val(valT const value,
                                             const char *const var_name) const {
     const bool good =
-        (value == valT{0}) or (std::isnormal(1e10 * value) && std::isnormal(value));
+        (value == valT{0}) || (std::isnormal(1e10 * value) && std::isnormal(value));
     if (not good) {
       using PortsOfCall::printf;
       printf("### ERROR: Bad singularity-eos input\n  Var: %s\n  Value: %e\n", var_name,
@@ -291,7 +291,7 @@ struct final_functor {
   PORTABLE_FORCEINLINE_FUNCTION int bad_val(valT const value,
                                             const char *const var_name) const {
     const bool good =
-        (value == valT{0} or (std::isnormal(1e10 * value) && std::isnormal(value)));
+        (value == valT{0} || (std::isnormal(1e10 * value) && std::isnormal(value)));
     if (not good) {
       using PortsOfCall::printf;
       printf("### ERROR: Bad singularity-eos output\n  Var: %s\n  Value: %e\n", var_name,

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -16,8 +16,8 @@
 #define _SINGULARITY_EOS_EOS_GET_SG_EOS_LAMBDAS_HPP_
 
 #include <ports-of-call/portability.hpp>
-#include <singularity-eos/eos/get_sg_eos.hpp>
 #include <singularity-eos/base/error_utils.hpp>
+#include <singularity-eos/eos/get_sg_eos.hpp>
 
 #include <cmath>
 
@@ -53,14 +53,13 @@ struct init_functor {
                ScratchV<double> &vfrac_pte_, ScratchV<double> &sie_pte_,
                ScratchV<double> &temp_pte_, ScratchV<double> &press_pte_,
                ScratchV<double> &rho_pte_, dev_v &spvol_v_, dev_v &temp_v_,
-               dev_v &press_v_, dev_v &sie_v_, int &nmat,
-               double &mass_frac_cutoff_)
+               dev_v &press_v_, dev_v &sie_v_, int &nmat, double &mass_frac_cutoff_)
       : frac_mass_v{frac_mass_v_}, pte_idxs{pte_idxs_}, eos_offsets_v{eos_offsets_v_},
         frac_vol_v{frac_vol_v_}, frac_ie_v{frac_ie_v_}, pte_mats{pte_mats_},
         vfrac_pte{vfrac_pte_}, sie_pte{sie_pte_}, temp_pte{temp_pte_},
         press_pte{press_pte_}, rho_pte{rho_pte_}, spvol_v{spvol_v_}, temp_v{temp_v_},
-        press_v{press_v_}, sie_v{sie_v_}, nmat{nmat}, mass_frac_cutoff{mass_frac_cutoff_}
-        {}
+        press_v{press_v_}, sie_v{sie_v_}, nmat{nmat}, mass_frac_cutoff{
+                                                          mass_frac_cutoff_} {}
 
   PORTABLE_INLINE_FUNCTION
   void operator()(const int i, const int tid, double &mass_sum, int &npte,
@@ -119,8 +118,8 @@ struct init_functor {
 #ifndef NDEBUG
     bool any_bad_vals = false;
     for (int m = 0; m < nmat; ++m) {
-      any_bad_vals = any_bad_vals || error_utils::bad_value(frac_mass_v(i, m),
-                                                            "frac_mass");
+      any_bad_vals =
+          any_bad_vals || error_utils::bad_value(frac_mass_v(i, m), "frac_mass");
     }
     any_bad_vals = any_bad_vals || error_utils::bad_value(press_v(i), "pres");
     any_bad_vals = any_bad_vals || error_utils::bad_value(sie_v(i), "sie");
@@ -285,22 +284,30 @@ struct final_functor {
     bool any_bad_vals = false;
     for (auto mp = 0; mp < npte; ++mp) {
       const int m = pte_mats(tid, mp);
-      any_bad_vals = any_bad_vals || error_utils::bad_value(frac_mass_v(i, m), "frac_mass");
+      any_bad_vals =
+          any_bad_vals || error_utils::bad_value(frac_mass_v(i, m), "frac_mass");
       any_bad_vals = any_bad_vals || error_utils::bad_value(frac_ie_v(i, m), "frac_ie");
       any_bad_vals = any_bad_vals || error_utils::bad_value(frac_vol_v(i, m), "frac_vol");
-      any_bad_vals = any_bad_vals || error_utils::negative_value(frac_mass_v(i, m), "frac_mass");
-      any_bad_vals = any_bad_vals || error_utils::non_positive_value(frac_vol_v(i, m), "frac_vol");
+      any_bad_vals =
+          any_bad_vals || error_utils::negative_value(frac_mass_v(i, m), "frac_mass");
+      any_bad_vals =
+          any_bad_vals || error_utils::non_positive_value(frac_vol_v(i, m), "frac_vol");
       if (do_frac_bmod) {
-        any_bad_vals = any_bad_vals || error_utils::bad_value(frac_bmod_v(i, m), "frac_bmod");
-        any_bad_vals = any_bad_vals || error_utils::negative_value(frac_bmod_v(i, m), "frac_bmod");
+        any_bad_vals =
+            any_bad_vals || error_utils::bad_value(frac_bmod_v(i, m), "frac_bmod");
+        any_bad_vals =
+            any_bad_vals || error_utils::negative_value(frac_bmod_v(i, m), "frac_bmod");
       }
       if (do_frac_cv) {
         any_bad_vals = any_bad_vals || error_utils::bad_value(frac_cv_v(i, m), "frac_cv");
-        any_bad_vals = any_bad_vals || error_utils::negative_value(frac_cv_v(i, m), "frac_cv");
+        any_bad_vals =
+            any_bad_vals || error_utils::negative_value(frac_cv_v(i, m), "frac_cv");
       }
       if (do_frac_dpde) {
-        any_bad_vals = any_bad_vals || error_utils::bad_value(frac_dpde_v(i, m), "frac_dpde");
-        any_bad_vals = any_bad_vals || error_utils::negative_value(frac_dpde_v(i, m), "frac_dpde");
+        any_bad_vals =
+            any_bad_vals || error_utils::bad_value(frac_dpde_v(i, m), "frac_dpde");
+        any_bad_vals =
+            any_bad_vals || error_utils::negative_value(frac_dpde_v(i, m), "frac_dpde");
       }
     }
     any_bad_vals = any_bad_vals || error_utils::bad_value(press_v(i), "pres");

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -107,16 +107,18 @@ struct init_functor {
     }
     return;
   }
+
  private:
   // Check to make sure returned values are normal or zero
-  template<typename valT>
-  PORTABLE_FORCEINLINE_FUNCTION
-  int bad_val(valT const value, const char *const var_name) const {
-    const bool good = (value == valT{0}) or (std::isnormal(1e10 * value) and std::isnormal(value));
+  template <typename valT>
+  PORTABLE_FORCEINLINE_FUNCTION int bad_val(valT const value,
+                                            const char *const var_name) const {
+    const bool good =
+        (value == valT{0}) or (std::isnormal(1e10 * value) and std::isnormal(value));
     if (not good) {
       using PortsOfCall::printf;
-      printf("### ERROR: Bad singularity-eos input\n  Var: %s\n  Value: %e\n",
-             var_name, value);
+      printf("### ERROR: Bad singularity-eos input\n  Var: %s\n  Value: %e\n", var_name,
+             value);
     }
     return not good;
   }
@@ -282,46 +284,48 @@ struct final_functor {
     }
     return;
   }
+
  private:
   // Check to make sure returned values are normal or zero
-  template<typename valT>
-  PORTABLE_FORCEINLINE_FUNCTION
-  int bad_val(valT const value, const char *const var_name) const {
-    const bool good = (value == valT{0} or (std::isnormal(1e10 * value) and std::isnormal(value)));
+  template <typename valT>
+  PORTABLE_FORCEINLINE_FUNCTION int bad_val(valT const value,
+                                            const char *const var_name) const {
+    const bool good =
+        (value == valT{0} or (std::isnormal(1e10 * value) and std::isnormal(value)));
     if (not good) {
       using PortsOfCall::printf;
-      printf("### ERROR: Bad singularity-eos output\n  Var: %s\n  Value: %e\n",
-             var_name, value);
+      printf("### ERROR: Bad singularity-eos output\n  Var: %s\n  Value: %e\n", var_name,
+             value);
     }
     return not good;
   }
   // Check for prrecluding zero and negative (non-positive) values
-  template<typename valT>
-  PORTABLE_FORCEINLINE_FUNCTION
-  int non_positive_val(valT const value, const char *const var_name) const {
+  template <typename valT>
+  PORTABLE_FORCEINLINE_FUNCTION int non_positive_val(valT const value,
+                                                     const char *const var_name) const {
     const bool not_positive = value <= valT{0};
     if (not_positive) {
       using PortsOfCall::printf;
-      printf("### ERROR: Bad singularity-eos output\n  Var: %s\n  Value: %e\n",
-             var_name, value);
+      printf("### ERROR: Bad singularity-eos output\n  Var: %s\n  Value: %e\n", var_name,
+             value);
     }
     return not_positive;
   }
   // Check for prrecluding negative values
-  template<typename valT>
-  PORTABLE_FORCEINLINE_FUNCTION
-  int negative_val(valT const value, const char *const var_name) const {
+  template <typename valT>
+  PORTABLE_FORCEINLINE_FUNCTION int negative_val(valT const value,
+                                                 const char *const var_name) const {
     const bool negative = value < valT{0};
     if (negative) {
       using PortsOfCall::printf;
-      printf("### ERROR: Bad singularity-eos output\n  Var: %s\n  Value: %e\n",
-             var_name, value);
+      printf("### ERROR: Bad singularity-eos output\n  Var: %s\n  Value: %e\n", var_name,
+             value);
     }
     return negative;
   }
   // Only run these checks when built with debug flags
   PORTABLE_FORCEINLINE_FUNCTION
-  void check_all_vals(int const i, int const npte, int const tid, 
+  void check_all_vals(int const i, int const npte, int const tid,
                       bool const pte_converged) const {
 #ifndef NDEBUG
     int n_bad_vals = 0;

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -98,7 +98,7 @@ struct init_functor {
     for (int mp = 0; mp < npte; ++mp) {
       const int m = pte_mats(tid, mp);
       // Need to guess volume fractions
-      vfrac_pte(tid, mp) = rac_mass_v(i, m);
+      vfrac_pte(tid, mp) = frac_mass_v(i, m);
       // Calculate densities to be consistent with these volume fractions
       rho_pte(tid, mp) = frac_mass_v(i, m) / spvol_v(i) / vfrac_pte(tid, mp);
       temp_pte(tid, mp) = temp_v(i) * ev2k * t_mult;

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -138,11 +138,11 @@ struct init_functor {
     if (n_bad_vals > 0) {
       using PortsOfCall::printf;
       printf("### Bad Value Output state:\n");
-      printf("  - Bulk state -\n");
+      printf("  ~~Bulk state~~\n");
       printf("    Pressure        : % #24.15g\n", press_v(i));
       printf("    Specific IE     : % #24.15g\n", sie_v(i));
       printf("    Specific Volume : % #24.15g\n", spvol_v(i));
-      printf("  - Material States -\n");
+      printf("  ~~Mass fractions~~\n");
       printf("   mat:");
       printf(" %24s", "Mass fraction");
       printf("\n");

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -114,7 +114,7 @@ struct init_functor {
   PORTABLE_FORCEINLINE_FUNCTION int bad_val(valT const value,
                                             const char *const var_name) const {
     const bool good =
-        (value == valT{0}) or (std::isnormal(1e10 * value) and std::isnormal(value));
+        (value == valT{0}) or (std::isnormal(1e10 * value) && std::isnormal(value));
     if (not good) {
       using PortsOfCall::printf;
       printf("### ERROR: Bad singularity-eos input\n  Var: %s\n  Value: %e\n", var_name,
@@ -291,7 +291,7 @@ struct final_functor {
   PORTABLE_FORCEINLINE_FUNCTION int bad_val(valT const value,
                                             const char *const var_name) const {
     const bool good =
-        (value == valT{0} or (std::isnormal(1e10 * value) and std::isnormal(value)));
+        (value == valT{0} or (std::isnormal(1e10 * value) && std::isnormal(value)));
     if (not good) {
       using PortsOfCall::printf;
       printf("### ERROR: Bad singularity-eos output\n  Var: %s\n  Value: %e\n", var_name,

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -178,8 +178,8 @@ struct final_functor {
   bool do_frac_dpde;
 
  public:
-  final_functor(dev_v &spvol_v_, dev_v &temp_v_, dev_v &press_v_, dev_v &sie_v_, dev_v &bmod_v_,
-                dev_v &cv_v_, dev_v &dpde_v_, ScratchV<int> &pte_mats_,
+  final_functor(dev_v &spvol_v_, dev_v &temp_v_, dev_v &press_v_, dev_v &sie_v_,
+                dev_v &bmod_v_, dev_v &cv_v_, dev_v &dpde_v_, ScratchV<int> &pte_mats_,
                 ScratchV<double> &press_pte_, ScratchV<double> &vfrac_pte_,
                 ScratchV<double> &temp_pte_, ScratchV<double> &sie_pte_,
                 dev_frac_v &frac_mass_v_, dev_frac_v &frac_ie_v_, dev_frac_v &frac_vol_v_,

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -188,12 +188,12 @@ struct final_functor {
                 dev_frac_v &frac_bmod_v_, dev_frac_v &frac_cv_v_,
                 dev_frac_v &frac_dpde_v_, int &nmat_, bool do_frac_bmod_,
                 bool do_frac_cv_, bool do_frac_dpde_)
-      : spvol_v{spvol_v_}, temp_v{temp_v_}, press_v{press_v_}, sie_v{sie_v_}, bmod_v{bmod_v_}, cv_v{cv_v_},
-        dpde_v{dpde_v_}, pte_mats{pte_mats_}, press_pte{press_pte_},
-        vfrac_pte{vfrac_pte_}, temp_pte{temp_pte_}, sie_pte{sie_pte_},
-        frac_mass_v{frac_mass_v_}, frac_ie_v{frac_ie_v_}, frac_vol_v{frac_vol_v_},
-        vol_v{vol_v_}, eos_v{eos_v_}, pte_idxs{pte_idxs_}, rho_pte{rho_pte_},
-        frac_bmod_v{frac_bmod_v_}, frac_cv_v{frac_cv_v_},
+      : spvol_v{spvol_v_}, temp_v{temp_v_}, press_v{press_v_}, sie_v{sie_v_},
+        bmod_v{bmod_v_}, cv_v{cv_v_}, dpde_v{dpde_v_}, pte_mats{pte_mats_},
+        press_pte{press_pte_}, vfrac_pte{vfrac_pte_}, temp_pte{temp_pte_},
+        sie_pte{sie_pte_}, frac_mass_v{frac_mass_v_}, frac_ie_v{frac_ie_v_},
+        frac_vol_v{frac_vol_v_}, vol_v{vol_v_}, eos_v{eos_v_}, pte_idxs{pte_idxs_},
+        rho_pte{rho_pte_}, frac_bmod_v{frac_bmod_v_}, frac_cv_v{frac_cv_v_},
         frac_dpde_v{frac_dpde_v_}, nmat{nmat_}, do_frac_bmod{do_frac_bmod_},
         do_frac_cv{do_frac_cv_}, do_frac_dpde{do_frac_dpde_} {}
 

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -150,6 +150,7 @@ struct init_functor {
 
 struct final_functor {
  private:
+  dev_v spvol_v;
   dev_v temp_v;
   dev_v press_v;
   dev_v sie_v;
@@ -177,7 +178,7 @@ struct final_functor {
   bool do_frac_dpde;
 
  public:
-  final_functor(dev_v &temp_v_, dev_v &press_v_, dev_v &sie_v_, dev_v &bmod_v_,
+  final_functor(dev_v &spvol_v_, dev_v &temp_v_, dev_v &press_v_, dev_v &sie_v_, dev_v &bmod_v_,
                 dev_v &cv_v_, dev_v &dpde_v_, ScratchV<int> &pte_mats_,
                 ScratchV<double> &press_pte_, ScratchV<double> &vfrac_pte_,
                 ScratchV<double> &temp_pte_, ScratchV<double> &sie_pte_,

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -331,7 +331,7 @@ struct final_functor {
       printf("    Temperature     : % #24.15g eV\n", temp_v(i));
       printf("    Specific IE     : % #24.15e erg/g\n", sie_v(i));
       printf("    Bulk Modulus    : % #24.15e microbar\n", bmod_v(i));
-      printf("    Heat Capacity   : % #24.15e erg/g/K\n", cv_v(i));
+      printf("    Heat Capacity   : % #24.15e erg/g/eV\n", cv_v(i));
       printf("    dPdE            : % #24.15g g/cm^3\n", dpde_v(i));
       printf("  ~~Material States~~\n");
       // Maybe we can loop, but this is pretty straight-forward

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -117,7 +117,7 @@ struct init_functor {
   void check_all_vals(int const i) const {
 #ifndef NDEBUG
     bool any_bad_vals = false;
-    for (int m = 0; m < nmat; ++m) {
+    for (auto m = 0; m < nmat; ++m) {
       any_bad_vals =
           any_bad_vals || error_utils::bad_value(frac_mass_v(i, m), "frac_mass");
     }
@@ -136,7 +136,7 @@ struct init_functor {
       printf("   mat:");
       printf(" %24s", "Mass fraction");
       printf("\n");
-      for (int m = 0; m < nmat; ++m) {
+      for (auto m = 0; m < nmat; ++m) {
         printf("   %3i:", m + 1);
         printf(" %24.15g", frac_mass_v(i, m));
         printf("\n");
@@ -283,7 +283,7 @@ struct final_functor {
 #ifndef NDEBUG
     bool any_bad_vals = false;
     for (auto mp = 0; mp < npte; ++mp) {
-      const int m = pte_mats(tid, mp);
+      const auto m = pte_mats(tid, mp);
       any_bad_vals =
           any_bad_vals || error_utils::bad_value(frac_mass_v(i, m), "frac_mass");
       any_bad_vals = any_bad_vals || error_utils::bad_value(frac_ie_v(i, m), "frac_ie");
@@ -348,7 +348,7 @@ struct final_functor {
       }
       printf("\n");
       for (auto mp = 0; mp < npte; ++mp) {
-        const int m = pte_mats(tid, mp);
+        const auto m = pte_mats(tid, mp);
         printf("%7i:", m + 1);
         printf(" %24.15g", frac_mass_v(i, m));
         printf(" %24.15e", frac_ie_v(i, m));

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -98,7 +98,7 @@ struct init_functor {
     for (int mp = 0; mp < npte; ++mp) {
       const int m = pte_mats(tid, mp);
       // Need to guess volume fractions
-      vfrac_pte(tid, mp) = 1.0 / npte;
+      vfrac_pte(tid, mp) = rac_mass_v(i, m);
       // Calculate densities to be consistent with these volume fractions
       rho_pte(tid, mp) = frac_mass_v(i, m) / spvol_v(i) / vfrac_pte(tid, mp);
       temp_pte(tid, mp) = temp_v(i) * ev2k * t_mult;

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -18,6 +18,8 @@
 #include <ports-of-call/portability.hpp>
 #include <singularity-eos/eos/get_sg_eos.hpp>
 
+#include <cmath>
+
 #ifdef PORTABILITY_STRATEGY_KOKKOS
 
 namespace singularity {
@@ -71,31 +73,87 @@ struct init_functor {
     for (int m = 0; m < nmat; ++m) {
       frac_mass_v(i, m) /= mass_sum;
     }
-    /* set inputs */
+    check_all_vals(i);
+    // count the number of participating materials and zero the inputs
     npte = 0;
     for (int m = 0; m < nmat; ++m) {
       if (frac_mass_v(i, m) > 1.e-12) {
+        // participating materials are those with non-negligible mass fractions
         pte_idxs(tid, npte) = eos_offsets_v(m) - 1;
         pte_mats(tid, npte) = m;
         npte += 1;
       } else {
         frac_ie_v(i, m) = 0.0;
       }
+      // zero the inputs
       vfrac_pte(tid, m) = 0.0;
       sie_pte(tid, m) = 0.0;
       temp_pte(tid, m) = 0.0;
       press_pte(tid, m) = 0.0;
     }
+    // Populate the inputs with consistent values.
+    // NOTE: the volume fractions and densities need to be consistent with the
+    // total specific volume since they are used to calculate internal
+    // quantities for the PTE solver
     for (int mp = 0; mp < npte; ++mp) {
       const int m = pte_mats(tid, mp);
-      rho_pte(tid, mp) = npte / spvol_v(i) * frac_mass_v(i, m);
+      // Need to guess volume fractions
       vfrac_pte(tid, mp) = 1.0 / npte;
+      // Calculate densities to be consistent with these volume fractions
+      rho_pte(tid, mp) = frac_mass_v(i, m) / spvol_v(i) / vfrac_pte(tid, mp);
       temp_pte(tid, mp) = temp_v(i) * ev2k * t_mult;
       press_pte(tid, mp) = press_v(i) * p_mult;
       sie_pte(tid, mp) = sie_v(i) * frac_mass_v(i, m) * s_mult;
     }
     return;
   }
+ private:
+  // Check to make sure returned values are normal or zero
+  template<typename valT>
+  PORTABLE_FORCEINLINE_FUNCTION
+  int bad_val(valT const value, const char *const var_name) const {
+    const bool good = (value == valT{0}) or (std::isnormal(1e10 * value) and std::isnormal(value));
+    if (not good) {
+      using PortsOfCall::printf;
+      printf("### ERROR: Bad singularity-eos input\n  Var: %s\n  Value: %e\n",
+             var_name, value);
+    }
+    return not good;
+  }
+  // Only run these checks when built with debug flags
+  PORTABLE_FORCEINLINE_FUNCTION
+  void check_all_vals(int const i) const {
+#ifndef NDEBUG
+    int n_bad_vals = 0;
+
+    for (int m = 0; m < nmat; ++m) {
+      n_bad_vals += bad_val(frac_mass_v(i, m), "frac_mass");
+    }
+    n_bad_vals += bad_val(press_v(i), "pres");
+    n_bad_vals += bad_val(sie_v(i), "sie");
+    n_bad_vals += bad_val(spvol_v(i), "spvol");
+
+    if (n_bad_vals > 0) {
+      using PortsOfCall::printf;
+      printf("### Bad Value Output state:\n");
+      printf("  - Bulk state -\n");
+      printf("    Pressure        : % #24.15g\n", press_v(i));
+      printf("    Specific IE     : % #24.15g\n", sie_v(i));
+      printf("    Specific Volume : % #24.15g\n", spvol_v(i));
+      printf("  - Material States -\n");
+      printf("   mat:");
+      printf(" %24s", "Mass fraction");
+      printf("\n");
+      for (int m = 0; m < nmat; ++m) {
+        printf("   %3i:", m + 1);
+        printf(" %24.15g", frac_mass_v(i, m));
+        printf("\n");
+      }
+      PORTABLE_ALWAYS_ABORT(
+          "Bad values input to singularity-eos interface. See output for details");
+    }
+  }
+#endif // #ifndef NDEBUG
 };
 
 struct final_functor {
@@ -150,6 +208,7 @@ struct final_functor {
   PORTABLE_INLINE_FUNCTION
   void operator()(const int i, const int tid, const int npte, const Real mass_sum,
                   const Real t_mult, const Real s_mult, const Real p_mult,
+                  const bool pte_converged,
                   singularity::mix_impl::CacheAccessor &cache) const {
     /* initialize averaged quantities to 0 */
     const bool do_t = t_mult == 1.0;
@@ -216,12 +275,113 @@ struct final_functor {
     if (do_s) {
       sie_v(i) /= mass_sum;
     }
+    check_all_vals(i, npte, tid, pte_converged);
     /* reset mass fractions to original values if not normalized to 1 */
     for (int m = 0; m < nmat; ++m) {
       frac_mass_v(i, m) *= mass_sum;
     }
     return;
   }
+ private:
+  // Check to make sure returned values are normal or zero
+  template<typename valT>
+  PORTABLE_FORCEINLINE_FUNCTION
+  int bad_val(valT const value, const char *const var_name) const {
+    const bool good = (value == valT{0} or (std::isnormal(1e10 * value) and std::isnormal(value)));
+    if (not good) {
+      using PortsOfCall::printf;
+      printf("### ERROR: Bad singularity-eos output\n  Var: %s\n  Value: %e\n",
+             var_name, value);
+    }
+    return not good;
+  }
+  // Only run these checks when built with debug flags
+  PORTABLE_FORCEINLINE_FUNCTION
+  void check_all_vals(int const i, int const npte, int const tid, 
+                      bool const pte_converged) const {
+#ifndef NDEBUG
+    int n_bad_vals = 0;
+    for (int mp = 0; mp < npte; ++mp) {
+      const int m = pte_mats(tid, mp);
+      n_bad_vals += bad_val(frac_mass_v(i, m), "frac_mass");
+      n_bad_vals += bad_val(frac_ie_v(i, m), "frac_ie");
+      n_bad_vals += bad_val(frac_vol_v(i, m), "frac_vol");
+      if (frac_vol_v(i, m) <= 0) {
+        // This material has a non-zero mass fraction but a non-positive volume
+        n_bad_vals += 1;
+      }
+      if (do_frac_bmod) {
+        n_bad_vals += bad_val(frac_bmod_v(i, m), "frac_bmod");
+      }
+      if (do_frac_cv) {
+        n_bad_vals += bad_val(frac_cv_v(i, m), "frac_cv");
+      }
+      if (do_frac_dpde) {
+        n_bad_vals += bad_val(frac_dpde_v(i, m), "frac_dpde");
+      }
+    }
+    n_bad_vals += bad_val(press_v(i), "pres");
+    n_bad_vals += bad_val(temp_v(i), "temp");
+    n_bad_vals += bad_val(sie_v(i), "sie");
+    n_bad_vals += bad_val(bmod_v(i), "bmod");
+    n_bad_vals += bad_val(cv_v(i), "cv");
+    n_bad_vals += bad_val(dpde_v(i), "dpde");
+
+    if (n_bad_vals > 0) {
+      using PortsOfCall::printf;
+      printf("### Bad Value Output state:\n");
+      printf("  ~~Bulk state~~\n");
+      printf("    Pressure      : % #24.15e\n", press_v(i));
+      printf("    Temperature   : % #24.15g\n", temp_v(i));
+      printf("    Specific IE   : % #24.15e\n", sie_v(i));
+      printf("    Bulk Modulus  : % #24.15e\n", bmod_v(i));
+      printf("    Heat Capacity : % #24.15e\n", cv_v(i));
+      printf("    dPdE          : % #24.15g\n", dpde_v(i));
+      printf("  ~~Material States~~\n");
+      // Maybe we can loop, but this is pretty straight-forward
+      printf("    mat:");
+      printf(" %24s", "Mass fraction");
+      printf(" %24s", "Material IE");
+      printf(" %24s", "Material Volume");
+      if (do_frac_bmod) {
+        printf(" %24s", "Material Bulk Modulus");
+      }
+      if (do_frac_cv) {
+        printf(" %24s", "Material Heat Capacity");
+      }
+      if (do_frac_dpde) {
+        printf(" %24s", "Material dPdE");
+      }
+      printf("\n");
+      for (int mp = 0; mp < npte; ++mp) {
+        const int m = pte_mats(tid, mp);
+        printf("%7i:", m + 1);
+        printf(" %24.15g", frac_mass_v(i, m));
+        printf(" %24.15e", frac_ie_v(i, m));
+        printf(" %24.15g", frac_vol_v(i, m));
+        if (do_frac_bmod) {
+          printf(" %24.15e", frac_bmod_v(i, m));
+        }
+        if (do_frac_cv) {
+          printf(" %24.15e", frac_cv_v(i, m));
+        }
+        if (do_frac_dpde) {
+          printf(" %24.15g", frac_dpde_v(i, m));
+        }
+        printf("\n");
+      }
+      if (npte > 1) {
+        if (pte_converged) {
+          printf("  ~~PTE iteration converged~~\n");
+        } else {
+          printf("  ~~PTE iteration *DID NOT* converge~~\n");
+        }
+      }
+      PORTABLE_ALWAYS_ABORT(
+          "Bad value returned from singularity-eos interface. See output for details");
+    }
+  }
+#endif // #ifndef NDEBUG
 };
 
 } // namespace singularity

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -188,7 +188,7 @@ struct final_functor {
                 dev_frac_v &frac_bmod_v_, dev_frac_v &frac_cv_v_,
                 dev_frac_v &frac_dpde_v_, int &nmat_, bool do_frac_bmod_,
                 bool do_frac_cv_, bool do_frac_dpde_)
-      : temp_v{temp_v_}, press_v{press_v_}, sie_v{sie_v_}, bmod_v{bmod_v_}, cv_v{cv_v_},
+      : spvol_v{spvol_v_}, temp_v{temp_v_}, press_v{press_v_}, sie_v{sie_v_}, bmod_v{bmod_v_}, cv_v{cv_v_},
         dpde_v{dpde_v_}, pte_mats{pte_mats_}, press_pte{press_pte_},
         vfrac_pte{vfrac_pte_}, temp_pte{temp_pte_}, sie_pte{sie_pte_},
         frac_mass_v{frac_mass_v_}, frac_ie_v{frac_ie_v_}, frac_vol_v{frac_vol_v_},

--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -129,9 +129,9 @@ struct init_functor {
       using PortsOfCall::printf;
       printf("### Bad Value Output state:\n");
       printf("  ~~Bulk state~~\n");
-      printf("    Pressure        : % #24.15g\n", press_v(i));
-      printf("    Specific IE     : % #24.15g\n", sie_v(i));
-      printf("    Specific Volume : % #24.15g\n", spvol_v(i));
+      printf("    Pressure        : % #24.15g microbar\n", press_v(i));
+      printf("    Specific IE     : % #24.15g erg/g\n", sie_v(i));
+      printf("    Specific Volume : % #24.15g cm^3/g\n", spvol_v(i));
       printf("  ~~Mass fractions~~\n");
       printf("   mat:");
       printf(" %24s", "Mass fraction");
@@ -325,26 +325,27 @@ struct final_functor {
       using PortsOfCall::printf;
       printf("### Bad Value Output state:\n");
       printf("  ~~Bulk state~~\n");
-      printf("    Pressure      : % #24.15e\n", press_v(i));
-      printf("    Temperature   : % #24.15g\n", temp_v(i));
-      printf("    Specific IE   : % #24.15e\n", sie_v(i));
-      printf("    Bulk Modulus  : % #24.15e\n", bmod_v(i));
-      printf("    Heat Capacity : % #24.15e\n", cv_v(i));
-      printf("    dPdE          : % #24.15g\n", dpde_v(i));
+      printf("    Pressure        : % #24.15e microbar\n", press_v(i));
+      printf("    Specific Volume : % #24.15e cm^3/g\n", spvol_v(i));
+      printf("    Temperature     : % #24.15g eV\n", temp_v(i));
+      printf("    Specific IE     : % #24.15e erg/g\n", sie_v(i));
+      printf("    Bulk Modulus    : % #24.15e microbar\n", bmod_v(i));
+      printf("    Heat Capacity   : % #24.15e erg/g/K\n", cv_v(i));
+      printf("    dPdE            : % #24.15g g/cm^3\n", dpde_v(i));
       printf("  ~~Material States~~\n");
       // Maybe we can loop, but this is pretty straight-forward
       printf("    mat:");
-      printf(" %24s", "Mass fraction");
-      printf(" %24s", "Material IE");
-      printf(" %24s", "Material Volume");
+      printf(" %24s", "Mass fraction (--)");
+      printf(" %24s", "Material IE (erg)");
+      printf(" %24s", "Material Volume (cm^3)");
       if (do_frac_bmod) {
-        printf(" %24s", "Material Bulk Modulus");
+        printf(" %24s", "Material BMod (ubar)");
       }
       if (do_frac_cv) {
-        printf(" %24s", "Material Heat Capacity");
+        printf(" %24s", "Material Cv (erg/g/eV)");
       }
       if (do_frac_dpde) {
-        printf(" %24s", "Material dPdE");
+        printf(" %24s", "Material dPdE (g/cm^3)");
       }
       printf("\n");
       for (auto mp = 0; mp < npte; ++mp) {

--- a/singularity-eos/eos/get_sg_eos_p_t.cpp
+++ b/singularity-eos/eos/get_sg_eos_p_t.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/eos/get_sg_eos_p_t.cpp
+++ b/singularity-eos/eos/get_sg_eos_p_t.cpp
@@ -85,7 +85,7 @@ void get_sg_eos_p_t(const char *name, int ncell, int nmat, indirection_v &offset
           vfrac_pte(tid, m) /= vfrac_tot;
         }
         // assign remaining outputs
-        f_func(i, tid, nmat, mass_sum, 0.0, 0.0, 0.0, cache);
+        f_func(i, tid, nmat, mass_sum, 0.0, 0.0, 0.0, true, cache);
         // assign max pressure
         pmax_v(i) = press_v(i) > pmax_v(i) ? press_v(i) : pmax_v(i);
         // release the token used for scratch arrays

--- a/singularity-eos/eos/get_sg_eos_rho_e.cpp
+++ b/singularity-eos/eos/get_sg_eos_rho_e.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -47,6 +47,7 @@ void get_sg_eos_rho_e(const char *name, int ncell, indirection_v &offsets_v,
         const int neq = npte + 1;
         singularity::mix_impl::CacheAccessor cache(&solver_scratch(tid, 0) +
                                                    neq * (neq + 4) + 2 * npte);
+        bool pte_converged = true;
         if (npte > 1) {
           // create solver lambda
           // eos accessor
@@ -56,7 +57,7 @@ void get_sg_eos_rho_e(const char *name, int ncell, indirection_v &offsets_v,
               npte, eos_inx, 1.0, sie_v(i), &rho_pte(tid, 0), &vfrac_pte(tid, 0),
               &sie_pte(tid, 0), &temp_pte(tid, 0), &press_pte(tid, 0), cache,
               &solver_scratch(tid, 0));
-          const bool res_{PTESolver(method)};
+          pte_converged = PTESolver(method);
         } else {
           // pure cell (nmat = 1)
           temp_pte(tid, 0) = eos_v(pte_idxs(tid, 0))
@@ -67,7 +68,7 @@ void get_sg_eos_rho_e(const char *name, int ncell, indirection_v &offsets_v,
                                       rho_pte(tid, 0), temp_pte(tid, 0), cache[0]);
         }
         // assign outputs
-        f_func(i, tid, npte, mass_sum, 1.0, 0.0, 1.0, cache);
+        f_func(i, tid, npte, mass_sum, 1.0, 0.0, 1.0, pte_converged, cache);
         // assign max pressure
         pmax_v(i) = press_v(i) > pmax_v(i) ? press_v(i) : pmax_v(i);
         // release the token used for scratch arrays

--- a/singularity-eos/eos/get_sg_eos_rho_t.cpp
+++ b/singularity-eos/eos/get_sg_eos_rho_t.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -49,6 +49,7 @@ void get_sg_eos_rho_t(const char *name, int ncell, indirection_v &offsets_v,
         const int neq = npte;
         singularity::mix_impl::CacheAccessor cache(&solver_scratch(tid, 0) +
                                                    neq * (neq + 4) + 2 * npte);
+        bool pte_converged = true;
         if (npte > 1) {
           // create solver lambda
           // eos accessor
@@ -57,7 +58,7 @@ void get_sg_eos_rho_t(const char *name, int ncell, indirection_v &offsets_v,
               npte, eos_inx, 1.0, temp_pte(tid, 0), &rho_pte(tid, 0), &vfrac_pte(tid, 0),
               &sie_pte(tid, 0), &temp_pte(tid, 0), &press_pte(tid, 0), cache,
               &solver_scratch(tid, 0));
-          const bool res_{PTESolver(method)};
+          pte_converged = PTESolver(method);
           // calculate total internal energy
           for (int mp = 0; mp < npte; ++mp) {
             const int m = pte_mats(tid, mp);
@@ -79,7 +80,7 @@ void get_sg_eos_rho_t(const char *name, int ncell, indirection_v &offsets_v,
         // total sie is known
         sie_v(i) = sie_tot_true;
         // assign quantities
-        f_func(i, tid, npte, mass_sum, 0.0, 0.0, 1.0, cache);
+        f_func(i, tid, npte, mass_sum, 0.0, 0.0, 1.0, pte_converged, cache);
         // assign max pressure
         pmax_v(i) = press_v(i) > pmax_v(i) ? press_v(i) : pmax_v(i);
         // release the token used for scratch arrays

--- a/singularity-eos/eos/singularity_eos.f90
+++ b/singularity-eos/eos/singularity_eos.f90
@@ -1,5 +1,5 @@
 !------------------------------------------------------------------------------
-! © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+! © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 ! program was produced under U.S. Government contract 89233218CNA000001
 ! for Los Alamos National Laboratory (LANL), which is operated by Triad
 ! National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/eos/singularity_eos.f90
+++ b/singularity-eos/eos/singularity_eos.f90
@@ -377,7 +377,7 @@ contains
     real(kind=8), dimension(:,:), target, optional, intent(inout) :: frac_bmod
     real(kind=8), dimension(:,:), target, optional, intent(inout) :: frac_dpde
     real(kind=8), dimension(:,:), target, optional, intent(inout) :: frac_cv
-    real(kind=c_double),                  optional, intent(in) :: mass_frac_cutoff
+    real(kind=8),                         optional, intent(in)    :: mass_frac_cutoff
 
     ! pointers
     type(c_ptr) :: bmod_ptr, dpde_ptr, cv_ptr

--- a/singularity-eos/eos/singularity_eos.f90
+++ b/singularity-eos/eos/singularity_eos.f90
@@ -298,7 +298,8 @@ module singularity_eos
                  offsets,&
                  press, pmax, vol, spvol, sie, temp, bmod, dpde, cv,&
                  frac_mass, frac_vol, frac_sie,&
-                 frac_bmod, frac_dpde, frac_cv, mass_frac_cutoff)&
+                 frac_bmod, frac_dpde, frac_cv,&
+                 mass_frac_cutoff)&
       bind(C, name='get_sg_eos')
       import
       integer(kind=c_int), value, intent(in) :: nmat

--- a/singularity-eos/eos/singularity_eos.hpp
+++ b/singularity-eos/eos/singularity_eos.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/eos/singularity_eos.hpp
+++ b/singularity-eos/eos/singularity_eos.hpp
@@ -114,9 +114,11 @@ int get_sg_eos( // sizing information
     double *press, double *pmax, double *vol, double *spvol, double *sie, double *temp,
     double *bmod, double *dpde, double *cv,
     // per material quantities
-    double *frac_mass, double *frac_vol, double *frac_sie,
+    double *frac_mass, double *frac_vol, double *frac_ie,
     // optional per material quantities
-    double *frac_bmod, double *frac_dpde, double *frac_cv);
+    double *frac_bmod, double *frac_dpde, double *frac_cv,
+    // Mass fraction cutoff for PTE
+    double mass_frac_cutoff);
 
 int finalize_sg_eos(const int nmat, EOS *&eos, const int own_kokkos = 0);
 

--- a/utils/scripts/format.sh
+++ b/utils/scripts/format.sh
@@ -39,6 +39,6 @@ for f in $(git grep --untracked -ail res -- :/*.hpp :/*.cpp); do
     if [ ${VERBOSE} -ge 1 ]; then
        echo ${f}
     fi
-    ${CFM} -i ${REPO}/${f}
+    ${CFM} -style=file -i ${REPO}/${f}
 done
 echo "...Done"


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

When the library is built with debug flags, this adds introspection functions to the `init` and `final` functors in the `get_sg_eos` interface.

These functions check to make sure the values being passed are either zero or normal. I'm using slightly more complicated logic than just `is_finite` so that I can detect underflow values as well. For some quantities, I'm also including checks to make sure the returned value is strictly positive or non-negative where appropriate.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- N/A Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- N/A Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- N/A Update the version in cmake.
- N/A Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
