### PR TITLE
Fix #endif locations

### DIFF
--- a/singularity-eos/eos/get_sg_eos_functors.hpp
+++ b/singularity-eos/eos/get_sg_eos_functors.hpp
@@ -144,8 +144,8 @@ struct init_functor {
       PORTABLE_ALWAYS_ABORT(
           "Bad values INPUT to singularity-eos interface. See output for details");
     }
-  }
 #endif // #ifndef NDEBUG
+  }
 };
 
 struct final_functor {
@@ -376,8 +376,8 @@ struct final_functor {
       PORTABLE_ALWAYS_ABORT(
           "Bad value RETURNED from singularity-eos. See output for details");
     }
-  }
 #endif // #ifndef NDEBUG
+  }
 };
 
 } // namespace singularity


### PR DESCRIPTION
Currently building in release mode on main gives the following errors:

```console
 78     In file included from /var/folders/c7/8jd35_cn1d780xhx4jwpzt40000rgj/T/ptb/spack-stage/spack-stage-singularity-eos-git.8260182
            f89897aefdf2e34fd30a11e7f7777eec9_1.8.2-ukalvuw2x2ig5e46ryqqozonojzwhwtu/spack-src/singularity-eos/eos/get_sg_eos_rho_t.cpp:19
            :
  >> 79     /var/folders/c7/8jd35_cn1d780xhx4jwpzt40000rgj/T/ptb/spack-stage/spack-stage-singularity-eos-git.8260182f89897aefdf2e34fd30a11
            e7f7777eec9_1.8.2-ukalvuw2x2ig5e46ryqqozonojzwhwtu/spack-src/singularity-eos/eos/get_sg_eos_functors.hpp:383:2: error: expecte
            d ';' after struct
     80     } // namespace singularity
     81      ^
     82      ;
  >> 83     /var/folders/c7/8jd35_cn1d780xhx4jwpzt40000rgj/T/ptb/spack-stage/spack-stage-singularity-eos-git.8260182f89897aefdf2e34fd30a11
            e7f7777eec9_1.8.2-ukalvuw2x2ig5e46ryqqozonojzwhwtu/spack-src/singularity-eos/eos/get_sg_eos_functors.hpp:28:8: error: missing
            '}' at end of definition of 'singularity::init_functor'
     84     struct init_functor {
     85            ^
...
```
The culprits are two `#endif`s that were on the incorrect lines 