### PR TITLE
Add missing eos_powermg header to install

### DIFF
--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -40,6 +40,7 @@ register_headers(
     eos/eos_ideal.hpp
     eos/eos_models.hpp
     eos/eos_mgusup.hpp
+    eos/eos_powermg.hpp
     eos/eos_spiner.hpp
     eos/eos_davis.hpp
     eos/eos_gruneisen.hpp


### PR DESCRIPTION
Add `eos/eos_powermg.hpp` to installed headers