### PR TITLE
Fix for internal energy scaling in PTE closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added (new features/APIs/variables/...)
 
 ### Fixed (Repair bugs, etc)
+- [[PR401]](https://github.com/lanl/singularity-eos/pull/401) Fix for internal energy scaling in PTE closure
 
 ### Changed (changing behavior/API/variables/...)
 
@@ -44,7 +45,7 @@ Date: 7/29/2024
 ### Changed (changing behavior/API/variables/...)
 - [[PR363]](https://github.com/lanl/singularity-eos/pull/363) Template lambda values for scalar calls
 - [[PR372]](https://github.com/lanl/singularity-eos/pull/372) Removed E0 from Davis Products EOS in favor of using the shifted EOS modifier. CHANGES API!
-- [[PR#382]](https://github.com/lanl/singularity-eos/pull/382) Changed `get_sg_eos()` API to allow optionally specifying the mass fraction cutoff for materials to participate in the PTE solver 
+- [[PR#382]](https://github.com/lanl/singularity-eos/pull/382) Changed `get_sg_eos()` API to allow optionally specifying the mass fraction cutoff for materials to participate in the PTE solver
 
 ### Infrastructure (changes irrelevant to downstream codes)
 - [[PR329]](https://github.com/lanl/singularity-eos/pull/329) Move vinet tests into analytic test suite

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -310,7 +310,7 @@ class PTESolverBase {
 
     // intialize rhobar array and final density
     InitRhoBarandRho();
-    uscale = rho_total * abs(sie_total);
+    uscale = rho_total * sie_total;
 
     // guess some non-zero temperature to start
     const Real Tguess = GetTguess();
@@ -328,11 +328,8 @@ class PTESolverBase {
     }
 
     // note the scaling of the material internal energy densities
-    uscale_total = 0.0;
-    for (int m = 0; m < nmat; ++m) {
+    for (int m = 0; m < nmat; ++m)
       u[m] = sie[m] * robust::ratio(rhobar[m], uscale);
-      uscale_total += u[m];
-    }
   }
 
   PORTABLE_INLINE_FUNCTION
@@ -455,7 +452,7 @@ class PTESolverBase {
   const RealIndexer &press;
   Real *jacobian, *dx, *sol_scratch, *residual, *u, *rhobar;
   CacheAccessor Cache;
-  Real rho_total, uscale, uscale_total, Tnorm;
+  Real rho_total, uscale, Tnorm;
 };
 
 } // namespace mix_impl
@@ -542,7 +539,6 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::press;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho_total;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale_total;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::MatIndex;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::TryIdealPTE;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::jacobian;
@@ -594,7 +590,8 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
       esum += u[m];
     }
     residual[0] = vfrac_total - vsum;
-    residual[1] = uscale_total - esum;
+    // the 1 here is the scaled total internal energy density
+    residual[1] = 1.0 - esum;
     for (int m = 0; m < nmat - 1; ++m) {
       residual[2 + m] = press[m + 1] - press[m];
     }
@@ -769,7 +766,6 @@ class PTESolverFixedT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::press;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho_total;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale_total;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::MatIndex;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::jacobian;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::residual;
@@ -821,11 +817,9 @@ class PTESolverFixedT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
       // note the scaling of pressure
       press[m] = eos[m].PressureFromDensityTemperature(rho[m], Tequil, Cache[m]);
     }
-    uscale_total = 0.0;
     for (int m = 0; m < nmat; ++m) {
       press[m] = robust::ratio(press[m], uscale);
       u[m] = sie[m] * robust::ratio(rhobar[m], uscale);
-      uscale_total += u[m];
     }
     Residual();
     return ResidualNorm();
@@ -837,6 +831,7 @@ class PTESolverFixedT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
     for (int m = 0; m < nmat; ++m) {
       vsum += vfrac[m];
     }
+    // the 1 here is the scaled volume fraction
     residual[0] = vfrac_total - vsum;
     for (int m = 0; m < nmat - 1; ++m) {
       residual[1 + m] = press[m] - press[m + 1];
@@ -980,7 +975,6 @@ class PTESolverFixedP : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::press;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho_total;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale_total;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::MatIndex;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::TryIdealPTE;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::jacobian;
@@ -1033,12 +1027,10 @@ class PTESolverFixedP : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
     }
 
     // note the scaling of the material internal energy densities
-    uscale_total = 0.0;
     for (int m = 0; m < nmat; ++m) {
       u[m] = robust::ratio(sie[m] * rhobar[m], uscale);
       press[m] = robust::ratio(
           eos[m].PressureFromDensityTemperature(rho[m], Tguess, Cache[m]), uscale);
-      uscale_total += u[m];
     }
     Residual();
     // Set the current guess for the equilibrium temperature.  Note that this is already
@@ -1215,7 +1207,6 @@ class PTESolverRhoU : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::press;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho_total;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale_total;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::TryIdealPTE;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::MatIndex;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::jacobian;
@@ -1266,7 +1257,8 @@ class PTESolverRhoU : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
       esum += u[m];
     }
     residual[0] = vfrac_total - vsum;
-    residual[1] = uscale_total - esum;
+    // the 1 here is the scaled total internal energy density
+    residual[1] = 1.0 - esum;
     for (int m = 0; m < nmat - 1; ++m) {
       residual[2 + m] = press[m + 1] - press[m];
     }

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -310,7 +310,10 @@ class PTESolverBase {
 
     // intialize rhobar array and final density
     InitRhoBarandRho();
-    uscale = rho_total * sie_total;
+    const Real utotal = rho_total * sie_total;
+    uscale = std::abs(utotal);
+    // TODO(): Consider edge case when utotal \simeq 0
+    utotal_scale = robust::ratio(utotal, uscale);
 
     // guess some non-zero temperature to start
     const Real Tguess = GetTguess();
@@ -452,7 +455,7 @@ class PTESolverBase {
   const RealIndexer &press;
   Real *jacobian, *dx, *sol_scratch, *residual, *u, *rhobar;
   CacheAccessor Cache;
-  Real rho_total, uscale, Tnorm;
+  Real rho_total, uscale, utotal_scale, Tnorm;
 };
 
 } // namespace mix_impl
@@ -539,6 +542,7 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::press;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho_total;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::utotal_scale;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::MatIndex;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::TryIdealPTE;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::jacobian;
@@ -590,8 +594,7 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
       esum += u[m];
     }
     residual[0] = vfrac_total - vsum;
-    // the 1 here is the scaled total internal energy density
-    residual[1] = 1.0 - esum;
+    residual[1] = utotal_scale - esum;
     for (int m = 0; m < nmat - 1; ++m) {
       residual[2 + m] = press[m + 1] - press[m];
     }
@@ -831,7 +834,6 @@ class PTESolverFixedT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
     for (int m = 0; m < nmat; ++m) {
       vsum += vfrac[m];
     }
-    // the 1 here is the scaled volume fraction
     residual[0] = vfrac_total - vsum;
     for (int m = 0; m < nmat - 1; ++m) {
       residual[1 + m] = press[m] - press[m + 1];
@@ -1207,6 +1209,7 @@ class PTESolverRhoU : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::press;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho_total;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::utotal_scale;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::TryIdealPTE;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::MatIndex;
   using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::jacobian;
@@ -1257,8 +1260,7 @@ class PTESolverRhoU : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
       esum += u[m];
     }
     residual[0] = vfrac_total - vsum;
-    // the 1 here is the scaled total internal energy density
-    residual[1] = 1.0 - esum;
+    residual[1] = utotal_scale - esum;
     for (int m = 0; m < nmat - 1; ++m) {
       residual[2 + m] = press[m + 1] - press[m];
     }

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -203,15 +203,15 @@ SCENARIO("Density-Temperature PTE Solver", "[PTE]") {
         Real u_bulk_out = std::numeric_limits<Real>::max();
         const bool pte_converged = run_PTE_from_state(num_pte, v_EOS, spvol_bulk,
                                                       sie_bulk, mass_frac, u_bulk_out);
-        // Check that PTE converged
         CHECK(pte_converged);
-        // Check that PTE obeys the bulk internal energy constraint
-        // NOTE(@pdmullen): The following fails prior to PR401
-        const Real u_bulk = ratio(sie_bulk, spvol_bulk);
-        const Real u_scale = std::abs(u_bulk);
-        const Real u_bulk_scale = ratio(u_bulk, u_scale);
-        const Real residual = std::abs(u_bulk_scale - ratio(u_bulk_out, u_scale));
-        CHECK(residual < pte_rel_tolerance_e);
+        AND_THEN("The solution satisfies the bulk internal energy constraint") {
+          // NOTE(@pdmullen): The following fails prior to PR401
+          const Real u_bulk = ratio(sie_bulk, spvol_bulk);
+          const Real u_scale = std::abs(u_bulk);
+          const Real u_bulk_scale = ratio(u_bulk, u_scale);
+          const Real residual = std::abs(u_bulk_scale - ratio(u_bulk_out, u_scale));
+          CHECK(residual < pte_rel_tolerance_e);
+        }
         // Free EOS copies on device
         PORTABLE_FREE(v_EOS);
       }
@@ -232,15 +232,15 @@ SCENARIO("Density-Temperature PTE Solver", "[PTE]") {
         Real u_bulk_out = std::numeric_limits<Real>::max();
         const bool pte_converged = run_PTE_from_state(num_pte, v_EOS, spvol_bulk,
                                                       sie_bulk, mass_frac, u_bulk_out);
-        // // Check that PTE converged
         // CHECK(pte_converged);
-        // // Check that PTE obeys the bulk internal energy constraint
-        // // NOTE(@pdmullen): The following fails prior to PR401
-        // const Real u_bulk = ratio(sie_bulk, spvol_bulk);
-        // const Real u_scale = std::abs(u_bulk);
-        // const Real u_bulk_scale = ratio(u_bulk, u_scale);
-        // const Real residual = std::abs(u_bulk_scale - ratio(u_bulk_out, u_scale));
-        // CHECK(residual < pte_rel_tolerance_e);
+        // AND_THEN("The solution satisfies the bulk internal energy constraint") {
+        //   // NOTE(@pdmullen): The following fails prior to PR401
+        //   const Real u_bulk = ratio(sie_bulk, spvol_bulk);
+        //   const Real u_scale = std::abs(u_bulk);
+        //   const Real u_bulk_scale = ratio(u_bulk, u_scale);
+        //   const Real residual = std::abs(u_bulk_scale - ratio(u_bulk_out, u_scale));
+        //   CHECK(residual < pte_rel_tolerance_e);
+        // }
         // Free EOS copies on device
         PORTABLE_FREE(v_EOS);
       }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
The _total_ volumetric internal energy 

$$ u_\mathrm{total} = \sum_m \bar{\rho}_m e_m $$  

can be a negative quantity.  I believe that the internal energy scaling routines in `singularity/main` `mixed_cell_models.hpp` do not respect this.  For example, here: https://github.com/lanl/singularity-eos/blob/main/singularity-eos/closure/mixed_cell_models.hpp#L313, an `abs` is applied to the (potentially negative) `sie_total` to compute `uscale`.  In the case of a negative `sie_total`, the sum of the resultant, scaled `u[m]` can be `-1`.  Inside residual calculations (e.g., https://github.com/lanl/singularity-eos/blob/main/singularity-eos/closure/mixed_cell_models.hpp#L594), a positive 1 is assumed for the sum over scaled material internal energies.  

I believe the fix here is to just remove the `abs` (as here: https://github.com/lanl/singularity-eos/commit/c843e16ab51ee27f7d870ee7e2ae1a7a8b5d52c6).  However, after some discussion with folks, this means that the sign of `uscale` can depend on the sign of `sie_tot`... an alternative choice is to introduce `uscale_total = (sie_tot > 0.0) ? 1.0 : -1.0`

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
