### PR TITLE
Sgerberding adding python eos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR402]](https://github.com/lanl/singularity-eos/pull/402) Added stiff gas to python interface
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -36,10 +36,6 @@ PYBIND11_MODULE(singularity_eos, m) {
   .def(py::init())
   .def(py::init<Real, Real, Real, Real>(), py::arg("gm1"), py::arg("Cv"), py::arg("Pinf"), py::arg("q"));
 
-  //eos_class<NobleAble>(m, "NobleAble")
-  //.def(py::init())
-  //.def(py::init<Real, Real, Real, Real>(), py::arg("gm1"), py::arg("Cv"), py::arg("b"), py::arg("q"))
-
   eos_class<Gruneisen>(m, "Gruneisen")
     .def(py::init())
     .def(

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -36,6 +36,9 @@ PYBIND11_MODULE(singularity_eos, m) {
   .def(py::init())
   .def(py::init<Real, Real, Real, Real>(), py::arg("gm1"), py::arg("Cv"), py::arg("q"), py:;arg("Pinf"));
 
+  eos_class<NobleAble>(m, "NobleAble")
+  .def(py::init())
+  .def(py::init<Real, Real, Real, Real>(), py::arg("gm1"), py::arg("Cv"), py::arg("b"), py::arg("q"))
 
   eos_class<Gruneisen>(m, "Gruneisen")
     .def(py::init())

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -34,11 +34,11 @@ PYBIND11_MODULE(singularity_eos, m) {
 
   eos_class<StiffGas>(m, "StiffGas")
   .def(py::init())
-  .def(py::init<Real, Real, Real, Real>(), py::arg("gm1"), py::arg("Cv"), py::arg("q"), py:;arg("Pinf"));
+  .def(py::init<Real, Real, Real, Real>(), py::arg("gm1"), py::arg("Cv"), py::arg("Pinf"), py:arg("q"));
 
-  eos_class<NobleAble>(m, "NobleAble")
-  .def(py::init())
-  .def(py::init<Real, Real, Real, Real>(), py::arg("gm1"), py::arg("Cv"), py::arg("b"), py::arg("q"))
+  //eos_class<NobleAble>(m, "NobleAble")
+  //.def(py::init())
+  //.def(py::init<Real, Real, Real, Real>(), py::arg("gm1"), py::arg("Cv"), py::arg("b"), py::arg("q"))
 
   eos_class<Gruneisen>(m, "Gruneisen")
     .def(py::init())

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -34,7 +34,7 @@ PYBIND11_MODULE(singularity_eos, m) {
 
   eos_class<StiffGas>(m, "StiffGas")
   .def(py::init())
-  .def(py::init<Real, Real, Real, Real>(), py::arg("gm1"), py::arg("Cv"), py::arg("Pinf"), py:arg("q"));
+  .def(py::init<Real, Real, Real, Real>(), py::arg("gm1"), py::arg("Cv"), py::arg("Pinf"), py::arg("q"));
 
   //eos_class<NobleAble>(m, "NobleAble")
   //.def(py::init())

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -32,6 +32,11 @@ PYBIND11_MODULE(singularity_eos, m) {
       py::arg("gm1"), py::arg("Cv")
     );
 
+  eos_class<StiffGas>(m, "StiffGas")
+  .def(py::init())
+  .def(py::init<Real, Real, Real, Real>(), py::arg("gm1"), py::arg("Cv"), py::arg("q"), py:;arg("Pinf"));
+
+
   eos_class<Gruneisen>(m, "Gruneisen")
     .def(py::init())
     .def(

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -120,6 +120,36 @@ class Variant {
         eos_);
   }
 
+  /////////////////////////////
+  /// NEW SGERBERDING STUFF ///
+  /////////////////////////////
+
+  template <typename Indexer_t = Real *>
+  PORTABLE_INLINE_FUNCTION Real InternalEnergyFromDensityPressure(
+      const Real rho, const Real pressure,
+      Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
+    return mpark::visit(
+        [&rho, &pressure, &lambda](const auto &eos) {
+          return eos.InternalEnergyFromDensityPressure(rho, pressure, lambda);
+        },
+        eos_);
+  }
+
+    template <typename Indexer_t = Real *>
+      PORTABLE_INLINE_FUNCTION Real TemperatureFromDensityPressure(
+          const Real rho, const Real pressure,
+          Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
+        return mpark::visit(
+            [&rho, &pressure, &lambda](const auto &eos) {
+              return eos.TemperatureFromDensityPressure(rho, pressure, lambda);
+            },
+            eos_);
+      }
+
+//////////////////////////////////////
+//////////////////////////////////////
+//////////////////////////////////////
+
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real PressureFromDensityTemperature(
       const Real rho, const Real temperature,

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -120,36 +120,6 @@ class Variant {
         eos_);
   }
 
-  /////////////////////////////
-  /// NEW SGERBERDING STUFF ///
-  /////////////////////////////
-
-  template <typename Indexer_t = Real *>
-  PORTABLE_INLINE_FUNCTION Real InternalEnergyFromDensityPressure(
-      const Real rho, const Real pressure,
-      Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
-    return mpark::visit(
-        [&rho, &pressure, &lambda](const auto &eos) {
-          return eos.InternalEnergyFromDensityPressure(rho, pressure, lambda);
-        },
-        eos_);
-  }
-
-    template <typename Indexer_t = Real *>
-      PORTABLE_INLINE_FUNCTION Real TemperatureFromDensityPressure(
-          const Real rho, const Real pressure,
-          Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
-        return mpark::visit(
-            [&rho, &pressure, &lambda](const auto &eos) {
-              return eos.TemperatureFromDensityPressure(rho, pressure, lambda);
-            },
-            eos_);
-      }
-
-//////////////////////////////////////
-//////////////////////////////////////
-//////////////////////////////////////
-
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real PressureFromDensityTemperature(
       const Real rho, const Real temperature,

--- a/test/python_bindings.py
+++ b/test/python_bindings.py
@@ -67,7 +67,7 @@ class EOS(unittest.TestCase):
     def testIdealGas(self):
         eos = singularity_eos.IdealGas(1,1)
 
-    def testStiffGase(self):
+    def testStiffGas(self):
         eos = singularity_eos.StiffGas(1,1,1)
 
     def testShiftedIdealGas(self):

--- a/test/python_bindings.py
+++ b/test/python_bindings.py
@@ -68,7 +68,7 @@ class EOS(unittest.TestCase):
         eos = singularity_eos.IdealGas(1,1)
 
     def testStiffGas(self):
-        eos = singularity_eos.StiffGas(1,1,1)
+        eos = singularity_eos.StiffGas(1,1,1,1)
 
     def testShiftedIdealGas(self):
         eos = singularity_eos.Shifted(singularity_eos.IdealGas(1,1),1)

--- a/test/python_bindings.py
+++ b/test/python_bindings.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+# © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 # program was produced under U.S. Government contract 89233218CNA000001
 # for Los Alamos National Laboratory (LANL), which is operated by Triad
 # National Security, LLC for the U.S.  Department of Energy/National

--- a/test/python_bindings.py
+++ b/test/python_bindings.py
@@ -67,6 +67,9 @@ class EOS(unittest.TestCase):
     def testIdealGas(self):
         eos = singularity_eos.IdealGas(1,1)
 
+    def testStiffGase(self):
+        eos = singularity_eos.StiffGas(1,1,1)
+
     def testShiftedIdealGas(self):
         eos = singularity_eos.Shifted(singularity_eos.IdealGas(1,1),1)
 


### PR DESCRIPTION
## PR Summary

Added StiffGas into module.cpp so that stiff gas can be called in python bindings. 

Can be called using (for example): 

```python
from singularity_eos import StiffGas
gm1 = 5./3. - 1
Cv = 2

gamma = 5./3.
q = -(gamma/(gamma-1))
P_inf = 1
sing_stiff_gas = StiffGas(gm1, Cv, P_inf, q)

```

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- N/A Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
