### PR TITLE
eospac serialization fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [[PR330]](https://github.com/lanl/singularity-eos/pull/330) Piecewise grids for Spiner EOS.
 
 ### Fixed (Repair bugs, etc)
+- [[PR417]](https://github.com/lanl/singularity-eos/pull/417) Bugs in shared memory related to eospac resolved
 - [[PR330]](https://github.com/lanl/singularity-eos/pull/330) Includes a fix for extrapolation of specific internal energy in SpinerEOS.
 - [[PR401]](https://github.com/lanl/singularity-eos/pull/401) Fix for internal energy scaling in PTE closure
 - [[PR403]](https://github.com/lanl/singularity-eos/pull/403) Fix Gruneisen EOS DensityEnergyFromPressureTemperature function

--- a/cmake/singularity-eos/hdf5.cmake
+++ b/cmake/singularity-eos/hdf5.cmake
@@ -73,7 +73,9 @@ macro(singularity_enable_hdf5 target)
     
     target_include_directories(${target} SYSTEM INTERFACE ${HDF5_INCLUDE_DIRS})
     target_link_libraries(${target} INTERFACE ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES})
-    
+    target_link_libraries(${target} INTERFACE dl)
+    target_link_libraries(${target} INTERFACE z)
+
     if(HDF5_IS_PARALLEL)
       # find_package(MPI COMPONENTS C CXX REQUIRED)
       # target_link_libraries(${target} INTERFACE MPI::MPI_C MPI::MPI_CXX)

--- a/singularity-eos/closure/kinetic_phasetransition_methods.hpp
+++ b/singularity-eos/closure/kinetic_phasetransition_methods.hpp
@@ -14,6 +14,7 @@
 
 #ifndef _SINGULARITY_EOS_CLOSURE_KINETIC_PHSETRANSITION_METHODS_
 #define _SINGULARITY_EOS_CLOSURE_KINETIC_PHSETRANSITION_METHODS_
+#ifdef SINGULARITY_BUILD_CLOSURE
 
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_errors.hpp>
@@ -97,4 +98,5 @@ PORTABLE_INLINE_FUNCTION void SmallStepMFUpdate(const Real logdt, const int num_
 
 } // namespace singularity
 
+#endif // SINGULARITY_BUILD_CLOSURE
 #endif // _SINGULARITY_EOS_CLOSURE_KINETIC_PHSETRANSITION_METHODS_

--- a/singularity-eos/closure/kinetic_phasetransition_models.hpp
+++ b/singularity-eos/closure/kinetic_phasetransition_models.hpp
@@ -15,6 +15,8 @@
 #ifndef _SINGULARITY_EOS_CLOSURE_KINETIC_PHSETRANSITION_MODELS_
 #define _SINGULARITY_EOS_CLOSURE_KINETIC_PHSETRANSITION_MODELS_
 
+#ifdef SINGULARITY_BUILD_CLOSURE
+
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_errors.hpp>
 #include <singularity-eos/base/fast-math/logs.hpp>
@@ -94,4 +96,5 @@ PORTABLE_INLINE_FUNCTION Real LogMaxTimeStep(const int num_phases, const Real *m
 
 } // namespace singularity
 
+#endif // SINGULARITY_BUILD_CLOSURE
 #endif // _SINGULARITY_EOS_CLOSURE_KINETIC_PHSETRANSITION_MODELS_

--- a/singularity-eos/closure/kinetic_phasetransition_utils.hpp
+++ b/singularity-eos/closure/kinetic_phasetransition_utils.hpp
@@ -15,6 +15,8 @@
 #ifndef _SINGULARITY_EOS_CLOSURE_KINETIC_PHSETRANSITION_UTILS_
 #define _SINGULARITY_EOS_CLOSURE_KINETIC_PHSETRANSITION_UTILS_
 
+#ifdef SINGULARITY_BUILD_CLOSURE
+
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_errors.hpp>
 #include <singularity-eos/base/fast-math/logs.hpp>
@@ -58,4 +60,5 @@ PORTABLE_INLINE_FUNCTION void SortGibbs(const int num_phases, const Real *gibbs,
 
 } // namespace singularity
 
+#endif // SINGULARITY_BUILD_CLOSURE
 #endif // _SINGULARITY_EOS_CLOSURE_KINETIC_PHSETRANSITION_UTILS_

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -1251,14 +1251,14 @@ inline std::size_t EOSPAC::SetDynamicMemory(char *src, const SharedMemSettings &
   static_assert(sizeof(char) == sizeof(EOS_CHAR), "EOS_CHAR is one byte");
   EOS_INTEGER NTABLES[] = {NT};
   EOS_INTEGER error_code = EOS_OK;
-  eosCheckError(error_code, "eos_DestroyAll", Verbosity::Debug);
 #ifdef SINGULARITY_EOSPAC_ENABLE_SHARED_MEMORY
   PORTABLE_ALWAYS_REQUIRE(
       stngs.data != nullptr,
       "EOSPAC with shared memory active requires a shared memory pointer");
-  // JMM: EOS_BOOLEAN is an enum with EOS_FALSE=0 and EOS_TRUE=1.
+  // EOS_BOOLEAN is not a type alias
+  EOS_BOOLEAN root = stngs.is_domain_root ? EOS_TRUE : EOS_FALSE;
   eos_SetSharedPackedTables(NTABLES, &packed_size_, (EOS_CHAR *)src,
-                            (EOS_CHAR *)stngs.data, stngs.is_node_root, tablehandle,
+                            (EOS_CHAR *)stngs.data, root, tablehandle,
                             &error_code);
 #else
   eos_SetPackedTables(NTABLES, &packed_size_, (EOS_CHAR *)src, tablehandle, &error_code);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,12 +47,14 @@ add_executable(
   test_eos_stellar_collapse.cpp
   )
 
-add_executable(
-  closure_unit_tests
-  catch2_define.cpp
-  test_closure_pte.cpp
-  test_kpt_models.cpp
-  )
+if (SINGULARITY_BUILD_CLOSURE)
+  add_executable(
+    closure_unit_tests
+    catch2_define.cpp
+    test_closure_pte.cpp
+    test_kpt_models.cpp
+    )
+endif()
 
 get_property(plugin_tests GLOBAL PROPERTY PLUGIN_TESTS)
 if (plugin_tests)
@@ -71,7 +73,6 @@ endif()
 
 if(SINGULARITY_TEST_SESAME)
   target_compile_definitions(eos_tabulated_unit_tests PRIVATE SINGULARITY_TEST_SESAME)
-  target_compile_definitions(closure_unit_tests PRIVATE SINGULARITY_TEST_SESAME)
 endif()
 if(SINGULARITY_TEST_STELLAR_COLLAPSE)
   target_compile_definitions(eos_tabulated_unit_tests
@@ -84,8 +85,6 @@ target_link_libraries(eos_infrastructure_tests PRIVATE Catch2::Catch2
   singularity-eos::singularity-eos)
 target_link_libraries(eos_tabulated_unit_tests PRIVATE Catch2::Catch2
   singularity-eos::singularity-eos)
-target_link_libraries(closure_unit_tests PRIVATE Catch2::Catch2
-  singularity-eos::singularity-eos)
 if (plugin_tests)
   target_link_libraries(eos_plugin_tests PRIVATE Catch2::Catch2
     singularity-eos::singularity-eos)
@@ -94,7 +93,6 @@ include(Catch)
 catch_discover_tests(eos_analytic_unit_tests PROPERTIES TIMEOUT 60)
 catch_discover_tests(eos_infrastructure_tests PROPERTIES TIMEOUT 60)
 catch_discover_tests(eos_tabulated_unit_tests PROPERTIES TIMEOUT 60)
-catch_discover_tests(closure_unit_tests PROPERTIES TIMEOUT 120)
 if (plugin_tests)
   catch_discover_tests(eos_plugin_tests PROPERTIES TIMEOUT 60)
 endif()
@@ -106,6 +104,13 @@ if(SINGULARITY_USE_EOSPAC AND SINGULARITY_TEST_SESAME)
 endif()
 
 if(SINGULARITY_BUILD_CLOSURE)
+  if (SINGULARITY_TEST_SESAME)
+    target_compile_definitions(closure_unit_tests PRIVATE SINGULARITY_TEST_SESAME)
+  endif()
+  target_link_libraries(closure_unit_tests PRIVATE Catch2::Catch2
+    singularity-eos::singularity-eos)
+  catch_discover_tests(closure_unit_tests PROPERTIES TIMEOUT 120)
+
   if(SINGULARITY_USE_SPINER)
     add_executable(test_pte test_pte.cpp)
     target_link_libraries(test_pte PRIVATE Catch2::Catch2

--- a/test/test_eos_tabulated.cpp
+++ b/test/test_eos_tabulated.cpp
@@ -269,8 +269,8 @@ SCENARIO("SpinerEOS and EOSPAC Serialization",
     SpinerEOSDependsRhoT rhoT_orig = SpinerEOSDependsRhoT(eosName, steelID);
     SpinerEOSDependsRhoSie rhoSie_orig = SpinerEOSDependsRhoSie(eosName, steelID);
     EOS eospac_orig = EOSPAC(steelID);
-    // not actually used but we want to stress test that we can serialize
-    // and deserialize multiple EOSPAC objects
+    // we want to stress test that we can serialize and deserialize
+    // multiple EOSPAC objects
     EOS eospac_air = EOSPAC(airID);
     THEN("They report dynamic vs static memory correctly") {
       REQUIRE(rhoT_orig.AllDynamicMemoryIsShareable());

--- a/test/test_eos_tabulated.cpp
+++ b/test/test_eos_tabulated.cpp
@@ -269,12 +269,17 @@ SCENARIO("SpinerEOS and EOSPAC Serialization",
     SpinerEOSDependsRhoT rhoT_orig = SpinerEOSDependsRhoT(eosName, steelID);
     SpinerEOSDependsRhoSie rhoSie_orig = SpinerEOSDependsRhoSie(eosName, steelID);
     EOS eospac_orig = EOSPAC(steelID);
+    // not actually used but we want to stress test that we can serialize
+    // and deserialize multiple EOSPAC objects
+    EOS eospac_air = EOSPAC(airID); 
     THEN("They report dynamic vs static memory correctly") {
       REQUIRE(rhoT_orig.AllDynamicMemoryIsShareable());
       REQUIRE(rhoSie_orig.AllDynamicMemoryIsShareable());
       REQUIRE(!eospac_orig.AllDynamicMemoryIsShareable());
       REQUIRE(eospac_orig.SerializedSizeInBytes() >
               eospac_orig.DynamicMemorySizeInBytes());
+      REQUIRE(eospac_air.SerializedSizeInBytes() >
+              eospac_air.DynamicMemorySizeInBytes());
     }
     WHEN("We serialize") {
       auto [rhoT_size, rhoT_data] = rhoT_orig.Serialize();
@@ -285,7 +290,10 @@ SCENARIO("SpinerEOS and EOSPAC Serialization",
 
       auto [eospac_size, eospac_data] = eospac_orig.Serialize();
       REQUIRE(eospac_size == eospac_orig.SerializedSizeInBytes());
-
+      
+      auto [air_size, air_data] = eospac_air.Serialize();
+      REQUIRE(air_size == eospac_air.SerializedSizeInBytes());
+     
       const std::size_t rhoT_shared_size = rhoT_orig.DynamicMemorySizeInBytes();
       REQUIRE(rhoT_size > rhoT_shared_size);
 
@@ -294,6 +302,9 @@ SCENARIO("SpinerEOS and EOSPAC Serialization",
 
       const std::size_t eospac_shared_size = eospac_orig.DynamicMemorySizeInBytes();
       REQUIRE(eospac_size > eospac_shared_size);
+
+      const std::size_t air_shared_size = eospac_air.DynamicMemorySizeInBytes();
+      REQUIRE(air_size > eospac_shared_size);
 
       THEN("We can deserialize into shared memory") {
         using singularity::SharedMemSettings;
@@ -304,6 +315,7 @@ SCENARIO("SpinerEOS and EOSPAC Serialization",
         char *rhoT_shared_data = (char *)malloc(rhoT_shared_size);
         char *rhoSie_shared_data = (char *)malloc(rhoSie_shared_size);
         char *eospac_shared_data = (char *)malloc(eospac_shared_size);
+        char *air_shared_data = (char *)malloc(air_shared_size);
 
         SpinerEOSDependsRhoT eos_rhoT;
         std::size_t read_size_rhoT =
@@ -322,6 +334,12 @@ SCENARIO("SpinerEOS and EOSPAC Serialization",
         std::size_t read_size_eospac = eos_eospac.DeSerialize(
             eospac_data, SharedMemSettings(eospac_shared_data, true));
         REQUIRE(read_size_eospac == eospac_size);
+
+        eospac_air.Finalize();
+        EOS eos_air_2 = EOSPAC();
+        std::size_t read_size_air = eos_air_2.DeSerialize(
+            air_data, SharedMemSettings(air_shared_data, true));
+        REQUIRE(read_size_air == air_size);
 
         AND_THEN("EOS lookups work") {
           constexpr Real rho_trial = 1;

--- a/test/test_eos_tabulated.cpp
+++ b/test/test_eos_tabulated.cpp
@@ -304,7 +304,7 @@ SCENARIO("SpinerEOS and EOSPAC Serialization",
       REQUIRE(eospac_size > eospac_shared_size);
 
       const std::size_t air_shared_size = eospac_air.DynamicMemorySizeInBytes();
-      REQUIRE(air_size > eospac_shared_size);
+      REQUIRE(air_size > air_shared_size);
 
       THEN("We can deserialize into shared memory") {
         using singularity::SharedMemSettings;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In the previous serialization MR #410 I punted one issue with EOSPAC. This MR now fixes the inconsistencies. I test EOSPAC with shared memory in the unit tests and I update the default cmake option to assume shared memory is available.

I also had to add some link libraries (available in the standard library) that HDF5 depends on to FindHDF5 as cmake was not properly adding them. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
