### PR TITLE
Cleanup test PTE structure and remove variant from shared header

### DIFF
--- a/.github/workflows/tests_minimal_kokkos.yml
+++ b/.github/workflows/tests_minimal_kokkos.yml
@@ -1,4 +1,4 @@
-name: Tests Minimal No Kokkos
+name: Tests Minimal With Kokkos
 
 on:
   push:
@@ -32,7 +32,7 @@ jobs:
                   -DSINGULARITY_USE_SPINER_WITH_HDF5=OFF \
                   -DSINGULARITY_BUILD_TESTS=ON \
                   -DSINGULARITY_FORCE_SUBMODULE_MODE=ON \
-                  -DSINGULARITY_USE_KOKKOS=OFF \
+                  -DSINGULARITY_USE_KOKKOS=ON \
                   ..
             make
             make install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [[PR330]](https://github.com/lanl/singularity-eos/pull/330) Piecewise grids for Spiner EOS.
 
 ### Fixed (Repair bugs, etc)
+- [[PR420]](https://github.com/lanl/singularity-eos/pull/420) Fix broken test_get_sg_eos
 - [[PR417]](https://github.com/lanl/singularity-eos/pull/417) Bugs in shared memory related to eospac resolved
 - [[PR330]](https://github.com/lanl/singularity-eos/pull/330) Includes a fix for extrapolation of specific internal energy in SpinerEOS.
 - [[PR401]](https://github.com/lanl/singularity-eos/pull/401) Fix for internal energy scaling in PTE closure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,10 @@ if(SINGULARITY_USE_HIGH_RISK_MATH)
   target_compile_definitions(singularity-eos_Interface
                              INTERFACE SINGULARITY_USE_HIGH_RISK_MATH)
 endif()
+if (SINGULARITY_USE_TRUE_LOG_GRIDDING)
+  target_compile_definitions(singularity-eos_Interface
+    SINGULARITY_USE_TRUE_LOG_GRIDDING)
+endif()
 if(SINGULARITY_TEST_SESAME)
   target_compile_definitions(singularity-eos_Interface INTERFACE SINGULARITY_TEST_SESAME)
 endif()

--- a/test/pte_longtest_2phaseVinetSn.hpp
+++ b/test/pte_longtest_2phaseVinetSn.hpp
@@ -83,10 +83,10 @@ inline void set_eos(T *eos) {
                                0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
                                0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.};
 
-  EOS Snbeta = singularity::Vinet(7.285, 298.0, 0.529e12, 5.3345, 0.000072977, 0.2149e07,
-                                  0.658e09, 0.4419e07, d2to40);
-  EOS Sngamma = singularity::Vinet(7.271, 298.0, 0.3878e12, 6.0532, 0.0001085405,
-                                   0.2161e07, 1.025e09, 0.5051e07, d2to40);
+  T Snbeta = singularity::Vinet(7.285, 298.0, 0.529e12, 5.3345, 0.000072977, 0.2149e07,
+                                0.658e09, 0.4419e07, d2to40);
+  T Sngamma = singularity::Vinet(7.271, 298.0, 0.3878e12, 6.0532, 0.0001085405, 0.2161e07,
+                                 1.025e09, 0.5051e07, d2to40);
   eos[0] = Snbeta.GetOnDevice();
   eos[1] = Sngamma.GetOnDevice();
   return;

--- a/test/pte_test_2phaseVinetSn.hpp
+++ b/test/pte_test_2phaseVinetSn.hpp
@@ -59,10 +59,10 @@ inline void set_eos(T *eos) {
                                0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
                                0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.};
 
-  EOS Snbeta = singularity::Vinet(7.285, 298.0, 0.529e12, 5.3345, 0.000072977, 0.2149e07,
-                                  0.658e09, 0.4419e07, d2to40);
-  EOS Sngamma = singularity::Vinet(7.271, 298.0, 0.3878e12, 6.0532, 0.0001085405,
-                                   0.2161e07, 1.025e09, 0.5051e07, d2to40);
+  T Snbeta = singularity::Vinet(7.285, 298.0, 0.529e12, 5.3345, 0.000072977, 0.2149e07,
+                                0.658e09, 0.4419e07, d2to40);
+  T Sngamma = singularity::Vinet(7.271, 298.0, 0.3878e12, 6.0532, 0.0001085405, 0.2161e07,
+                                 1.025e09, 0.5051e07, d2to40);
   eos[0] = Snbeta.GetOnDevice();
   eos[1] = Sngamma.GetOnDevice();
   return;

--- a/test/pte_test_3mat_analytic.hpp
+++ b/test/pte_test_3mat_analytic.hpp
@@ -30,17 +30,15 @@ constexpr int HIST_SIZE = 10;
 using singularity::DavisProducts;
 using singularity::DavisReactants;
 using singularity::Gruneisen;
-using singularity::Variant;
-using EOS = Variant<Gruneisen, DavisReactants, DavisProducts>;
 
 template <typename T>
 inline void set_eos(T *eos) {
-  EOS gr = singularity::Gruneisen(394000.0, 1.489, 0.0, 0.0, 2.02, 0.47, 8.93, 297.0,
-                                  1.0e6, 0.383e7);
-  EOS dr = singularity::DavisReactants(1.890, 4.115e10, 1.0e6, 297.0, 1.8e5, 4.6, 0.34,
-                                       0.56, 0.0, 0.4265, 0.001074e10);
-  EOS dp = singularity::DavisProducts(0.798311, 0.58, 1.35, 2.66182, 0.75419, 3.2e10,
-                                      0.001072e10);
+  T gr = singularity::Gruneisen(394000.0, 1.489, 0.0, 0.0, 2.02, 0.47, 8.93, 297.0, 1.0e6,
+                                0.383e7);
+  T dr = singularity::DavisReactants(1.890, 4.115e10, 1.0e6, 297.0, 1.8e5, 4.6, 0.34,
+                                     0.56, 0.0, 0.4265, 0.001074e10);
+  T dp = singularity::DavisProducts(0.798311, 0.58, 1.35, 2.66182, 0.75419, 3.2e10,
+                                    0.001072e10);
   eos[0] = gr.GetOnDevice();
   eos[1] = dr.GetOnDevice();
   eos[2] = dp.GetOnDevice();

--- a/test/pte_test_5phaseSesameSn.hpp
+++ b/test/pte_test_5phaseSesameSn.hpp
@@ -80,10 +80,10 @@ inline void set_eos(T *eos) {
 
   // bool invert_at_setup = true;
 
-  EOS Snbeta = singularity::EOSPAC(SnbetaID);
-  EOS Sngamma = singularity::EOSPAC(SngammaID);
+  T Snbeta = singularity::EOSPAC(SnbetaID);
+  T Sngamma = singularity::EOSPAC(SngammaID);
   //  EOS Sndelta = singularity::EOSPAC(SndeltaID);
-  EOS Snhcp = singularity::EOSPAC(SnhcpID);
+  T Snhcp = singularity::EOSPAC(SnhcpID);
   //  EOS Snliquid = singularity::EOSPAC(SnliquidID);
 
   eos[0] = Snbeta.GetOnDevice();

--- a/test/test_get_sg_eos.cpp
+++ b/test/test_get_sg_eos.cpp
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 
 #include <ports-of-call/portability.hpp>
+#include <pte_test_3mat_analytic.hpp>
 #include <pte_test_utils.hpp>
 #include <singularity-eos/closure/mixed_cell_models.hpp>
 #include <singularity-eos/eos/eos.hpp>

--- a/test/test_pte.cpp
+++ b/test/test_pte.cpp
@@ -21,7 +21,7 @@
 
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
-#include <pte_test_first.hpp>
+#include <pte_test_3mat_analytic.hpp>
 #include <pte_test_utils.hpp>
 #include <singularity-eos/closure/mixed_cell_models.hpp>
 #include <spiner/databox.hpp>
@@ -32,6 +32,8 @@
 using DataBox = Spiner::DataBox<Real>;
 using singularity::PTESolverRhoT;
 using singularity::PTESolverRhoTRequiredScratch;
+using singularity::Variant;
+using EOS = Variant<Gruneisen, DavisReactants, DavisProducts>;
 
 int main(int argc, char *argv[]) {
 

--- a/test/test_pte_2phase.cpp
+++ b/test/test_pte_2phase.cpp
@@ -28,14 +28,13 @@
 #include <singularity-eos/eos/eos_models.hpp>
 #include <singularity-eos/eos/eos_variant.hpp>
 
-// these two headers share a variant
-using EOS = singularity::Variant<singularity::Vinet>;
 #include <pte_longtest_2phaseVinetSn.hpp>
 #include <pte_test_2phaseVinetSn.hpp>
 
 using namespace pte_longtest_2phaseVinetSn;
 using singularity::PTESolverRhoT;
 using singularity::PTESolverRhoTRequiredScratch;
+using EOS = singularity::Variant<singularity::Vinet>;
 
 using DataBox = Spiner::DataBox<Real>;
 

--- a/test/test_pte_3phase.cpp
+++ b/test/test_pte_3phase.cpp
@@ -28,12 +28,12 @@
 #include <singularity-eos/eos/eos_models.hpp>
 #include <singularity-eos/eos/eos_variant.hpp>
 
-using EOS = singularity::Variant<singularity::EOSPAC>;
 #include <pte_test_5phaseSesameSn.hpp>
 
 using DataBox = Spiner::DataBox<Real>;
 using singularity::PTESolverRhoT;
 using singularity::PTESolverRhoTRequiredScratch;
+using EOS = singularity::Variant<singularity::EOSPAC>;
 
 int main(int argc, char *argv[]) {
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

What it says on the can. In a previous MR (where I was cleaning things up) I broke the test in `test_get_sg_eos`. I'm not sure why the CI didn't catch this---going to leave that mystery to @rbberger . To reproduce, build with at least

```
﻿﻿﻿﻿﻿cmake -DSINGULARITY_USE_KOKKOS=ON -DSINGULARITY_BUILD_TESTS=ON -DSINGULARITY_USE_FORTRAN=ON -DSINGULARITY_FORCE_SUBMODULE_MODE=ON ..
```

This MR resolves the issue and also cleans up the organization of the tests a bit by:
- Renaming the offending header file something more descriptive
- Moving the variant declarations (when they are needed by tests) into the implementation files
- Making the tests not depend on include order by more properly templating the `set_eos` function

I also thread through a missing cmake definition for fast logs. Unrelated to the rest of this MR.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
