### PR TITLE
Fix reference to old cuda_compatibility patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [[PR330]](https://github.com/lanl/singularity-eos/pull/330) Piecewise grids for Spiner EOS.
 
 ### Fixed (Repair bugs, etc)
+- [[PR424]](https://github.com/lanl/singularity-eos/pull/424) Fix for variant patch: point to correct patch file
 - [[PR420]](https://github.com/lanl/singularity-eos/pull/420) Fix broken test_get_sg_eos
 - [[PR417]](https://github.com/lanl/singularity-eos/pull/417) Bugs in shared memory related to eospac resolved
 - [[PR330]](https://github.com/lanl/singularity-eos/pull/330) Includes a fix for extrapolation of specific internal energy in SpinerEOS.

--- a/cmake/singularity-eos/mpark_variant.cmake
+++ b/cmake/singularity-eos/mpark_variant.cmake
@@ -7,7 +7,7 @@ macro(singularity_import_mpark_variant)
       COMMAND
         patch -N -s -V never
         ${CMAKE_CURRENT_SOURCE_DIR}/utils/variant/include/mpark/variant.hpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/utils/cuda_compatibility.patch)
+        ${CMAKE_CURRENT_SOURCE_DIR}/utils/gpu_compatibility.patch)
   endif()
   if(NOT TARGET mpark_variant)
     add_subdirectory(utils/variant)


### PR DESCRIPTION
The `variant` patch erroneously referenced the old `cuda_compatibility.patch`. This PR fixes that to point to `gpu_compatibility.patch`.

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
