### PR TITLE
Make sure that DensityEnergyFromPressureTemperature works for all equations of state

### DIFF
--- a/.github/workflows/tests_minimal.yml
+++ b/.github/workflows/tests_minimal.yml
@@ -36,5 +36,4 @@ jobs:
                   ..
             make -j4
             make install
-            make test
-            ctest --output-on-failure --rerun-failed
+            ctest --output-on-failure

--- a/.github/workflows/tests_minimal.yml
+++ b/.github/workflows/tests_minimal.yml
@@ -37,3 +37,4 @@ jobs:
             make -j4
             make install
             make test
+            ctest --output-on-failure --rerun-failed

--- a/.github/workflows/tests_minimal_kokkos.yml
+++ b/.github/workflows/tests_minimal_kokkos.yml
@@ -36,4 +36,4 @@ jobs:
                   ..
             make -j4
             make install
-            make test
+            ctest --output-on-failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [[PR444]](https://github.com/lanl/singularity-eos/pull/444) Add Z split modifier and electron ideal gas EOS
 
 ### Fixed (Repair bugs, etc)
+- [[PR449]](https://github.com/lanl/singularity-eos/pull/449) Ensure that DensityEnergyFromPressureTemperature works for all equations of state and is properly tested
 - [[PR439]](https://github.com/lanl/singularity-eos/pull/439) Add mean atomic mass and number to EOS API
 - [[PR437]](https://github.com/lanl/singularity-eos/pull/437) Fix segfault on HIP, clean up warnings, add strict sanitizer test
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -1172,3 +1172,35 @@ Similarly,
 
 returns the density at which pressure is minimized for a given
 temperature. This is again useful for root finds.
+
+The function
+
+.. code-block:: cpp
+
+  template <typename Indexer_t = Real*>
+  void DensityEnergyFromPressureTemperature(const Real press, const Real temp,
+                                            Indexer_t &&lambda, Real &rho, Real &sie) const;
+
+is designed for working in Pressure-Temperature space. Given a
+pressure ``press`` and temperature ``temp``, it sets a density ``rho``
+and specific internal energy ``sie``.
+
+.. note::
+
+  Note that ``lambda`` must be passed in, whether or not a given
+  equation of state requires one. You may pass in ``nullptr`` safely,
+  however.
+
+Typically this operation requires a root find. You may pass in an
+initial guess for the density ``rho`` in-place and most EOS models
+will use it.
+
+.. warning::
+
+  Pressure is not necessarily monotone in density and it may be double
+  valued. Thus you are not guaranteed to find the correct root and the
+  value of your initial guess may determine correctness. The fact that
+  ``rho`` may be used as an initial guess means you **must** pass in
+  an initialized variable, even if it is zero-initialized. Do not pass
+  uninitialized memory into this function!
+

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -1171,7 +1171,18 @@ Similarly,
 .. cpp:function:: Real RhoPmin(const Real temp) const;
 
 returns the density at which pressure is minimized for a given
-temperature. This is again useful for root finds.
+temperature. The function
+
+.. cpp:function:: Real MinimumPressure() const;
+
+provides the minimum pressure an equation of state supports, which may
+be the most negative tension state. The function
+
+.. cpp:function:: Real MaximumPressureFromTemperature() const;
+
+provides a maximum possible pressure an equation of state
+supports. (Most models are unbounded in pressure.) This is again
+useful for root finds.
 
 The function
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -1194,13 +1194,8 @@ The function
 
 is designed for working in Pressure-Temperature space. Given a
 pressure ``press`` and temperature ``temp``, it sets a density ``rho``
-and specific internal energy ``sie``.
-
-.. note::
-
-  Note that ``lambda`` must be passed in, whether or not a given
-  equation of state requires one. You may pass in ``nullptr`` safely,
-  however.
+and specific internal energy ``sie``. The ``lambda`` is optional and
+defaults to a ``nullptr``.
 
 Typically this operation requires a root find. You may pass in an
 initial guess for the density ``rho`` in-place and most EOS models

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -1143,16 +1143,30 @@ quantities as outputs.
 Methods Used for Mixed Cell Closures
 --------------------------------------
 
-Several methods were developed in support of mixed cell closures. In particular:
+Several methods were developed in support of mixed cell closures. In particular the function
 
 .. cpp:function:: Real MinimumDensity() const;
 
-and 
+the function
 
 .. cpp:function:: Real MinimumTemperature() const;
 
+and the function
+
+.. cpp:function:: Real MaximumDensity() const;
+
 provide bounds for valid inputs into a table, which can be used by a
-root finder to meaningful bound the root search. Similarly,
+root finder to meaningful bound the root search.
+
+.. warning::
+
+  For unbounded equations of state, ``MinimumDensity`` and
+  ``MinimumTemperature`` will return zero, while ``MaximumDensity``
+  will return a very large finite number. Which number you get,
+  however, is not guaranteed. You may wish to apply more sensible
+  bounds in your own code.
+
+Similarly,
 
 .. cpp:function:: Real RhoPmin(const Real temp) const;
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -1178,11 +1178,11 @@ temperature. The function
 provides the minimum pressure an equation of state supports, which may
 be the most negative tension state. The function
 
-.. cpp:function:: Real MaximumPressureFromTemperature() const;
+.. cpp:function:: Real MaximumPressureAtTemperature(const Real temp) const;
 
-provides a maximum possible pressure an equation of state
-supports. (Most models are unbounded in pressure.) This is again
-useful for root finds.
+provides a maximum possible pressure an equation of state supports at
+a given temperature. (Most models are unbounded in pressure.) This is
+again useful for root finds.
 
 The function
 

--- a/eospac-wrapper/eospac_wrapper.cpp
+++ b/eospac-wrapper/eospac_wrapper.cpp
@@ -25,9 +25,9 @@
 namespace EospacWrapper {
 
 void eosGetMetadata(int matid, SesameMetadata &metadata, Verbosity eospacWarn) {
-  constexpr int NT = 2;
+  constexpr int NT = 3;
   EOS_INTEGER tableHandle[NT];
-  EOS_INTEGER tableType[NT] = {EOS_Info, EOS_Ut_DT};
+  EOS_INTEGER tableType[NT] = {EOS_Info, EOS_Ut_DT, EOS_Pt_DT};
 
   EOS_INTEGER commentsHandle[1];
   EOS_INTEGER commentsType[1] = {EOS_Comment};
@@ -48,7 +48,8 @@ void eosGetMetadata(int matid, SesameMetadata &metadata, Verbosity eospacWarn) {
     }
   }
 
-  eosSafeLoad(NT, matid, tableType, tableHandle, {"EOS_Info", "EOS_Ut_DT"}, eospacWarn);
+  eosSafeLoad(NT, matid, tableType, tableHandle, {"EOS_Info", "EOS_Ut_DT", "EOS_Pt_DT"},
+              eospacWarn);
 
   for (int i = 0; i < numInfoTables; i++) {
     eosSafeTableInfo(&(tableHandle[i]), NI[i], infoItems[i].data(), infoVals[i].data(),
@@ -66,6 +67,8 @@ void eosGetMetadata(int matid, SesameMetadata &metadata, Verbosity eospacWarn) {
   metadata.TMax = temperatureFromSesame(infoVals[1][3]);
   metadata.sieMin = sieFromSesame(infoVals[1][4]);
   metadata.sieMax = sieFromSesame(infoVals[1][5]);
+  metadata.PMin = pressureFromSesame(infoVals[2][4]);
+  metadata.PMax = pressureFromSesame(infoVals[2][5]);
   metadata.numRho = static_cast<int>(infoVals[1][6]);
   metadata.numT = static_cast<int>(infoVals[1][7]);
   metadata.rhoConversionFactor = infoVals[1][8];

--- a/eospac-wrapper/eospac_wrapper.hpp
+++ b/eospac-wrapper/eospac_wrapper.hpp
@@ -59,6 +59,7 @@ class SesameMetadata {
   double rhoMin, rhoMax;
   double TMin, TMax;
   double sieMin, sieMax;
+  double PMin, PMax;
   double rhoConversionFactor;
   double TConversionFactor;
   double sieConversionFactor;

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -869,8 +869,8 @@ class EosBase {
     auto PofRT = [&](const Real r) {
       return copy.PressureFromDensityTemperature(r, temp, lambda);
     };
-    Real rhoguess = rho; // use input density
-    if ((rhoguess < rhomin) || (rhoguess > rhomax)) {
+    Real rhoguess = rho;                                // use input density
+    if ((rhoguess <= rhomin) || (rhoguess >= rhomax)) { // avoid edge effects
       if ((rhomin < DEFAULT_RHO_GUESS) && (DEFAULT_RHO_GUESS < rhomax)) {
         rhoguess = DEFAULT_RHO_GUESS;
       } else {

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -856,10 +856,10 @@ class EosBase {
     using RootFinding1D::findRoot; // more robust but slower. Better default.
     using RootFinding1D::Status;
 
-    // Pressure is not monotone in density at low densities, due to a
-    // phase transition, which can prevent convergence. We want to
-    // approach tension from above, not below. Choose close to, but
-    // above, normal density for a metal like copper.
+    // Pressure is not monotone in density at low densities, which can
+    // prevent convergence. We want to approach tension from above,
+    // not below. Choose close to, but above, normal density for a
+    // metal like copper.
     constexpr Real DEFAULT_RHO_GUESS = 12;
 
     CRTP copy = *(static_cast<CRTP const *>(this));
@@ -870,14 +870,13 @@ class EosBase {
       return copy.PressureFromDensityTemperature(r, temp, lambda);
     };
     Real rhoguess = rho; // use input density
-    if ((rhoguess < rhomin) || (rhoguess > rhomax)) {
-      if ((rhomin < DEFAULT_RHO_GUESS) && (DEFAULT_RHO_GUESS < rhomax)) {
+    if ((rhoguess <= rhomin) || (rhoguess >= rhomax)) {
+      if ((rhomin <= DEFAULT_RHO_GUESS) && (DEFAULT_RHO_GUESS <= rhomax)) {
         rhoguess = DEFAULT_RHO_GUESS;
       } else {
         rhoguess = 0.5 * (rhomin + rhomax);
       }
     }
-    printf("%.14e %.14e %.14e\n", rhomin, rhomax, rhoguess);
     auto status = findRoot(PofRT, press, rhoguess, rhomin, rhomax, robust::EPS(),
                            robust::EPS(), rho);
     // JMM: This needs to not fail and instead return something sane

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -877,7 +877,6 @@ class EosBase {
         rhoguess = 0.5 * (rhomin + rhomax);
       }
     }
-    // JMM: Demand as much tolerance as we can, but don't reset rho below.
     auto status = findRoot(PofRT, press, rhoguess, rhomin, rhomax, robust::EPS(),
                            robust::EPS(), rho);
     // JMM: This needs to not fail and instead return something sane.

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -864,7 +864,7 @@ class EosBase {
 
     CRTP copy = *(static_cast<CRTP const *>(this));
     // P(rho) not monotone. When relevant, bound rhopmin.
-    Real rhomin = std::max(copy.rhoPmin(temp), copy.MinimumDensity());
+    Real rhomin = std::max(copy.RhoPmin(temp), copy.MinimumDensity());
     Real rhomax = copy.MaximumDensity();
     auto PofRT = [&](const Real r) {
       return copy.PressureFromDensityTemperature(r, temp, lambda);

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -848,7 +848,7 @@ class EosBase {
     constexpr Real MAXFAC = 1e8;
     constexpr Real EPS = 10 * robust::EPS();
     constexpr Real MINR_DEFAULT = 1e-4;
-    using RootFinding1D::regula_falsi;
+    using RootFinding1D::findRoot; // more robust but slower. Better default.
     using RootFinding1D::Status;
     CRTP copy = *(static_cast<CRTP const *>(this));
     auto PofRT = [&](const Real r) {
@@ -863,7 +863,7 @@ class EosBase {
     // JMM: This can't be zero, in case MinimumDensity is zero
     Real rhomin = std::max(MINR_DEFAULT, copy.MinimumDensity());
     Real rhomax = MAXFAC * rhomin;
-    auto status = regula_falsi(PofRT, press, rhoguess, rhomin, rhomax, EPS, EPS, rho);
+    auto status = findRoot(PofRT, press, rhoguess, rhomin, rhomax, EPS, EPS, rho);
     if (status != Status::SUCCESS) {
       PORTABLE_THROW_OR_ABORT(
           "DensityEnergyFromPressureTemperature failed to find root\n");

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -854,6 +854,7 @@ class EosBase {
   DensityEnergyFromPressureTemperature(const Real press, const Real temp,
                                        Indexer_t &&lambda, Real &rho, Real &sie) const {
     using RootFinding1D::findRoot; // more robust but slower. Better default.
+    using RootFinding1D::regula_falsi;
     using RootFinding1D::Status;
 
     // Pressure is not monotone in density at low densities, which can

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -877,12 +877,13 @@ class EosBase {
         rhoguess = 0.5 * (rhomin + rhomax);
       }
     }
-    auto status = findRoot(PofRT, press, rhoguess, rhomin, rhomax, robust::EPS(),
-                           robust::EPS(), rho);
-    // JMM: This needs to not fail and instead return something sane
+    auto status = findRoot(PofRT, press, rhoguess, rhomin, rhomax, 10 * robust::EPS(),
+                           10 * robust::EPS(), rho);
+    // JMM: This needs to not fail and instead return something sane.
+    // If root find failed to converge, density will at least be
+    // within bounds.
     if (status != Status::SUCCESS) {
       PORTABLE_WARN("DensityEnergyFromPressureTemperature failed to find root\n");
-      rho = rhoguess;
     }
     sie = copy.InternalEnergyFromDensityTemperature(rho, temp, lambda);
     return;

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -846,7 +846,7 @@ class EosBase {
     // TODO(JMM): A lot hardcoded in here... Hopefully relevent EOS's
     // overwrite.
     constexpr Real MAXFAC = 1e8;
-    constexpr Real EPS = robust::EPS();
+    constexpr Real EPS = 100 * robust::EPS();
     constexpr Real MINR_DEFAULT = 1e-4;
     using RootFinding1D::findRoot; // more robust but slower. Better default.
     using RootFinding1D::Status;

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -846,7 +846,7 @@ class EosBase {
     // TODO(JMM): A lot hardcoded in here... Hopefully relevent EOS's
     // overwrite.
     constexpr Real MAXFAC = 1e8;
-    constexpr Real EPS = std::max(1e-8, 100 * robust::EPS());
+    constexpr Real EPS = 10 * robust::EPS();
     constexpr Real MINR_DEFAULT = 1e-4;
     constexpr Real DEFAULT_RHO_GUESS = 4;
     using RootFinding1D::findRoot; // more robust but slower. Better default.

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -846,7 +846,7 @@ class EosBase {
     // TODO(JMM): A lot hardcoded in here... Hopefully relevent EOS's
     // overwrite.
     constexpr Real MAXFAC = 1e8;
-    constexpr Real EPS = 10 * robust::EPS();
+    constexpr Real EPS = robust::EPS();
     constexpr Real MINR_DEFAULT = 1e-4;
     using RootFinding1D::findRoot; // more robust but slower. Better default.
     using RootFinding1D::Status;

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -793,6 +793,16 @@ class EosBase {
   PORTABLE_FORCEINLINE_FUNCTION
   Real MaximumDensity() const { return 1e100; }
 
+  // These are for the PT space PTE solver to bound the iterations in
+  // a safe range.
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumPressure() const { return 0; }
+  // Gruneisen EOS's often have a maximum density, which implies a maximum pressure.
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumPressureFromTemperature([[maybe_unused]] const Real T) const {
+    return 1e100;
+  }
+
   PORTABLE_INLINE_FUNCTION
   Real RhoPmin(const Real temp) const { return 0.0; }
 

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -799,9 +799,7 @@ class EosBase {
   Real MinimumPressure() const { return 0; }
   // Gruneisen EOS's often have a maximum density, which implies a maximum pressure.
   PORTABLE_FORCEINLINE_FUNCTION
-  Real MaximumPressureFromTemperature([[maybe_unused]] const Real T) const {
-    return 1e100;
-  }
+  Real MaximumPressureAtTemperature([[maybe_unused]] const Real T) const { return 1e100; }
 
   PORTABLE_INLINE_FUNCTION
   Real RhoPmin(const Real temp) const { return 0.0; }

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -846,7 +846,7 @@ class EosBase {
     // TODO(JMM): A lot hardcoded in here... Hopefully relevent EOS's
     // overwrite.
     constexpr Real MAXFAC = 1e8;
-    constexpr Real EPS = 100 * robust::EPS();
+    constexpr Real EPS = std::max(1e-8, 100 * robust::EPS());
     constexpr Real MINR_DEFAULT = 1e-4;
     using RootFinding1D::findRoot; // more robust but slower. Better default.
     using RootFinding1D::Status;

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -901,6 +901,14 @@ class EosBase {
     sie = copy.InternalEnergyFromDensityTemperature(rho, temp, lambda);
     return;
   }
+  PORTABLE_INLINE_FUNCTION void DensityEnergyFromPressureTemperature(const Real press,
+                                                                     const Real temp,
+                                                                     Real &rho,
+                                                                     Real &sie) const {
+    CRTP copy = *(static_cast<CRTP const *>(this));
+    copy.DensityEnergyFromPressureTemperature(press, temp, static_cast<Real *>(nullptr),
+                                              rho, sie);
+  }
 
   // Serialization
   /*

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -870,8 +870,8 @@ class EosBase {
       return copy.PressureFromDensityTemperature(r, temp, lambda);
     };
     Real rhoguess = rho; // use input density
-    if ((rhoguess <= rhomin) || (rhoguess >= rhomax)) {
-      if ((rhomin <= DEFAULT_RHO_GUESS) && (DEFAULT_RHO_GUESS <= rhomax)) {
+    if ((rhoguess < rhomin) || (rhoguess > rhomax)) {
+      if ((rhomin < DEFAULT_RHO_GUESS) && (DEFAULT_RHO_GUESS < rhomax)) {
         rhoguess = DEFAULT_RHO_GUESS;
       } else {
         rhoguess = 0.5 * (rhomin + rhomax);

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -874,14 +874,11 @@ class EosBase {
     };
     Real rhoguess = rho;                                // use input density
     if ((rhoguess <= rhomin) || (rhoguess >= rhomax)) { // avoid edge effects
-      /*
       if ((rhomin < DEFAULT_RHO_GUESS) && (DEFAULT_RHO_GUESS < rhomax)) {
         rhoguess = DEFAULT_RHO_GUESS;
       } else {
         rhoguess = 0.5 * (rhomin + rhomax);
       }
-      */
-      rhoguess = 0.5 * (rhomin + rhomax);
     }
     auto status = findRoot(PofRT, press, rhoguess, rhomin, rhomax, robust::EPS(),
                            robust::EPS(), rho);

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -860,7 +860,7 @@ class EosBase {
     Real rhomax = MAXFAC * rhomin;
     Real rhoguess = rho; // use input density
     if ((rhoguess < rhomin) || (rhoguess > rhomax)) {
-      if ((rhomin < DEFAULT_RHO_GUESS) && (rhomax > DEFAULT_RHOG_UESS)) {
+      if ((rhomin < DEFAULT_RHO_GUESS) && (rhomax > DEFAULT_RHO_GUESS)) {
         rhoguess = DEFAULT_RHO_GUESS;
       } else {
         rhoguess = 0.5 * (rhomin + rhomax);

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -848,6 +848,7 @@ class EosBase {
     constexpr Real MAXFAC = 1e8;
     constexpr Real EPS = std::max(1e-8, 100 * robust::EPS());
     constexpr Real MINR_DEFAULT = 1e-4;
+    constexpr Real DEFAULT_RHO_GUESS = 4;
     using RootFinding1D::findRoot; // more robust but slower. Better default.
     using RootFinding1D::Status;
     CRTP copy = *(static_cast<CRTP const *>(this));
@@ -859,7 +860,11 @@ class EosBase {
     Real rhomax = MAXFAC * rhomin;
     Real rhoguess = rho; // use input density
     if ((rhoguess < rhomin) || (rhoguess > rhomax)) {
-      rhoguess = 0.5 * (rhomin + rhomax);
+      if ((rhomin < DEFAULT_RHO_GUESS) && (rhomax > DEFAULT_RHOG_UESS)) {
+        rhoguess = DEFAULT_RHO_GUESS;
+      } else {
+        rhoguess = 0.5 * (rhomin + rhomax);
+      }
     }
     auto status = findRoot(PofRT, press, rhoguess, rhomin, rhomax, EPS, EPS, rho);
     // JMM: This needs to not fail and instead return something sane

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -854,7 +854,6 @@ class EosBase {
   DensityEnergyFromPressureTemperature(const Real press, const Real temp,
                                        Indexer_t &&lambda, Real &rho, Real &sie) const {
     using RootFinding1D::findRoot; // more robust but slower. Better default.
-    using RootFinding1D::regula_falsi;
     using RootFinding1D::Status;
 
     // Pressure is not monotone in density at low densities, which can
@@ -875,11 +874,14 @@ class EosBase {
     };
     Real rhoguess = rho;                                // use input density
     if ((rhoguess <= rhomin) || (rhoguess >= rhomax)) { // avoid edge effects
+      /*
       if ((rhomin < DEFAULT_RHO_GUESS) && (DEFAULT_RHO_GUESS < rhomax)) {
         rhoguess = DEFAULT_RHO_GUESS;
       } else {
         rhoguess = 0.5 * (rhomin + rhomax);
       }
+      */
+      rhoguess = 0.5 * (rhomin + rhomax);
     }
     auto status = findRoot(PofRT, press, rhoguess, rhomin, rhomax, robust::EPS(),
                            robust::EPS(), rho);

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -863,9 +863,12 @@ class EosBase {
     constexpr Real DEFAULT_RHO_GUESS = 12;
 
     CRTP copy = *(static_cast<CRTP const *>(this));
+
     // P(rho) not monotone. When relevant, bound rhopmin.
     Real rhomin = std::max(copy.RhoPmin(temp), copy.MinimumDensity());
     Real rhomax = copy.MaximumDensity();
+    PORTABLE_REQUIRE(rhomax > rhomin, "max bound > min bound");
+
     auto PofRT = [&](const Real r) {
       return copy.PressureFromDensityTemperature(r, temp, lambda);
     };

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -845,9 +845,10 @@ class EosBase {
                                        Indexer_t &&lambda, Real &rho, Real &sie) const {
     // TODO(JMM): A lot hardcoded in here... Hopefully relevent EOS's
     // overwrite.
-    constexpr Real MAXFAC = 1e8;
+    constexpr Real MAXFAC = 1e12; // For MINR_DEFAULT, produces max
+                                  // density of 1e4
     constexpr Real EPS = 10 * robust::EPS();
-    constexpr Real MINR_DEFAULT = 1e-4;
+    constexpr Real MINR_DEFAULT = 1e-8;
     constexpr Real DEFAULT_RHO_GUESS = 4;
     using RootFinding1D::findRoot; // more robust but slower. Better default.
     using RootFinding1D::Status;

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -877,8 +877,9 @@ class EosBase {
         rhoguess = 0.5 * (rhomin + rhomax);
       }
     }
-    auto status = findRoot(PofRT, press, rhoguess, rhomin, rhomax, 10 * robust::EPS(),
-                           10 * robust::EPS(), rho);
+    // JMM: Demand as much tolerance as we can, but don't reset rho below.
+    auto status = findRoot(PofRT, press, rhoguess, rhomin, rhomax, robust::EPS(),
+                           robust::EPS(), rho);
     // JMM: This needs to not fail and instead return something sane.
     // If root find failed to converge, density will at least be
     // within bounds.

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -1104,6 +1104,7 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rho_min_; }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return temp_min_; }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const { return press_min_; }
 
  private:
   static constexpr const unsigned long _preferred_input =
@@ -1128,6 +1129,7 @@ class EOSPAC : public EosBase<EOSPAC> {
   Real dvdt_ref_ = 1;
   Real rho_min_ = 0;
   Real temp_min_ = 0;
+  Real press_min_ = 0;
   // TODO(JMM): Is the fact that EOS_INTEGER isn't a size_t a
   // problem? Could it ever realistically overflow?
   EOS_INTEGER shared_size_, packed_size_;
@@ -1199,6 +1201,8 @@ inline EOSPAC::EOSPAC(const int matid, bool invert_at_setup, Real insert_data,
   rho_ref_ = m.normalDensity;
   rho_min_ = m.rhoMin;
   temp_min_ = m.TMin;
+  press_min_ = m.PMin;
+
   // use std::max to hydrogen, in case of bad table
   AZbar_.Abar = std::max(1.0, m.meanAtomicMass);
   AZbar_.Zbar = std::max(1.0, m.meanAtomicNumber);

--- a/singularity-eos/eos/eos_gruneisen.hpp
+++ b/singularity-eos/eos/eos_gruneisen.hpp
@@ -170,6 +170,17 @@ class Gruneisen : public EosBase<Gruneisen> {
            s1, _C0, _s1, _s2, _s3, _G0, _b, _rho0, _T0, _P0, _Cv, _rho_max);
     _AZbar.PrintParams();
   }
+
+  // Report minimum values of density and temperature
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumDensity() const { return _rho_max; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumPressure() const { return PressureFromDensityInternalEnergy(0, 0); }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumPressureFromTemperature(const Real T) const {
+    return MaxStableDensityAtTemperature(T);
+  }
+
   template <typename Indexer_t>
   PORTABLE_INLINE_FUNCTION void
   DensityEnergyFromPressureTemperature(const Real press, const Real temp,

--- a/singularity-eos/eos/eos_gruneisen.hpp
+++ b/singularity-eos/eos/eos_gruneisen.hpp
@@ -177,7 +177,7 @@ class Gruneisen : public EosBase<Gruneisen> {
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumPressure() const { return PressureFromDensityInternalEnergy(0, 0); }
   PORTABLE_FORCEINLINE_FUNCTION
-  Real MaximumPressureFromTemperature(const Real T) const {
+  Real MaximumPressureAtTemperature(const Real T) const {
     return MaxStableDensityAtTemperature(T);
   }
 

--- a/singularity-eos/eos/eos_helmholtz.hpp
+++ b/singularity-eos/eos/eos_helmholtz.hpp
@@ -676,16 +676,35 @@ class Helmholtz : public EosBase<Helmholtz> {
   ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
                          Real &bmod, Real &dpde, Real &dvdt,
                          Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
-    // JMM: I'm not sure what to put here or if it matters. Some
-    // reference state, maybe stellar denity, would be appropriate.
-    PORTABLE_ALWAYS_ABORT("Stub");
+    // TODO(JMM): Is this right???
+    rho = 1e7;
+    temp = 1.5e9;
+    FillEos(rho, temp, sie, press, cv, bmod,
+            thermalqs::specific_internal_energy | thermalqs::pressure |
+                thermalqs::specific_heat | thermalqs::bulk_modulus,
+            lambda);
+    dpde = GruneisenParamFromDensityTemperature(rho, temp, lambda) * rho;
+    dvdt = 0;
   }
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION void
   DensityEnergyFromPressureTemperature(const Real press, const Real temp,
                                        Indexer_t &&lambda, Real &rho, Real &sie) const {
-    // This is only used for mixed cell closures. Stubbing it out for now.
-    PORTABLE_ALWAYS_ABORT("Stub");
+    using RootFinding1D::regula_falsi;
+    using RootFinding1D::Status;
+    PORTABLE_REQUIRE(temp > = 0, "Non-negative temperature required");
+    PofRT = [&](const Real r) { return PressureFromDensityTemperature(r, temp, lambda); };
+    auto status = regula_falsi(PofRT, press, 1e7, electrons_.rhoMin(),
+                               electrons_.rhoMax(), 1.0e-8, 1.0e-8, rho);
+    if (status != Status::SUCCESS) {
+      PORTABLE_THROW_OR_ABORT("Helmholtz::DensityEnergyFromPressureTemperature: "
+                              "Root find failed to find a solution given P, T\n");
+    }
+    if (rho < 0.) {
+      PORTABLE_THROW_OR_ABORT("Helmholtz::DensityEnergyFromPressureTemperature: "
+                              "Root find produced negative energy solution\n");
+    }
+    sie = InternalEnergyFromDensityTemperature(rho, temp, lambda);
   }
   static std::string EosType() { return std::string("Helmholtz"); }
   static std::string EosPyType() { return EosType(); }

--- a/singularity-eos/eos/eos_helmholtz.hpp
+++ b/singularity-eos/eos/eos_helmholtz.hpp
@@ -264,6 +264,12 @@ class HelmElectrons {
   std::size_t numTemp() const { return NTEMP; }
   PORTABLE_FORCEINLINE_FUNCTION
   std::size_t numRho() const { return NRHO; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumDensity() const { return rhoMin(); }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumTemperature() const { return TMin_; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumDensity() const { return rhoMax(); }
 
  private:
   inline void InitDataFile_(const std::string &filename);

--- a/singularity-eos/eos/eos_helmholtz.hpp
+++ b/singularity-eos/eos/eos_helmholtz.hpp
@@ -676,7 +676,8 @@ class Helmholtz : public EosBase<Helmholtz> {
   ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
                          Real &bmod, Real &dpde, Real &dvdt,
                          Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
-    // TODO(JMM): Is this right???
+    // JMM: Conditions for an oxygen burning shell in a stellar
+    // core. Not sure if that's the best choice.
     rho = 1e7;
     temp = 1.5e9;
     FillEos(rho, temp, sie, press, cv, bmod,

--- a/singularity-eos/eos/eos_helmholtz.hpp
+++ b/singularity-eos/eos/eos_helmholtz.hpp
@@ -693,7 +693,9 @@ class Helmholtz : public EosBase<Helmholtz> {
     using RootFinding1D::regula_falsi;
     using RootFinding1D::Status;
     PORTABLE_REQUIRE(temp > = 0, "Non-negative temperature required");
-    PofRT = [&](const Real r) { return PressureFromDensityTemperature(r, temp, lambda); };
+    auto PofRT = [&](const Real r) {
+      return PressureFromDensityTemperature(r, temp, lambda);
+    };
     auto status = regula_falsi(PofRT, press, 1e7, electrons_.rhoMin(),
                                electrons_.rhoMax(), 1.0e-8, 1.0e-8, rho);
     if (status != Status::SUCCESS) {

--- a/singularity-eos/eos/eos_mgusup.hpp
+++ b/singularity-eos/eos/eos_mgusup.hpp
@@ -126,6 +126,8 @@ class MGUsup : public EosBase<MGUsup> {
           const unsigned long output,
           Indexer_t &&lambda = static_cast<Real *>(nullptr)) const;
 
+  // Since reference isotherm scales as _rho0/rho, EOS diverges at
+  // zero density. This bounds that to some degree.
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumDensity() const { return 10 * robust::EPS(); }
 
@@ -135,7 +137,7 @@ class MGUsup : public EosBase<MGUsup> {
       return 0.99 * robust::ratio(_s * _rho0, _s - 1);
     } else { // for s <= 1, no maximum, but we need to pick something.
       return 1e3 * _rho0;
-    }
+    } // note that s < 0 implies unphysical shock derivative.
   }
 
   template <typename Indexer_t = Real *>

--- a/singularity-eos/eos/eos_mgusup.hpp
+++ b/singularity-eos/eos/eos_mgusup.hpp
@@ -126,10 +126,10 @@ class MGUsup : public EosBase<MGUsup> {
           const unsigned long output,
           Indexer_t &&lambda = static_cast<Real *>(nullptr)) const;
 
-  // Since reference isotherm scales as _rho0/rho, EOS diverges at
-  // zero density. This bounds that to some degree.
+  // Since reference isotherm scales as eta = 1 -_rho0/rho, EOS
+  // diverges for rho << rho0. eta^2 is used, so...
   PORTABLE_FORCEINLINE_FUNCTION
-  Real MinimumDensity() const { return 10 * robust::EPS(); }
+  Real MinimumDensity() const { return _RHOMINFAC * _rho0; }
 
   PORTABLE_FORCEINLINE_FUNCTION
   Real MaximumDensity() const {
@@ -170,6 +170,7 @@ class MGUsup : public EosBase<MGUsup> {
  private:
   static constexpr const unsigned long _preferred_input =
       thermalqs::density | thermalqs::specific_internal_energy;
+  const Real RHOMINFAC = std::sqrt(robust::EPS());
   Real _rho0, _T0, _Cs, _s, _G0, _Cv0, _E0, _S0;
   MeanAtomicProperties _AZbar;
 };

--- a/singularity-eos/eos/eos_mgusup.hpp
+++ b/singularity-eos/eos/eos_mgusup.hpp
@@ -139,6 +139,14 @@ class MGUsup : public EosBase<MGUsup> {
       return 1e3 * _rho0;
     } // note that s < 0 implies unphysical shock derivative.
   }
+  // Hugoniot pressure ill defined at reference density. On one side,
+  // negative. On the other positive.
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumPressure() const { return -1e100; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumPressureFromTemperature([[maybe_unused]] const Real T) const {
+    return 1e100;
+  }
 
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION void

--- a/singularity-eos/eos/eos_mgusup.hpp
+++ b/singularity-eos/eos/eos_mgusup.hpp
@@ -170,7 +170,7 @@ class MGUsup : public EosBase<MGUsup> {
  private:
   static constexpr const unsigned long _preferred_input =
       thermalqs::density | thermalqs::specific_internal_energy;
-  const Real _RHOMINFAC = std::sqrt(robust::EPS());
+  Real _RHOMINFAC = std::sqrt(robust::EPS());
   Real _rho0, _T0, _Cs, _s, _G0, _Cv0, _E0, _S0;
   MeanAtomicProperties _AZbar;
 };

--- a/singularity-eos/eos/eos_mgusup.hpp
+++ b/singularity-eos/eos/eos_mgusup.hpp
@@ -144,9 +144,7 @@ class MGUsup : public EosBase<MGUsup> {
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumPressure() const { return -1e100; }
   PORTABLE_FORCEINLINE_FUNCTION
-  Real MaximumPressureFromTemperature([[maybe_unused]] const Real T) const {
-    return 1e100;
-  }
+  Real MaximumPressureAtTemperature([[maybe_unused]] const Real T) const { return 1e100; }
 
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION void

--- a/singularity-eos/eos/eos_mgusup.hpp
+++ b/singularity-eos/eos/eos_mgusup.hpp
@@ -148,11 +148,6 @@ class MGUsup : public EosBase<MGUsup> {
     _AZbar.PrintParams();
     printf("\n\n");
   }
-  // Density/Energy from P/T not unique, if used will give error
-  template <typename Indexer_t>
-  PORTABLE_INLINE_FUNCTION void
-  DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                       Indexer_t &&lambda, Real &rho, Real &sie) const;
   inline void Finalize() {}
   static std::string EosType() { return std::string("MGUsup"); }
   static std::string EosPyType() { return EosType(); }
@@ -349,13 +344,6 @@ PORTABLE_INLINE_FUNCTION Real MGUsup::BulkModulusFromDensityInternalEnergy(
   value = value + _G0 * _G0 * _rho0 * (sie - HugInternalEnergyFromDensity(rho));
   value = robust::ratio(_rho0, rho) * value;
   return value;
-}
-// AEM: Give error since function is not well defined
-template <typename Indexer_t>
-PORTABLE_INLINE_FUNCTION void MGUsup::DensityEnergyFromPressureTemperature(
-    const Real press, const Real temp, Indexer_t &&lambda, Real &rho, Real &sie) const {
-  EOS_ERROR("MGUsup::DensityEnergyFromPressureTemperature: "
-            "Not implemented.\n");
 }
 // AEM: We should add entropy and Gruneissen parameters here so that it is complete
 // If we add also alpha and BT, those should also be in here.

--- a/singularity-eos/eos/eos_mgusup.hpp
+++ b/singularity-eos/eos/eos_mgusup.hpp
@@ -170,7 +170,7 @@ class MGUsup : public EosBase<MGUsup> {
  private:
   static constexpr const unsigned long _preferred_input =
       thermalqs::density | thermalqs::specific_internal_energy;
-  const Real RHOMINFAC = std::sqrt(robust::EPS());
+  const Real _RHOMINFAC = std::sqrt(robust::EPS());
   Real _rho0, _T0, _Cs, _s, _G0, _Cv0, _E0, _S0;
   MeanAtomicProperties _AZbar;
 };

--- a/singularity-eos/eos/eos_mgusup.hpp
+++ b/singularity-eos/eos/eos_mgusup.hpp
@@ -142,34 +142,6 @@ class MGUsup : public EosBase<MGUsup> {
 
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION void
-  DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                       Indexer_t &&lambda, Real &rho, Real &sie) const {
-    using RootFinding1D::findRoot;
-    using RootFinding1D::Status;
-    // JMM: diverges for rho -> 0
-    // and for s > 1 and rho -> rho0
-    Real rhomin = MinimumDensity();
-    Real rhomax = MaximumDensity();
-    auto PofRT = [&](const Real r) {
-      return PressureFromDensityTemperature(r, temp, lambda);
-    };
-    Real rhoguess = rho; // use input density
-    if ((rhoguess < rhomin) || (rhoguess > rhomax)) {
-      rhoguess = 0.5 * (rhomin + rhomax);
-    }
-    // JMM: regula_falsi does not respect bounds
-    auto status = findRoot(PofRT, press, rhoguess, rhomin, rhomax, robust::EPS(),
-                           robust::EPS(), rho);
-    if (status != Status::SUCCESS) {
-      PORTABLE_THROW_OR_ABORT(
-          "DensityEnergyFromPressureTemperature failed to find root\n");
-    }
-    sie = InternalEnergyFromDensityTemperature(rho, temp, lambda);
-    return;
-  }
-
-  template <typename Indexer_t = Real *>
-  PORTABLE_INLINE_FUNCTION void
   ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
                          Real &bmod, Real &dpde, Real &dvdt,
                          Indexer_t &&lambda = static_cast<Real *>(nullptr)) const;

--- a/singularity-eos/eos/eos_powermg.hpp
+++ b/singularity-eos/eos/eos_powermg.hpp
@@ -157,6 +157,25 @@ class PowerMG : public EosBase<PowerMG> {
     }
     printf("\n\n");
   }
+
+  // In principle, PowerMG should be valid for all densities. In
+  // practice, however, since the EOS is parametrized in terms of the
+  // compression, eta = 1 - rho0/rho, things will fail when rho is
+  // much less than rho0. Worse, since this is a power law in
+  // compression, it potentially depends on eta^M where M is the
+  // maximum index in the power series. In other words, the lower
+  // bound given by the M^th root of the smallest double times rho0, and
+  // the upper bound is given by the mth root of the maximum number,
+  // divided by rho0.
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumDensity() const {
+    return std::pow(std::numeric_limits<Real>::min(), 1. / _M) * _rho0;
+  }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumDensity() const {
+    return robust::ratio(std::pow(std::numeric_limits<Real>::max(), 1. / _M), _rho0);
+  }
+
   inline void Finalize() {}
   static std::string EosType() { return std::string("PowerMG"); }
   static std::string EosPyType() { return EosType(); }

--- a/singularity-eos/eos/eos_powermg.hpp
+++ b/singularity-eos/eos/eos_powermg.hpp
@@ -172,10 +172,6 @@ class PowerMG : public EosBase<PowerMG> {
     // NOT seem well behaved for, e.g., 10*rho0*machine epsilon.
     return 1e-4 * _rho0;
   }
-  PORTABLE_FORCEINLINE_FUNCTION
-  Real MaximumDensity() const {
-    return robust::ratio(std::pow(std::numeric_limits<Real>::max(), 1. / _M), _rho0);
-  }
 
   inline void Finalize() {}
   static std::string EosType() { return std::string("PowerMG"); }

--- a/singularity-eos/eos/eos_powermg.hpp
+++ b/singularity-eos/eos/eos_powermg.hpp
@@ -172,6 +172,13 @@ class PowerMG : public EosBase<PowerMG> {
     // NOT seem well behaved for, e.g., 10*rho0*machine epsilon.
     return 1e-4 * _rho0;
   }
+  // Essentially unbounded... I think.
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumPressure() const { return -1e100; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumPressureFromTemperature([[maybe_unused]] const Real T) const {
+    return 1e100;
+  }
 
   inline void Finalize() {}
   static std::string EosType() { return std::string("PowerMG"); }

--- a/singularity-eos/eos/eos_powermg.hpp
+++ b/singularity-eos/eos/eos_powermg.hpp
@@ -157,11 +157,6 @@ class PowerMG : public EosBase<PowerMG> {
     }
     printf("\n\n");
   }
-  // Density/Energy from P/T not unique, if used will give error
-  template <typename Indexer_t>
-  PORTABLE_INLINE_FUNCTION void
-  DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                       Indexer_t &&lambda, Real &rho, Real &sie) const;
   inline void Finalize() {}
   static std::string EosType() { return std::string("PowerMG"); }
   static std::string EosPyType() { return EosType(); }
@@ -430,13 +425,6 @@ PORTABLE_INLINE_FUNCTION Real PowerMG::EntropyFromDensityInternalEnergy(
     value = 1.e-12;
   }
   return value;
-}
-// AEM: Give error since function is not well defined
-template <typename Indexer_t>
-PORTABLE_INLINE_FUNCTION void PowerMG::DensityEnergyFromPressureTemperature(
-    const Real press, const Real temp, Indexer_t &&lambda, Real &rho, Real &sie) const {
-  EOS_ERROR("PowerMG::DensityEnergyFromPressureTemperature: "
-            "Not implemented.\n");
 }
 // AEM: We should add entropy and Gruneissen parameters here so that it is complete
 // If we add also alpha and BT, those should also be in here.

--- a/singularity-eos/eos/eos_powermg.hpp
+++ b/singularity-eos/eos/eos_powermg.hpp
@@ -166,7 +166,10 @@ class PowerMG : public EosBase<PowerMG> {
   // maximum index in the power series.
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumDensity() const {
-    // JMM: For whatever reason this seems a good heuristic.
+    // JMM: I think formally this should be the mth root of machine
+    // epsilon times rho0, but for m = 20 or something that's of order
+    // 1. Things seem reasonably well behaved with this bound. They do
+    // NOT seem well behaved for, e.g., 10*rho0*machine epsilon.
     return 1e-4 * _rho0;
   }
   PORTABLE_FORCEINLINE_FUNCTION

--- a/singularity-eos/eos/eos_powermg.hpp
+++ b/singularity-eos/eos/eos_powermg.hpp
@@ -163,13 +163,11 @@ class PowerMG : public EosBase<PowerMG> {
   // compression, eta = 1 - rho0/rho, things will fail when rho is
   // much less than rho0. Worse, since this is a power law in
   // compression, it potentially depends on eta^M where M is the
-  // maximum index in the power series. In other words, the lower
-  // bound given by the M^th root of the smallest double times rho0, and
-  // the upper bound is given by the mth root of the maximum number,
-  // divided by rho0.
+  // maximum index in the power series.
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumDensity() const {
-    return std::pow(std::numeric_limits<Real>::min(), 1. / _M) * _rho0;
+    // JMM: For whatever reason this seems a good heuristic.
+    return 1e-4 * _rho0;
   }
   PORTABLE_FORCEINLINE_FUNCTION
   Real MaximumDensity() const {

--- a/singularity-eos/eos/eos_powermg.hpp
+++ b/singularity-eos/eos/eos_powermg.hpp
@@ -176,9 +176,7 @@ class PowerMG : public EosBase<PowerMG> {
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumPressure() const { return -1e100; }
   PORTABLE_FORCEINLINE_FUNCTION
-  Real MaximumPressureFromTemperature([[maybe_unused]] const Real T) const {
-    return 1e100;
-  }
+  Real MaximumPressureAtTemperature([[maybe_unused]] const Real T) const { return 1e100; }
 
   inline void Finalize() {}
   static std::string EosType() { return std::string("PowerMG"); }

--- a/singularity-eos/eos/eos_sap_polynomial.hpp
+++ b/singularity-eos/eos/eos_sap_polynomial.hpp
@@ -209,14 +209,6 @@ class SAP_Polynomial : public EosBase<SAP_Polynomial> {
     printf("      b3  = %g\n", _b3);
     _AZbar.PrintParams();
   }
-  template <typename Indexer_t>
-  PORTABLE_INLINE_FUNCTION void
-  DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                       Indexer_t &&lambda, Real &rho, Real &sie) const {
-    PORTABLE_WARN("This function is a stub for an incomplete EoS.");
-    sie = 0.0;
-    rho = 0.0;
-  }
   inline void Finalize() {}
   static std::string EosType() { return std::string("SAP_Polynomial"); }
   static std::string EosPyType() { return EosType(); }

--- a/singularity-eos/eos/eos_sap_polynomial.hpp
+++ b/singularity-eos/eos/eos_sap_polynomial.hpp
@@ -166,9 +166,7 @@ class SAP_Polynomial : public EosBase<SAP_Polynomial> {
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumPressure() const { return -1e100; }
   PORTABLE_FORCEINLINE_FUNCTION
-  Real MaximumPressureFromTemperature([[maybe_unused]] const Real T) const {
-    return 1e100;
-  }
+  Real MaximumPressureAtTemperature([[maybe_unused]] const Real T) const { return 1e100; }
 
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION void

--- a/singularity-eos/eos/eos_sap_polynomial.hpp
+++ b/singularity-eos/eos/eos_sap_polynomial.hpp
@@ -162,6 +162,14 @@ class SAP_Polynomial : public EosBase<SAP_Polynomial> {
     return rho / _rho0 - 1;
   }
 
+  // Essentially unbounded... I think.
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumPressure() const { return -1e100; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumPressureFromTemperature([[maybe_unused]] const Real T) const {
+    return 1e100;
+  }
+
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION void
   FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, Real &bmod,

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -204,6 +204,7 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rhoMin(); }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return T_(lTMin_); }
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const { return rhoMax(); }
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return _n_lambda; }
   PORTABLE_INLINE_FUNCTION
@@ -472,6 +473,7 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
 
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rhoMin(); }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return TMin(); }
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const { return rhoMax(); }
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return _n_lambda; }

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -205,6 +205,9 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rhoMin(); }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return T_(lTMin_); }
   PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const { return rhoMax(); }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumPressure() const { return PMin_; }
+
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return _n_lambda; }
   PORTABLE_INLINE_FUNCTION
@@ -306,6 +309,7 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   Real lRhoMin_, lRhoMax_, rhoMax_;
   Real lRhoMinSearch_;
   Real lTMin_, lTMax_, TMax_;
+  Real PMin_;
   Real rhoNormal_, TNormal_, sieNormal_, PNormal_;
   Real CvNormal_, bModNormal_, dPdENormal_, dVdTNormal_;
   Real lRhoOffset_, lTOffset_; // offsets must be non-negative
@@ -474,6 +478,12 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rhoMin(); }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return TMin(); }
   PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const { return rhoMax(); }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumPressure() const { return PMin_; }
+  PORTABLE_INLINE_FUNCTION
+  Real RhoPmin(const Real temp) const {
+    return rho_at_pmin_.interpToReal(toLog_(temp, lTOffset_));
+  }
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return _n_lambda; }
@@ -517,22 +527,24 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
 
   DataBox sie_; // depends on (rho,T)
   DataBox T_;   // depends on (rho, sie)
+  DataBox rho_at_pmin_;
   SP5Tables dependsRhoT_;
   SP5Tables dependsRhoSie_;
-  int numRho_;
+  int numRho_, numT_;
   Real rhoNormal_, TNormal_, sieNormal_, PNormal_;
   Real CvNormal_, bModNormal_, dPdENormal_, dVdTNormal_;
   Real lRhoMin_, lRhoMax_, rhoMax_;
   DataBox PlRhoMax_, dPdRhoMax_;
-
+  Real PMin_;
   Real lRhoOffset_, lTOffset_, lEOffset_; // offsets must be non-negative
 
 #define DBLIST                                                                           \
-  &sie_, &T_, &(dependsRhoT_.P), &(dependsRhoT_.bMod), &(dependsRhoT_.dPdRho),           \
-      &(dependsRhoT_.dPdE), &(dependsRhoT_.dTdRho), &(dependsRhoT_.dTdE),                \
-      &(dependsRhoT_.dEdRho), &(dependsRhoSie_.P), &(dependsRhoSie_.bMod),               \
-      &(dependsRhoSie_.dPdRho), &(dependsRhoSie_.dPdE), &(dependsRhoSie_.dTdRho),        \
-      &(dependsRhoSie_.dTdE), &(dependsRhoSie_.dEdRho), &PlRhoMax_, &dPdRhoMax_
+  &sie_, &T_, &rho_at_pmin_, &(dependsRhoT_.P), &(dependsRhoT_.bMod),                    \
+      &(dependsRhoT_.dPdRho), &(dependsRhoT_.dPdE), &(dependsRhoT_.dTdRho),              \
+      &(dependsRhoT_.dTdE), &(dependsRhoT_.dEdRho), &(dependsRhoSie_.P),                 \
+      &(dependsRhoSie_.bMod), &(dependsRhoSie_.dPdRho), &(dependsRhoSie_.dPdE),          \
+      &(dependsRhoSie_.dTdRho), &(dependsRhoSie_.dTdE), &(dependsRhoSie_.dEdRho),        \
+      &PlRhoMax_, &dPdRhoMax_
   std::vector<const DataBox *> GetDataBoxPointers_() const {
     return std::vector<const DataBox *>{DBLIST};
   }
@@ -773,11 +785,11 @@ inline herr_t SpinerEOSDependsRhoT::loadDataboxes_(const std::string &matid_str,
   rho_at_pmin_.resize(numT_);
   rho_at_pmin_.setRange(0, P_.range(0));
   for (int i = 0; i < numT_; i++) {
-    Real pmin = std::numeric_limits<Real>::max();
+    PMin_ = std::numeric_limits<Real>::max();
     int jmax = -1;
     for (int j = 0; j < numRho_; j++) {
-      if (P_(j, i) < pmin) {
-        pmin = P_(j, i);
+      if (P_(j, i) < PMin_) {
+        PMin_ = P_(j, i);
         jmax = j;
       }
     }
@@ -1597,6 +1609,7 @@ herr_t SpinerEOSDependsRhoSie::loadDataboxes_(const std::string &matid_str, hid_
 
   // Metadata for root finding extrapolation
   numRho_ = sie_.dim(2);
+  numT_ = sie_.dim(1);
   lRhoMin_ = sie_.range(1).min();
   lRhoMax_ = sie_.range(1).max();
   rhoMax_ = fromLog_(lRhoMax_, lRhoOffset_);
@@ -1604,6 +1617,22 @@ herr_t SpinerEOSDependsRhoSie::loadDataboxes_(const std::string &matid_str, hid_
   // slice to maximum of rho
   PlRhoMax_ = dependsRhoT_.P.slice(numRho_ - 1);
   dPdRhoMax_ = dependsRhoT_.dPdRho.slice(numRho_ - 1);
+
+  // fill in minimum pressure as a function of temperature
+  rho_at_pmin_.resize(numT_);
+  rho_at_pmin_.setRange(0, sie_.range(0));
+  for (int i = 0; i < numT_; i++) {
+    PMin_ = std::numeric_limits<Real>::max();
+    int jmax = -1;
+    for (int j = 0; j < numRho_; j++) {
+      if (dependsRhoT_.P(j, i) < PMin_) {
+        PMin_ = dependsRhoT_.P(j, i);
+        jmax = j;
+      }
+    }
+    if (jmax < 0) printf("Failed to find minimum pressure.\n");
+    rho_at_pmin_(i) = fromLog_(dependsRhoT_.P.range(1).x(jmax), lRhoOffset_);
+  }
 
   // reference state
   Real lRhoNormal = toLog_(rhoNormal_, lRhoOffset_);

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -653,7 +653,25 @@ PORTABLE_INLINE_FUNCTION Real StellarCollapse::GruneisenParamFromDensityInternal
 template <typename Indexer_t>
 PORTABLE_INLINE_FUNCTION void StellarCollapse::DensityEnergyFromPressureTemperature(
     const Real press, const Real temp, Indexer_t &&lambda, Real &rho, Real &sie) const {
-  EOS_ERROR("StellarCollapse::DensityEnergyFromPRessureTemperature is a stub");
+  using RootFinding1D::regula_falsi;
+  using RootFinding1D::Status;
+  CheckLambda_(lambda);
+  Real lrguess = lRho_(rho);
+  Real lT = lT_(temp);
+  Real lP = P2lP_(press);
+  Real Ye = lambda[Lambda::Ye];
+
+  if ((lrguess < lRhoMin_) || (lrguess > lrMax_)) {
+    lrguess = lRho_(rhoNormal_);
+  }
+  auto lPofRT = [&](Real lR) { return lP_.interpToReal(Ye, lT, lR); };
+  auto status = regula_falsi(lPofRT, lP, lrguess, lRhoMin_, lRhoMax_, ROOT_THRESH,
+                             ROOT_THRESH, lrguess);
+
+  Real lE = lE_.interpToReal(Ye, lT, lrguess);
+  rho = rho_(lrguess);
+  sie = le2e_(lE);
+  lambda[Lambda::lT] = lT;
 }
 
 template <typename Indexer_t>

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -237,6 +237,7 @@ class StellarCollapse : public EosBase<StellarCollapse> {
   }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rhoMin(); }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return TMin(); }
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const { return rhoMax(); }
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return _n_lambda; }
   inline RootFinding1D::Status rootStatus() const { return status_; }

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -655,7 +655,7 @@ PORTABLE_INLINE_FUNCTION void StellarCollapse::DensityEnergyFromPressureTemperat
     const Real press, const Real temp, Indexer_t &&lambda, Real &rho, Real &sie) const {
   using RootFinding1D::regula_falsi;
   using RootFinding1D::Status;
-  CheckLambda_(lambda);
+  checkLambda_(lambda);
   Real lrguess = lRho_(rho);
   Real lT = lT_(temp);
   Real lP = P2lP_(press);

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -661,7 +661,7 @@ PORTABLE_INLINE_FUNCTION void StellarCollapse::DensityEnergyFromPressureTemperat
   Real lP = P2lP_(press);
   Real Ye = lambda[Lambda::Ye];
 
-  if ((lrguess < lRhoMin_) || (lrguess > lrMax_)) {
+  if ((lrguess < lRhoMin_) || (lrguess > lRhoMax_)) {
     lrguess = lRho_(rhoNormal_);
   }
   auto lPofRT = [&](Real lR) { return lP_.interpToReal(Ye, lT, lR); };

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -664,6 +664,7 @@ PORTABLE_INLINE_FUNCTION void StellarCollapse::DensityEnergyFromPressureTemperat
   if ((lrguess < lRhoMin_) || (lrguess > lRhoMax_)) {
     lrguess = lRho_(rhoNormal_);
   }
+  // Since EOS is tabulated in logrho, use that for root find.
   auto lPofRT = [&](Real lR) { return lP_.interpToReal(Ye, lT, lR); };
   auto status = regula_falsi(lPofRT, lP, lrguess, lRhoMin_, lRhoMax_, ROOT_THRESH,
                              ROOT_THRESH, lrguess);

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -317,6 +317,16 @@ class Variant {
         },
         eos_);
   }
+  PORTABLE_INLINE_FUNCTION void DensityEnergyFromPressureTemperature(const Real press,
+                                                                     const Real temp,
+                                                                     Real &rho,
+                                                                     Real &sie) const {
+    return mpark::visit(
+        [&press, &temp, &rho, &sie](const auto &eos) {
+          return eos.DensityEnergyFromPressureTemperature(press, temp, rho, sie);
+        },
+        eos_);
+  }
 
   PORTABLE_INLINE_FUNCTION
   Real RhoPmin(const Real temp) const {

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -333,6 +333,23 @@ class Variant {
     return mpark::visit([](const auto &eos) { return eos.MinimumTemperature(); }, eos_);
   }
 
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumDensity() const {
+    return mpark::visit([](const auto &eos) { return eos.MaximumDensity(); }, eos_);
+  }
+
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumPressure() const {
+    return mpark::visit([](const auto &eos) { return eos.MinimumPressure(); }, eos_);
+  }
+
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumPressureFromTemperature(const Real temp) const {
+    return mpark::visit(
+        [&temp](const auto &eos) { return eos.MaximumPressureFromTemperature(temp); },
+        eos_);
+  }
+
   // Atomic mass/atomic number functions
   PORTABLE_INLINE_FUNCTION
   Real MeanAtomicMass() const {

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -354,9 +354,9 @@ class Variant {
   }
 
   PORTABLE_FORCEINLINE_FUNCTION
-  Real MaximumPressureFromTemperature(const Real temp) const {
+  Real MaximumPressureAtTemperature(const Real temp) const {
     return mpark::visit(
-        [&temp](const auto &eos) { return eos.MaximumPressureFromTemperature(temp); },
+        [&temp](const auto &eos) { return eos.MaximumPressureAtTemperature(temp); },
         eos_);
   }
 

--- a/singularity-eos/eos/eos_vinet.hpp
+++ b/singularity-eos/eos/eos_vinet.hpp
@@ -141,9 +141,7 @@ class Vinet : public EosBase<Vinet> {
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumPressure() const { return -1e100; }
   PORTABLE_FORCEINLINE_FUNCTION
-  Real MaximumPressureFromTemperature([[maybe_unused]] const Real T) const {
-    return 1e100;
-  }
+  Real MaximumPressureAtTemperature([[maybe_unused]] const Real T) const { return 1e100; }
 
   // Generic functions provided by the base class. These contain e.g. the vector
   // overloads that use the scalar versions declared here

--- a/singularity-eos/eos/eos_vinet.hpp
+++ b/singularity-eos/eos/eos_vinet.hpp
@@ -152,11 +152,6 @@ class Vinet : public EosBase<Vinet> {
     }
     printf("\n\n");
   }
-  // Density/Energy from P/T not unique, if used will give error
-  template <typename Indexer_t = Real *>
-  PORTABLE_INLINE_FUNCTION void
-  DensityEnergyFromPressureTemperature(const Real press, const Real temp,
-                                       Indexer_t &&lambda, Real &rho, Real &sie) const;
   inline void Finalize() {}
   static std::string EosType() { return std::string("Vinet"); }
   static std::string EosPyType() { return EosType(); }
@@ -374,13 +369,6 @@ PORTABLE_INLINE_FUNCTION Real Vinet::BulkModulusFromDensityInternalEnergy(
   temp = TemperatureFromDensityInternalEnergy(rho, sie);
   Vinet_F_DT_func(rho, temp, output);
   return output[7] * output[7] * rho;
-}
-// AEM: Give error since function is not well defined
-template <typename Indexer_t>
-PORTABLE_INLINE_FUNCTION void Vinet::DensityEnergyFromPressureTemperature(
-    const Real press, const Real temp, Indexer_t &&lambda, Real &rho, Real &sie) const {
-  EOS_ERROR("Vinet::DensityEnergyFromPressureTemperature: "
-            "Not implemented.\n");
 }
 // AEM: We should add entropy and Gruneissen parameters here so that it is complete
 // If we add also alpha and BT, those should also be in here.

--- a/singularity-eos/eos/eos_vinet.hpp
+++ b/singularity-eos/eos/eos_vinet.hpp
@@ -131,6 +131,10 @@ class Vinet : public EosBase<Vinet> {
   ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &press, Real &cv,
                          Real &bmod, Real &dpde, Real &dvdt,
                          Indexer_t &&lambda = static_cast<Real *>(nullptr)) const;
+
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumDensity() const { return std::cbrt(10 * robust::EPS()) * _rho0; }
+
   // Generic functions provided by the base class. These contain e.g. the vector
   // overloads that use the scalar versions declared here
   SG_ADD_BASE_CLASS_USINGS(Vinet)

--- a/singularity-eos/eos/eos_vinet.hpp
+++ b/singularity-eos/eos/eos_vinet.hpp
@@ -137,15 +137,6 @@ class Vinet : public EosBase<Vinet> {
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumDensity() const { return std::cbrt(10 * robust::EPS()) * _rho0; }
 
-  // In principle, density should be unbounded from above In
-  // practice, however, since since this is a power law in
-  // (rho0/rho)^(1/3), it may fail when rho is sufficiently large.
-  PORTABLE_FORCEINLINE_FUNCTION
-  Real MaximumDensity() const {
-    Real maxind = VinetInternalParametersSize;
-    return robust::ratio(std::pow(std::numeric_limits<Real>::max(), 1. / maxind), _rho0);
-  }
-
   // Generic functions provided by the base class. These contain e.g. the vector
   // overloads that use the scalar versions declared here
   SG_ADD_BASE_CLASS_USINGS(Vinet)

--- a/singularity-eos/eos/eos_vinet.hpp
+++ b/singularity-eos/eos/eos_vinet.hpp
@@ -137,6 +137,14 @@ class Vinet : public EosBase<Vinet> {
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumDensity() const { return std::cbrt(10 * robust::EPS()) * _rho0; }
 
+  // Essentially unbounded... I think.
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MinimumPressure() const { return -1e100; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumPressureFromTemperature([[maybe_unused]] const Real T) const {
+    return 1e100;
+  }
+
   // Generic functions provided by the base class. These contain e.g. the vector
   // overloads that use the scalar versions declared here
   SG_ADD_BASE_CLASS_USINGS(Vinet)

--- a/singularity-eos/eos/eos_vinet.hpp
+++ b/singularity-eos/eos/eos_vinet.hpp
@@ -132,6 +132,8 @@ class Vinet : public EosBase<Vinet> {
                          Real &bmod, Real &dpde, Real &dvdt,
                          Indexer_t &&lambda = static_cast<Real *>(nullptr)) const;
 
+  // EOS depends on (rho0/rho)^(1/3) so this is a reasonable bound
+  // before the EOS will become ill-behaved.
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumDensity() const { return std::cbrt(10 * robust::EPS()) * _rho0; }
 

--- a/singularity-eos/eos/eos_vinet.hpp
+++ b/singularity-eos/eos/eos_vinet.hpp
@@ -137,6 +137,15 @@ class Vinet : public EosBase<Vinet> {
   PORTABLE_FORCEINLINE_FUNCTION
   Real MinimumDensity() const { return std::cbrt(10 * robust::EPS()) * _rho0; }
 
+  // In principle, density should be unbounded from above In
+  // practice, however, since since this is a power law in
+  // (rho0/rho)^(1/3), it may fail when rho is sufficiently large.
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real MaximumDensity() const {
+    Real maxind = VinetInternalParametersSize;
+    return robust::ratio(std::pow(std::numeric_limits<Real>::max(), 1. / maxind), _rho0);
+  }
+
   // Generic functions provided by the base class. These contain e.g. the vector
   // overloads that use the scalar versions declared here
   SG_ADD_BASE_CLASS_USINGS(Vinet)

--- a/singularity-eos/eos/modifiers/eos_unitsystem.hpp
+++ b/singularity-eos/eos/modifiers/eos_unitsystem.hpp
@@ -248,6 +248,9 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const {
     return inv_temp_unit_ * t_.MinimumTemperature();
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
+    return inv_rho_unit_ * t_.MaximumDensity();
+  }
 
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real MeanAtomicMassFromDensityTemperature(

--- a/singularity-eos/eos/modifiers/eos_unitsystem.hpp
+++ b/singularity-eos/eos/modifiers/eos_unitsystem.hpp
@@ -254,9 +254,8 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
     return inv_press_unit_ * t_.MinimumPressure();
   }
-  PORTABLE_FORCEINLINE_FUNCTION Real
-  MaximumPressureFromTemperature(const Real temp) const {
-    return inv_press_unit_ * t_.MaximumPressureFromTemperature(temp_unit_ * temp);
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumPressureAtTemperature(const Real temp) const {
+    return inv_press_unit_ * t_.MaximumPressureAtTemperature(temp_unit_ * temp);
   }
 
   template <typename Indexer_t = Real *>

--- a/singularity-eos/eos/modifiers/eos_unitsystem.hpp
+++ b/singularity-eos/eos/modifiers/eos_unitsystem.hpp
@@ -251,6 +251,13 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
     return inv_rho_unit_ * t_.MaximumDensity();
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
+    return inv_press_unit_ * t_.MinimumPressure();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real
+  MaximumPressureFromTemperature(const Real temp) const {
+    return inv_press_unit_ * t_.MaximumPressureFromTemperature(temp_unit_ * temp);
+  }
 
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real MeanAtomicMassFromDensityTemperature(

--- a/singularity-eos/eos/modifiers/ramps_eos.hpp
+++ b/singularity-eos/eos/modifiers/ramps_eos.hpp
@@ -255,9 +255,8 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
     return t_.MinimumPressure();
   }
-  PORTABLE_FORCEINLINE_FUNCTION Real
-  MaximumPressureFromTemperature(const Real temp) const {
-    return t_.MaximumPressureFromTemperature(temp);
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumPressureAtTemperature(const Real temp) const {
+    return t_.MaximumPressureAtTemperature(temp);
   }
 
   template <typename Indexer_t = Real *>

--- a/singularity-eos/eos/modifiers/ramps_eos.hpp
+++ b/singularity-eos/eos/modifiers/ramps_eos.hpp
@@ -243,6 +243,16 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
     return;
   }
 
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const {
+    return t_.MinimumDensity();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const {
+    return t_.MinimumTemperature();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
+    return t_.MaximumDensity();
+  }
+
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real MeanAtomicMassFromDensityTemperature(
       const Real rho, const Real temperature,

--- a/singularity-eos/eos/modifiers/ramps_eos.hpp
+++ b/singularity-eos/eos/modifiers/ramps_eos.hpp
@@ -252,6 +252,13 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
     return t_.MaximumDensity();
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
+    return t_.MinimumPressure();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real
+  MaximumPressureFromTemperature(const Real temp) const {
+    return t_.MaximumPressureFromTemperature(temp);
+  }
 
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real MeanAtomicMassFromDensityTemperature(

--- a/singularity-eos/eos/modifiers/relativistic_eos.hpp
+++ b/singularity-eos/eos/modifiers/relativistic_eos.hpp
@@ -155,6 +155,9 @@ class RelativisticEOS : public EosBase<RelativisticEOS<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const {
     return t_.MinimumTemperature();
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
+    return t_.MaximumDensity();
+  }
 
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }
 

--- a/singularity-eos/eos/modifiers/relativistic_eos.hpp
+++ b/singularity-eos/eos/modifiers/relativistic_eos.hpp
@@ -161,9 +161,8 @@ class RelativisticEOS : public EosBase<RelativisticEOS<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
     return t_.MinimumPressure();
   }
-  PORTABLE_FORCEINLINE_FUNCTION Real
-  MaximumPressureFromTemperature(const Real temp) const {
-    return t_.MaximumPressureFromTemperature(temp);
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumPressureAtTemperature(const Real temp) const {
+    return t_.MaximumPressureAtTemperature(temp);
   }
 
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }

--- a/singularity-eos/eos/modifiers/relativistic_eos.hpp
+++ b/singularity-eos/eos/modifiers/relativistic_eos.hpp
@@ -158,6 +158,13 @@ class RelativisticEOS : public EosBase<RelativisticEOS<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
     return t_.MaximumDensity();
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
+    return t_.MinimumPressure();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real
+  MaximumPressureFromTemperature(const Real temp) const {
+    return t_.MaximumPressureFromTemperature(temp);
+  }
 
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }
 

--- a/singularity-eos/eos/modifiers/scaled_eos.hpp
+++ b/singularity-eos/eos/modifiers/scaled_eos.hpp
@@ -341,6 +341,9 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const {
     return t_.MinimumTemperature();
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
+    return inv_scale_ * t_.MaximumDensity();
+  }
 
   PORTABLE_INLINE_FUNCTION
   Real MeanAtomicMass() const { return inv_scale_ * t_.MeanAtomicMass(); }

--- a/singularity-eos/eos/modifiers/scaled_eos.hpp
+++ b/singularity-eos/eos/modifiers/scaled_eos.hpp
@@ -347,9 +347,8 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
     return t_.MinimumPressure();
   }
-  PORTABLE_FORCEINLINE_FUNCTION Real
-  MaximumPressureFromTemperature(const Real temp) const {
-    return t_.MaximumPressureFromTemperature(temp);
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumPressureAtTemperature(const Real temp) const {
+    return t_.MaximumPressureAtTemperature(temp);
   }
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-eos/eos/modifiers/scaled_eos.hpp
+++ b/singularity-eos/eos/modifiers/scaled_eos.hpp
@@ -344,6 +344,13 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
     return inv_scale_ * t_.MaximumDensity();
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
+    return t_.MinimumPressure();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real
+  MaximumPressureFromTemperature(const Real temp) const {
+    return t_.MaximumPressureFromTemperature(temp);
+  }
 
   PORTABLE_INLINE_FUNCTION
   Real MeanAtomicMass() const { return inv_scale_ * t_.MeanAtomicMass(); }

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -354,6 +354,13 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
     return t_.MaximumDensity();
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
+    return t_.MinimumPressure();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real
+  MaximumPressureFromTemperature(const Real temp) const {
+    return t_.MaximumPressureFromTemperature(temp);
+  }
 
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real MeanAtomicMassFromDensityTemperature(

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -357,9 +357,8 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
     return t_.MinimumPressure();
   }
-  PORTABLE_FORCEINLINE_FUNCTION Real
-  MaximumPressureFromTemperature(const Real temp) const {
-    return t_.MaximumPressureFromTemperature(temp);
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumPressureAtTemperature(const Real temp) const {
+    return t_.MaximumPressureAtTemperature(temp);
   }
 
   template <typename Indexer_t = Real *>

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -351,6 +351,9 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const {
     return t_.MinimumTemperature();
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
+    return t_.MaximumDensity();
+  }
 
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real MeanAtomicMassFromDensityTemperature(

--- a/singularity-eos/eos/modifiers/zsplit_eos.hpp
+++ b/singularity-eos/eos/modifiers/zsplit_eos.hpp
@@ -212,6 +212,16 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
     // dvdt, dpde unchanged
   }
 
+  template <typename Indexer_t = Real *>
+  PORTABLE_FUNCTION void
+  DensityEnergyFromPressureTemperature(const Real press, const Real temp,
+                                       Indexer_t &&lambda, Real &rho, Real &sie) const {
+    const Real scale = GetScale_(lambda);
+    const Real iscale = GetInvScale_(lambda);
+    t_.DensityEnergyFromPressureTemperature(iscale * press, temp, lambda, rho, sie);
+    sie *= scale;
+  }
+
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return NL + t_.nlambda(); }
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }

--- a/singularity-eos/eos/modifiers/zsplit_eos.hpp
+++ b/singularity-eos/eos/modifiers/zsplit_eos.hpp
@@ -245,9 +245,8 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
     return t_.MinimumPressure();
   }
-  PORTABLE_FORCEINLINE_FUNCTION Real
-  MaximumPressureFromTemperature(const Real temp) const {
-    return t_.MaximumPressureFromTemperature(temp);
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumPressureAtTemperature(const Real temp) const {
+    return t_.MaximumPressureAtTemperature(temp);
   }
 
   template <typename Indexer_t = Real *>

--- a/singularity-eos/eos/modifiers/zsplit_eos.hpp
+++ b/singularity-eos/eos/modifiers/zsplit_eos.hpp
@@ -239,6 +239,9 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const {
     return t_.MinimumTemperature();
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
+    return t_.MaximumDensity();
+  }
 
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real MeanAtomicMassFromDensityTemperature(

--- a/singularity-eos/eos/modifiers/zsplit_eos.hpp
+++ b/singularity-eos/eos/modifiers/zsplit_eos.hpp
@@ -242,6 +242,13 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const {
     return t_.MaximumDensity();
   }
+  PORTABLE_FORCEINLINE_FUNCTION Real MinimumPressure() const {
+    return t_.MinimumPressure();
+  }
+  PORTABLE_FORCEINLINE_FUNCTION Real
+  MaximumPressureFromTemperature(const Real temp) const {
+    return t_.MaximumPressureFromTemperature(temp);
+  }
 
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real MeanAtomicMassFromDensityTemperature(

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -152,7 +152,6 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
   const Real sie = eos.InternalEnergyFromDensityTemperature(rho, T, lambda);
   Real rtest, etest;
   eos.DensityEnergyFromPressureTemperature(P, T, lambda, rtest, etest);
-  Real bmod = eos.BulkModulusFromDensityTemperature(rho, T, lambda);
   Real P_test = eos.PressureFromDensityTemperature(rtest, T, lambda);
   Real residual = P_test - P;
   Real frac_residual =

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -155,7 +155,7 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
   Real bmod = eos.BulkModulusFromDensityTemperature(rho, T, lambda);
   Real P_test = eos.PressureFromDensityTemperature(rtest, T, lambda);
   Real residual = P_test - P;
-  Real frac_residual = singularity::robust::ratio(residual, P);
+  Real frac_residual = std::min(singularity::robust::ratio(residual, P), residual);
   bool results_good = (isClose(rho, rtest, 1e-8) && isClose(sie, etest, 1e-8))
                       // This is as good as it will get sometimes.
                       || (std::abs(frac_residual) < 10 * singularity::robust::EPS());
@@ -169,7 +169,7 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
            "\tsie      = %.14e\n"
            "\tP_test   = %.14e\n"
            "\tresidual = %.14e\n"
-           "\fracres   = %.14e\n",
+           "\tfracres  = %.14e\n",
            rho, sie, P, T, rtest, etest, P_test, residual, frac_residual);
   }
   return results_good;

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -159,7 +159,7 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
       std::min(std::abs(singularity::robust::ratio(residual, P)), std::abs(residual));
   bool results_good = (isClose(rho, rtest, 1e-8) && isClose(sie, etest, 1e-8))
                       // This is as good as it will get sometimes.
-                      || (std::abs(frac_residual) < 10 * singularity::robust::EPS());
+                      || (std::abs(frac_residual) <= 10 * singularity::robust::EPS());
   if (!results_good) {
     printf("RhoSie of PT failure!\n"
            "\trho_true = %.14e\n"

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -153,11 +153,13 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
   Real rtest, etest;
   eos.DensityEnergyFromPressureTemperature(P, T, lambda, rtest, etest);
   Real bmod = eos.BulkModulusFromDensityTemperature(rho, T, lambda);
-  bool results_good = (isClose(rho, rtest, bmod * 1e-8) || isClose(rho, rtest, 1e-8)) &&
-                      (isClose(sie, etest, bmod * 1e-8) || isClose(sie, etest, 1e-8));
+  Real P_test = eos.PressureFromDensityTemperature(rtest, T, lambda);
+  Real residual = P_test - P;
+  Real frac_residual = residual / P;
+  bool results_good = (isClose(rho, rtest, 1e-8) && isClose(sie, etest, 1e-8))
+    // This is as good as it will get sometimes.
+    || (std::abs(frac_residual) < 10*robust::EPS());
   if (!results_good) {
-    Real P_test = eos.PressureFromDensityTemperature(rtest, T, lambda);
-    Real residual = P_test - P;
     printf("RhoSie of PT failure!\n"
            "\trho_true = %.14e\n"
            "\tsie_true = %.14e\n"
@@ -166,8 +168,9 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
            "\trho      = %.14e\n"
            "\tsie      = %.14e\n"
            "\tP_test   = %.14e\n"
-           "\tresidual = %.14e\n",
-           rho, sie, P, T, rtest, etest, P_test, residual);
+           "\tresidual = %.14e\n"
+           "\fracres   = %.14e\n",
+           rho, sie, P, T, rtest, etest, P_test, residual, frac_residual);
   }
   return results_good;
 }

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -157,8 +157,8 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
   Real residual = P_test - P;
   Real frac_residual = robust::ratio(residual, P);
   bool results_good = (isClose(rho, rtest, 1e-8) && isClose(sie, etest, 1e-8))
-    // This is as good as it will get sometimes.
-    || (std::abs(frac_residual) < 10*robust::EPS());
+                      // This is as good as it will get sometimes.
+                      || (std::abs(frac_residual) < 10 * robust::EPS());
   if (!results_good) {
     printf("RhoSie of PT failure!\n"
            "\trho_true = %.14e\n"

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -158,7 +158,7 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
       std::min(std::abs(singularity::robust::ratio(residual, P)), std::abs(residual));
   bool results_good = (isClose(rho, rtest, 1e-8) && isClose(sie, etest, 1e-8))
                       // This is as good as it will get sometimes.
-                      || (std::abs(frac_residual) <= 10 * singularity::robust::EPS());
+                      || (std::abs(frac_residual) <= 1e-8);
   if (!results_good) {
     printf("RhoSie of PT failure!\n"
            "\trho_true = %.14e\n"

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -155,7 +155,8 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
   Real bmod = eos.BulkModulusFromDensityTemperature(rho, T, lambda);
   Real P_test = eos.PressureFromDensityTemperature(rtest, T, lambda);
   Real residual = P_test - P;
-  Real frac_residual = std::min(singularity::robust::ratio(residual, P), residual);
+  Real frac_residual =
+      std::min(std::abs(singularity::robust::ratio(residual, P)), std::abs(residual));
   bool results_good = (isClose(rho, rtest, 1e-8) && isClose(sie, etest, 1e-8))
                       // This is as good as it will get sometimes.
                       || (std::abs(frac_residual) < 10 * singularity::robust::EPS());

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -150,7 +150,8 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
                   Indexer_t &&lambda = static_cast<Real *>(nullptr)) {
   const Real P = eos.PressureFromDensityTemperature(rho, T, lambda);
   const Real sie = eos.InternalEnergyFromDensityTemperature(rho, T, lambda);
-  Real rtest, etest;
+  Real rtest = 12; // set these to something
+  Real etest = 1;
   eos.DensityEnergyFromPressureTemperature(P, T, lambda, rtest, etest);
   Real P_test = eos.PressureFromDensityTemperature(rtest, T, lambda);
   Real residual = P_test - P;

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -155,10 +155,10 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
   Real bmod = eos.BulkModulusFromDensityTemperature(rho, T, lambda);
   Real P_test = eos.PressureFromDensityTemperature(rtest, T, lambda);
   Real residual = P_test - P;
-  Real frac_residual = robust::ratio(residual, P);
+  Real frac_residual = singularity::robust::ratio(residual, P);
   bool results_good = (isClose(rho, rtest, 1e-8) && isClose(sie, etest, 1e-8))
                       // This is as good as it will get sometimes.
-                      || (std::abs(frac_residual) < 10 * robust::EPS());
+                      || (std::abs(frac_residual) < 10 * singularity::robust::EPS());
   if (!results_good) {
     printf("RhoSie of PT failure!\n"
            "\trho_true = %.14e\n"

--- a/test/eos_unit_test_helpers.hpp
+++ b/test/eos_unit_test_helpers.hpp
@@ -155,7 +155,7 @@ CheckRhoSieFromPT(EOS eos, Real rho, Real T,
   Real bmod = eos.BulkModulusFromDensityTemperature(rho, T, lambda);
   Real P_test = eos.PressureFromDensityTemperature(rtest, T, lambda);
   Real residual = P_test - P;
-  Real frac_residual = residual / P;
+  Real frac_residual = robust::ratio(residual, P);
   bool results_good = (isClose(rho, rtest, 1e-8) && isClose(sie, etest, 1e-8))
     // This is as good as it will get sometimes.
     || (std::abs(frac_residual) < 10*robust::EPS());

--- a/test/test_eos_carnahan_starling.cpp
+++ b/test/test_eos_carnahan_starling.cpp
@@ -161,6 +161,18 @@ SCENARIO("CarnahanStarling1", "[CarnahanStarling][CarnahanStarling1]") {
                         "Energy");
         }
       }
+
+      WHEN("We check RhoSie from PT") {
+        int nwrong = 0;
+        portableReduce(
+            "Check RhoSieFromPT", 0, 1,
+            PORTABLE_LAMBDA(const int i, int &nw) {
+              nw +=
+                  !CheckRhoSieFromPT(eos, 7.8290736890381501e-03, 1.5320999999999999e+03);
+            },
+            nwrong);
+        REQUIRE(nwrong == 0);
+      }
     }
   }
 }

--- a/test/test_eos_helmholtz.cpp
+++ b/test/test_eos_helmholtz.cpp
@@ -125,13 +125,16 @@ SCENARIO("Helmholtz equation of state - Table interpolation (tgiven)", "[Helmhol
                   eos.BulkModulusFromDensityTemperature(rho_in[i], temp_in[j], lambda);
               Real gruen =
                   eos.GruneisenParamFromDensityTemperature(rho_in[i], temp_in[j], lambda);
-
               if (!isClose(ein, ein_ref[k], 1e-10)) nwrong += 1;
               if (!isClose(press, press_ref[k], 1e-10)) nwrong += 1;
               if (!isClose(cv, cv_ref[k], 1e-6)) nwrong += 1;
               if (!isClose(bulkmod, bulkmod_ref[k], 1e-8)) nwrong += 1;
               if (!isClose(gruen, gruen_ref[k], 1e-6)) nwrong += 1;
 
+              // RhoSie of PT
+              nwrong += CheckRhoSieFromPT(eos, rho_in[i], temp_in[i], lambda);
+
+              // Deserialized EOS
               ein = eos_2.InternalEnergyFromDensityTemperature(rho_in[i], temp_in[j],
                                                                lambda);
               press = eos_2.PressureFromDensityTemperature(rho_in[i], temp_in[j], lambda);

--- a/test/test_eos_helmholtz.cpp
+++ b/test/test_eos_helmholtz.cpp
@@ -132,7 +132,7 @@ SCENARIO("Helmholtz equation of state - Table interpolation (tgiven)", "[Helmhol
               if (!isClose(gruen, gruen_ref[k], 1e-6)) nwrong += 1;
 
               // RhoSie of PT
-              nwrong += CheckRhoSieFromPT(eos, rho_in[i], temp_in[i], lambda);
+              nwrong += !CheckRhoSieFromPT(eos, rho_in[i], temp_in[i], lambda);
 
               // Deserialized EOS
               ein = eos_2.InternalEnergyFromDensityTemperature(rho_in[i], temp_in[j],

--- a/test/test_eos_mgusup.cpp
+++ b/test/test_eos_mgusup.cpp
@@ -408,6 +408,17 @@ SCENARIO("MGUsup EOS rho T", "[VectorEOS][MGUsupEOS]") {
         }
       }
 
+      WHEN("a [rho,sie](P, T) lookup is performed") {
+        int nwrong = 0;
+        portableReduce(
+            "Check density energy from pressure temperature", 0, num,
+            PORTABLE_LAMBDA(const int i, int &nw) {
+              nw += !CheckRhoSieFromPT(eos, v_density[i], v_temperature[i]);
+            },
+            nwrong);
+        THEN("There are no errors") { REQUIRE(nwrong == 0); }
+      }
+
       portableFor(
           "entropy", 0, num, PORTABLE_LAMBDA(const int i) {
             v_entropy[i] =

--- a/test/test_eos_noble_abel.cpp
+++ b/test/test_eos_noble_abel.cpp
@@ -125,6 +125,18 @@ SCENARIO("NobleAbel1", "[NobleAbel][NobleAbel1]") {
         }
       }
 
+      WHEN("A [rho,e](P, T) loopup is performed") {
+        int nwrong = 0;
+        portableReduce(
+            "Check density energy from pressure temperature", 0, num,
+            PORTABLE_LAMBDA(const int i, int &nw) {
+              nw +=
+                  !CheckRhoSieFromPT(eos, 7.2347087589269467e-03, 4.0000000000000000e+03);
+            },
+            nwrong);
+        THEN("There are no errors") { REQUIRE(nwrong == 0); }
+      }
+
       WHEN("A B_S(rho, e) lookup is performed") {
         eos.BulkModulusFromDensityInternalEnergy(v_density, v_energy, v_bulkmodulus, num);
 #ifdef PORTABILITY_STRATEGY_KOKKOS

--- a/test/test_eos_powermg.cpp
+++ b/test/test_eos_powermg.cpp
@@ -271,6 +271,17 @@ SCENARIO("PowerMG EOS rho sie", "[VectorEOS][PowerMGEOS]") {
         }
       }
 
+      WHEN("a [rho,sie](P, T) lookup is performed") {
+        int nwrong = 0;
+        portableReduce(
+            "Check density energy from pressure temperature", 0, 1,
+            PORTABLE_LAMBDA(const int i, int &nw) {
+              nw += !CheckRhoSieFromPT(eos, 7.285, 7.78960970661031411e+02);
+            },
+            nwrong);
+        THEN("There are no errors") { REQUIRE(nwrong == 0); }
+      }
+
       WHEN("A S(rho, e) lookup is performed") {
         portableFor(
             "Test entropy", 0, num, PORTABLE_LAMBDA(const int i) {

--- a/test/test_eos_stellar_collapse.cpp
+++ b/test/test_eos_stellar_collapse.cpp
@@ -278,6 +278,9 @@ SCENARIO("Stellar Collapse EOS", "[StellarCollapse]") {
                 if (!isClose(b1, b2)) {
                   nwrong_d() += 1;
                 }
+                if (!CheckRhoSieFromPT(sc_d, R, T, lambda)) {
+                  nwrong_d() += 1;
+                }
               });
 #ifdef PORTABILITY_STRATEGY_KOKKOS
           Kokkos::deep_copy(nwrong_h, nwrong_d);

--- a/test/test_eos_stiff.cpp
+++ b/test/test_eos_stiff.cpp
@@ -583,6 +583,16 @@ SCENARIO("Test Stiff Gas Entropy Calls", "[StiffGas][StiffGas5]") {
           array_compare(num, density, energy, h_entropy, entropy_true, "Density",
                         "Energy");
         }
+        THEN("[rho, e](P, T) also works") {
+          int nwrong = 0;
+          portableReduce(
+              "Check density energy from pressure temperature", 0, num,
+              PORTABLE_LAMBDA(const int i, int &nw) {
+                nw += !CheckRhoSieFromPT(eos, v_density[i], v_local_temp[i]);
+              },
+              nwrong);
+          AND_THEN("There are no errors") { REQUIRE(nwrong == 0); }
+        }
       }
     }
   }

--- a/test/test_eos_vinet.cpp
+++ b/test/test_eos_vinet.cpp
@@ -346,6 +346,16 @@ SCENARIO("Vinet EOS rho T", "[VectorEOS][VinetEOS]") {
           array_compare(num, density, temperature, h_pressure, pressure_true, "Density",
                         "Temperature");
         }
+        THEN("[rho, e](P, T) also works") {
+          int nwrong = 0;
+          portableReduce(
+              "Check density energy from pressure temperature", 0, num,
+              PORTABLE_LAMBDA(const int i, int &nw) {
+                nw += !CheckRhoSieFromPT(eos, v_density[i], v_temperature[i]);
+              },
+              nwrong);
+          AND_THEN("There are no errors") { REQUIRE(nwrong == 0); }
+        }
       }
 
       portableFor(

--- a/test/test_eos_zsplit.cpp
+++ b/test/test_eos_zsplit.cpp
@@ -124,6 +124,9 @@ SCENARIO("ZSplit of Ideal Gas", "[ZSplit][IdealGas][IdealElectrons]") {
                 printf("Bad sie ionized! %d %.14e %.14e\n", i, e_fi, e_ie);
                 nw += 1;
               }
+
+              nw += !CheckRhoSieFromPT(eos_ze, rho, T, lambda);
+              nw += !CheckRhoSieFromPT(eos_ie, rho, T, lambda);
             },
             nwrong);
         THEN("Pe_fi == PE_ie") { REQUIRE(nwrong == 0); }

--- a/test/test_eos_zsplit.cpp
+++ b/test/test_eos_zsplit.cpp
@@ -88,6 +88,11 @@ SCENARIO("ZSplit of Ideal Gas", "[ZSplit][IdealGas][IdealElectrons]") {
               printf("Bad sie Sum! %d %.14e %.14e %.14e\n", i, et, ei, ee);
               nw += 1;
             }
+
+            if (Z > 0) {
+              nw += !CheckRhoSieFromPT(eos_zi, rho, temp, lambda);
+              nw += !CheckRhoSieFromPT(eos_ze, rho, temp, lambda);
+            }
           },
           nwrong);
       THEN("Pe + Pi = Pt") { REQUIRE(nwrong == 0); }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

The easiest way to get the Jacobian for the PT-space PTE solver we are building is to ensure that the `DensityEnergyFromPressureTemperature` call works consistently for all equations of state. This MR makes sure thats the case and threads this call through all the tests. 

To ease this process, I added a base class implementation. However, I think most classes will want their own implementations, and I added them when appropriate.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
