### PR TITLE
Enable electron/ion subtables for SpinerEOS and EOSPAC backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR459]](https://github.com/lanl/singularity-eos/pull/459) Add electron and ion tables to EOSPAC and SpinerEOS backends
 - [[PR444]](https://github.com/lanl/singularity-eos/pull/444) Add Z split modifier and electron ideal gas EOS
 
 ### Fixed (Repair bugs, etc)

--- a/doc/sphinx/src/models.rst
+++ b/doc/sphinx/src/models.rst
@@ -218,9 +218,25 @@ density.
 ``singularity-eos`` assumes that, when 3T physics is active, electrons
 and ions are each described by a separate equation of state
 object. Several models are specifically designed to represent, e.g.,
-the electron equation of state or ion equation of state. The tabulated
-models may also support loading tables specifically for electron or
-ion equations of state.
+the electron equation of state or ion equation of state.
+
+The tabulated models may also support loading tables specifically for
+electron or ion equations of state. In these cases, an ``enum class``
+specifies which component of the material is being requst:
+
+.. code-block:: cpp
+
+   enum class TableSplit { Total, ElectronOnly, IonCold };
+
+where here ``ElectronOnly`` is the free electrons of the material,
+``IonCold`` is the ions plus cold curve (i.e., the ions if you don't
+know what a cold curve is), and ``Total`` is the sum of free electrons
+and ions.
+
+.. note::
+
+  The tabulated equations of state have an implicitly assumed
+  ionization fraction that depends on the electron temperature.
 
 Available EOS Information and Nomenclature
 ------------------------------------------
@@ -1665,15 +1681,19 @@ The constructor for ``SpinerEOSDependsRhoT`` is given by two overloads:
 .. code-block:: cpp
 
   SpinerEOSDependsRhoT(const std::string &filename, int matid,
+                       const singularity::TableSplit = singularity::TableSplit::Total,
                        bool reproduciblity_mode = false);
   SpinerEOSDependsRhoT(const std::string &filename, const std::string &materialName,
+                       const singularity::TableSplit = singularity::TableSplit::Total,
                        bool reproducibility_mode = false);
 
 where here ``filename`` is the input file, ``matid`` is the unique
 material ID in the database in the file, ``materialName`` is the name
 of the material in the file, and ``reproducability_mode`` is a boolean
 which slightly changes how initial guesses for root finds are
-computed. The constructor for ``SpinerEOSDependsRhoSie`` is identical.
+computed. The ``TableSplit`` option selects electron, ion, or total
+equation of state tables for partial ionization. The constructor for
+``SpinerEOSDependsRhoSie`` is identical.
 
 .. note::
 
@@ -2134,27 +2154,40 @@ EOSPAC EOS
     Entropy is not yet available for this EOS
 
 This is a striaghtforward wrapper of the `EOSPAC`_ library for the
-`Sesame`_ database. The constructor for the ``EOSPAC`` model looks like
+`Sesame`_ database. The constructor for the ``EOSPAC`` model has several overloads
 
 .. code-block::
 
-  EOSPAC(int matid, bool invert_at_setup = false, Real insert_data = 0.0, eospacMonotonicity monotonicity = eospacMonotonicity::none, bool apply_smoothing = false, eospacSplit apply_splitting = eospacSplit::none, bool linear_interp = false)
+  EOSPAC(int matid, TableSplit split, bool invert_at_setup = false,
+         Real insert_data = 0.0,
+         eospacMonotonicity monotonicity = eospacMonotonicity::none,
+         bool apply_smoothing = false,
+         eospacSplit apply_splitting = eospacSplit::none,
+         bool linear_interp = false);
+  EOSPAC(int matid, bool invert_at_setup = false, Real insert_data = 0.0,
+         eospacMonotonicity monotonicity = eospacMonotonicity::none,
+         bool apply_smoothing = false,
+         eospacSplit apply_splitting = eospacSplit::none,
+         bool linear_interp = false);
+  EOSPAC(int matid, const Options &opts);
 
 where ``matid`` is the unique material number in the database,
-``invert_at_setup`` specifies whether or not pre-compute tables of
-temperature as a function of density and energy, ``insert_data`` 
-inserts specified number of grid points between original grid points 
-in the `Sesame`_ table, ``monotonicity` enforces monotonicity in x, 
-y or both (:math:`monotonicityX/Y/XY`), ``apply_smoothing`` enables 
-data table smoothing that imposes a linear floor on temperature dependence, 
-forces linear temperature dependence for low temperature, and forces 
-linear density dependence for low and high density, ``apply_splitting`` 
-has the following options for ion data tables not found in the `Sesame`_ 
-database :. :math:`splitNumProp` uses the cold curve plus number-proportional 
-model, :math:`splitIdealGas` uses the cold curve plus ideal gas model 
-and :math:`splitCowan` uses the cold curve plus Cowan-nuclear model 
-for ions and the final option ``linear_interp`` uses linear instead of 
-bilinear interpolation. 
+``split`` is the ``TableSplit`` parameter for electron, ion, or total
+tables used in partial ionization. ``invert_at_setup`` specifies
+whether or not pre-compute tables of temperature as a function of
+density and energy, ``insert_data`` inserts specified number of grid
+points between original grid points in the `Sesame`_ table,
+``monotonicity` enforces monotonicity in x, y or both
+(:math:`monotonicityX/Y/XY`), ``apply_smoothing`` enables data table
+smoothing that imposes a linear floor on temperature dependence,
+forces linear temperature dependence for low temperature, and forces
+linear density dependence for low and high density,
+``apply_splitting`` has the following options for ion data tables not
+found in the `Sesame`_ database :. :math:`splitNumProp` uses the cold
+curve plus number-proportional model, :math:`splitIdealGas` uses the
+cold curve plus ideal gas model and :math:`splitCowan` uses the cold
+curve plus Cowan-nuclear model for ions and the final option
+``linear_interp`` uses linear instead of bilinear interpolation.
 
 .. note::
 

--- a/doc/sphinx/src/models.rst
+++ b/doc/sphinx/src/models.rst
@@ -229,9 +229,10 @@ specifies which component of the material is being requst:
    enum class TableSplit { Total, ElectronOnly, IonCold };
 
 where here ``ElectronOnly`` is the free electrons of the material,
-``IonCold`` is the ions plus cold curve (i.e., the ions if you don't
-know what a cold curve is), and ``Total`` is the sum of free electrons
-and ions.
+corresponding to Sesame 304 tables, ``IonCold`` is the ions plus cold
+curve (i.e., the ions if you don't know what a cold curve is),
+corresponding to the Sesame 303 tables, and ``Total`` is the sum of
+free electrons and ions, correspodning to the Sesame 301 tables.
 
 .. note::
 

--- a/doc/sphinx/src/models.rst
+++ b/doc/sphinx/src/models.rst
@@ -1756,6 +1756,12 @@ and files to locate files in the `sesame`_ database, and
 database need not be provided by the command line. For how to specify
 `sesame`_ file locations, see the `eospac`_ manual.
 
+.. note::
+
+  To enable 3T subtables with ``SpinerEOS``, you must set
+  ``ionization=true`` in the input file for ``sesame2spiner`` for the
+  desired material.
+
 Piecewise Spiner Grids
 ````````````````````````
 

--- a/sesame2spiner/examples/unit_tests/steel.dat
+++ b/sesame2spiner/examples/unit_tests/steel.dat
@@ -2,7 +2,7 @@
 #  Example input deck for sesame2spiner,
 #  a tool for converting eospac to spiner
 #  Author: Jonah Miller (jonahm@lanl.gov)
-#  © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+#  © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 #  program was produced under U.S. Government contract 89233218CNA000001
 #  for Los Alamos National Laboratory (LANL), which is operated by Triad
 #  National Security, LLC for the U.S.  Department of Energy/National

--- a/sesame2spiner/examples/unit_tests/steel.dat
+++ b/sesame2spiner/examples/unit_tests/steel.dat
@@ -17,3 +17,4 @@
 
 matid=4272
 name=steel
+ionization = true

--- a/sesame2spiner/generate_files.cpp
+++ b/sesame2spiner/generate_files.cpp
@@ -107,7 +107,8 @@ herr_t saveMaterial(hid_t loc, const SesameMetadata &metadata, const Bounds &lRh
     status += dTdRho.saveHDF(leGroup, SP5::Fields::dTdRho);
     status += dTdE.saveHDF(leGroup, SP5::Fields::dTdE);
     status += dEdRho.saveHDF(leGroup, SP5::Fields::dEdRho);
-    status += mask.saveHDF(leGroup, SP5::Fields::mask);
+    // currently unused
+    // status += mask.saveHDF(leGroup, SP5::Fields::mask);
   }
 
   {
@@ -123,21 +124,24 @@ herr_t saveMaterial(hid_t loc, const SesameMetadata &metadata, const Bounds &lRh
     status += dTdE.saveHDF(lTGroup, SP5::Fields::dTdE);
     status += dEdRho.saveHDF(lTGroup, SP5::Fields::dEdRho);
     status += dEdT.saveHDF(lTGroup, SP5::Fields::dEdT);
-    status += mask.saveHDF(lTGroup, SP5::Fields::mask);
+    // Currently unused
+    // status += mask.saveHDF(lTGroup, SP5::Fields::mask);
   }
   {
     DataBox P, sie, dPdRho, dEdRho, bMod, mask, transitionMask;
     eosColdCurves(matid, lRhoBounds, P, sie, dPdRho, dEdRho, bMod, mask, eospacWarn);
-    eosColdCurveMask(matid, lRhoBounds, leBounds.grid.nPoints(), sie, transitionMask,
-                     eospacWarn);
+    // currently unused
+    // eosColdCurveMask(matid, lRhoBounds, leBounds.grid.nPoints(), sie, transitionMask,
+    //                  eospacWarn);
 
     status += P.saveHDF(coldGroup, SP5::Fields::P);
     status += sie.saveHDF(coldGroup, SP5::Fields::sie);
     status += bMod.saveHDF(coldGroup, SP5::Fields::bMod);
     status += dPdRho.saveHDF(coldGroup, SP5::Fields::dPdRho);
     status += dEdRho.saveHDF(coldGroup, SP5::Fields::dEdRho);
-    status += mask.saveHDF(coldGroup, SP5::Fields::mask);
-    status += transitionMask.saveHDF(coldGroup, SP5::Fields::transitionMask);
+    // currently unused
+    // status += mask.saveHDF(coldGroup, SP5::Fields::mask);
+    // status += transitionMask.saveHDF(coldGroup, SP5::Fields::transitionMask);
   }
 
   if (addSubtables) {

--- a/sesame2spiner/generate_files.cpp
+++ b/sesame2spiner/generate_files.cpp
@@ -95,38 +95,10 @@ herr_t saveMaterial(hid_t loc, const SesameMetadata &metadata, const Bounds &lRh
   coldGroup =
       H5Gcreate(matGroup, SP5::Depends::coldCurve, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
-  {
-    DataBox P, sie, T, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho, mask;
-    eosDataOfRhoSie(matid, lRhoBounds, leBounds, P, T, bMod, dPdRho, dPdE, dTdRho, dTdE,
-                    dEdRho, mask, eospacWarn);
-    status += P.saveHDF(leGroup, SP5::Fields::P);
-    status += T.saveHDF(leGroup, SP5::Fields::T);
-    status += bMod.saveHDF(leGroup, SP5::Fields::bMod);
-    status += dPdRho.saveHDF(leGroup, SP5::Fields::dPdRho);
-    status += dPdE.saveHDF(leGroup, SP5::Fields::dPdE);
-    status += dTdRho.saveHDF(leGroup, SP5::Fields::dTdRho);
-    status += dTdE.saveHDF(leGroup, SP5::Fields::dTdE);
-    status += dEdRho.saveHDF(leGroup, SP5::Fields::dEdRho);
-    // currently unused
-    // status += mask.saveHDF(leGroup, SP5::Fields::mask);
-  }
-
-  {
-    DataBox P, sie, T, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho, dEdT, mask;
-    eosDataOfRhoT(matid, lRhoBounds, lTBounds, P, sie, bMod, dPdRho, dPdE, dTdRho, dTdE,
-                  dEdRho, dEdT, mask, eospacWarn);
-    status += P.saveHDF(lTGroup, SP5::Fields::P);
-    status += sie.saveHDF(lTGroup, SP5::Fields::sie);
-    status += bMod.saveHDF(lTGroup, SP5::Fields::bMod);
-    status += dPdRho.saveHDF(lTGroup, SP5::Fields::dPdRho);
-    status += dPdE.saveHDF(lTGroup, SP5::Fields::dPdE);
-    status += dTdRho.saveHDF(lTGroup, SP5::Fields::dTdRho);
-    status += dTdE.saveHDF(lTGroup, SP5::Fields::dTdE);
-    status += dEdRho.saveHDF(lTGroup, SP5::Fields::dEdRho);
-    status += dEdT.saveHDF(lTGroup, SP5::Fields::dEdT);
-    // Currently unused
-    // status += mask.saveHDF(lTGroup, SP5::Fields::mask);
-  }
+  status += saveTablesRhoSie(leGroup, matid, TableSplit::Total, lRhoBounds, leBounds,
+                             eospacWarn);
+  status +=
+      saveTablesRhoT(lTGroup, matid, TableSplit::Total, lRhoBounds, lTBounds, eospacWarn);
   {
     DataBox P, sie, dPdRho, dEdRho, bMod, mask, transitionMask;
     eosColdCurves(matid, lRhoBounds, P, sie, dPdRho, dEdRho, bMod, mask, eospacWarn);
@@ -147,42 +119,20 @@ herr_t saveMaterial(hid_t loc, const SesameMetadata &metadata, const Bounds &lRh
   if (addSubtables) {
     int i = 0;
     std::vector<TableSplit> splits = {TableSplit::ElectronOnly, TableSplit::IonCold};
-    std::vector<std::string> grpnames = {SP5::SubTable::electronOnly, SP5::SubTable::ionCold};
-    for (TableSplit split : splits) {
+    std::vector<std::string> grpnames = {SP5::SubTable::electronOnly,
+                                         SP5::SubTable::ionCold};
+    for (auto split : splits) {
       std::string grpname = grpnames[i++];
       {
         hid_t grp =
             H5Gcreate(leGroup, grpname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-        DataBox P, sie, T, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho, mask;
-        eosDataOfRhoSie(matid, split, lRhoBounds, leBounds, P, T, bMod, dPdRho, dPdE,
-                        dTdRho, dTdE, dEdRho, mask, eospacWarn);
-        status += P.saveHDF(grp, SP5::Fields::P);
-        status += T.saveHDF(grp, SP5::Fields::T);
-        status += bMod.saveHDF(grp, SP5::Fields::bMod);
-        status += dPdRho.saveHDF(grp, SP5::Fields::dPdRho);
-        status += dPdE.saveHDF(grp, SP5::Fields::dPdE);
-        status += dTdRho.saveHDF(grp, SP5::Fields::dTdRho);
-        status += dTdE.saveHDF(grp, SP5::Fields::dTdE);
-        status += dEdRho.saveHDF(grp, SP5::Fields::dEdRho);
-        status += mask.saveHDF(grp, SP5::Fields::mask);
+        status += saveTablesRhoSie(grp, matid, split, lRhoBounds, leBounds, eospacWarn);
         status += H5Gclose(grp);
       }
       {
         hid_t grp =
             H5Gcreate(lTGroup, grpname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-        DataBox P, sie, T, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho, dEdT, mask;
-        eosDataOfRhoT(matid, split, lRhoBounds, lTBounds, P, sie, bMod, dPdRho, dPdE,
-                      dTdRho, dTdE, dEdRho, dEdT, mask, eospacWarn);
-        status += P.saveHDF(grp, SP5::Fields::P);
-        status += sie.saveHDF(grp, SP5::Fields::sie);
-        status += bMod.saveHDF(grp, SP5::Fields::bMod);
-        status += dPdRho.saveHDF(grp, SP5::Fields::dPdRho);
-        status += dPdE.saveHDF(grp, SP5::Fields::dPdE);
-        status += dTdRho.saveHDF(grp, SP5::Fields::dTdRho);
-        status += dTdE.saveHDF(grp, SP5::Fields::dTdE);
-        status += dEdRho.saveHDF(grp, SP5::Fields::dEdRho);
-        status += dEdT.saveHDF(grp, SP5::Fields::dEdT);
-        status += mask.saveHDF(grp, SP5::Fields::mask);
+        status += saveTablesRhoT(grp, matid, split, lRhoBounds, lTBounds, eospacWarn);
         status += H5Gclose(grp);
       }
     }
@@ -286,6 +236,45 @@ herr_t saveAllMaterials(const std::string &savename,
   if (status != H5_SUCCESS) {
     std::cerr << "WARNING: problem with HDf5" << std::endl;
   }
+  return status;
+}
+
+herr_t saveTablesRhoSie(hid_t loc, int matid, TableSplit split, const Bounds &lRhoBounds,
+                        const Bounds &leBounds, Verbosity eospacWarn) {
+  herr_t status = 0;
+  DataBox P, T, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho, mask;
+  eosDataOfRhoSie(matid, split, lRhoBounds, leBounds, P, T, bMod, dPdRho, dPdE, dTdRho,
+                  dTdE, dEdRho, mask, eospacWarn);
+  status += P.saveHDF(loc, SP5::Fields::P);
+  status += T.saveHDF(loc, SP5::Fields::T);
+  status += bMod.saveHDF(loc, SP5::Fields::bMod);
+  status += dPdRho.saveHDF(loc, SP5::Fields::dPdRho);
+  status += dPdE.saveHDF(loc, SP5::Fields::dPdE);
+  status += dTdRho.saveHDF(loc, SP5::Fields::dTdRho);
+  status += dTdE.saveHDF(loc, SP5::Fields::dTdE);
+  status += dEdRho.saveHDF(loc, SP5::Fields::dEdRho);
+  // currently unused
+  // status += mask.saveHDF(loc, SP5::Fields::mask);
+  return status;
+}
+
+herr_t saveTablesRhoT(hid_t loc, int matid, TableSplit split, const Bounds &lRhoBounds,
+                      const Bounds &lTBounds, Verbosity eospacWarn) {
+  herr_t status = 0;
+  DataBox P, sie, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho, dEdT, mask;
+  eosDataOfRhoT(matid, split, lRhoBounds, lTBounds, P, sie, bMod, dPdRho, dPdE, dTdRho,
+                dTdE, dEdRho, dEdT, mask, eospacWarn);
+  status += P.saveHDF(loc, SP5::Fields::P);
+  status += sie.saveHDF(loc, SP5::Fields::sie);
+  status += bMod.saveHDF(loc, SP5::Fields::bMod);
+  status += dPdRho.saveHDF(loc, SP5::Fields::dPdRho);
+  status += dPdE.saveHDF(loc, SP5::Fields::dPdE);
+  status += dTdRho.saveHDF(loc, SP5::Fields::dTdRho);
+  status += dTdE.saveHDF(loc, SP5::Fields::dTdE);
+  status += dEdRho.saveHDF(loc, SP5::Fields::dEdRho);
+  status += dEdT.saveHDF(loc, SP5::Fields::dEdT);
+  // Currently unused
+  // status += mask.saveHDF(loc, SP5::Fields::mask);
   return status;
 }
 

--- a/sesame2spiner/generate_files.hpp
+++ b/sesame2spiner/generate_files.hpp
@@ -1,7 +1,7 @@
 //======================================================================
 // sesame2spiner tool for converting eospac to spiner
 // Author: Jonah Miller (jonahm@lanl.gov)
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -42,7 +42,15 @@ constexpr Real T_SPLIT_POINT_DEFAULT = 1e4;
 
 herr_t saveMaterial(hid_t loc, const SesameMetadata &metadata, const Bounds &lRhoBounds,
                     const Bounds &lTBounds, const Bounds &leBounds,
-                    const std::string &name, Verbosity eospacWarn = Verbosity::Quiet);
+                    const std::string &name, const bool addSubtables,
+                    Verbosity eospacWarn = Verbosity::Quiet);
+inline herr_t saveMaterial(hid_t loc, const SesameMetadata &metadata,
+                           const Bounds &lRhoBounds, const Bounds &lTBounds,
+                           const Bounds &leBounds, const std::string &name,
+                           Verbosity eospacWarn = Verbosity::Quiet) {
+  return saveMaterial(loc, metadata, lRhoBounds, lTBounds, leBounds, name, false,
+                      eospacWarn);
+}
 
 herr_t saveAllMaterials(const std::string &savename,
                         const std::vector<std::string> &filenames, bool printMetadata,

--- a/sesame2spiner/generate_files.hpp
+++ b/sesame2spiner/generate_files.hpp
@@ -56,6 +56,11 @@ herr_t saveAllMaterials(const std::string &savename,
                         const std::vector<std::string> &filenames, bool printMetadata,
                         Verbosity eospacWarn);
 
+herr_t saveTablesRhoSie(hid_t loc, int matid, TableSplit split, const Bounds &lRhoBounds,
+                        const Bounds &leBounds, Verbosity eospacWarn = Verbosity::Quiet);
+herr_t saveTablesRhoT(hid_t loc, int matid, TableSplit split, const Bounds &lRhoBounds,
+                      const Bounds &lTBounds, Verbosity eospacWarn = Verbosity::Quiet);
+
 void getMatBounds(int i, int matid, const SesameMetadata &metadata, const Params &params,
                   Bounds &lRhoBounds, Bounds &lTBounds, Bounds &leBounds);
 

--- a/sesame2spiner/io_eospac.cpp
+++ b/sesame2spiner/io_eospac.cpp
@@ -172,8 +172,8 @@ void eosDataOfRhoT(int matid, const TableSplit split, const Bounds &lRhoBounds,
   std::size_t iflat = 0;
   for (std::size_t j = 0; j < rhos.size(); ++j) {
     for (std::size_t i = 0; i < Ts.size(); ++i) {
-      rho_flat[i] = densityToSesame(rhos[j]);
-      T_flat[i] = temperatureToSesame(Ts[i]);
+      rho_flat[iflat] = densityToSesame(rhos[j]);
+      T_flat[iflat] = temperatureToSesame(Ts[i]);
       iflat++;
     }
   }
@@ -197,7 +197,6 @@ void eosDataOfRhoT(int matid, const TableSplit split, const Bounds &lRhoBounds,
   for (size_t j = 0; j < rhos.size(); j++) {
     Real rho = densityToSesame(rhos[j]);
     for (size_t i = 0; i < Ts.size(); i++) {
-      Real T = temperatureToSesame(Ts[i]);
       Real DPDE_R = DPDT_R[iflat] / DEDT_R[iflat];
       Real bMod =
           getBulkModulus(rho, P_pack[iflat], DPDR_T[iflat], DPDE_R, DEDR_T[iflat]);

--- a/sesame2spiner/io_eospac.hpp
+++ b/sesame2spiner/io_eospac.hpp
@@ -1,7 +1,7 @@
 //======================================================================
 // sesame2spiner tool for converting eospac to spiner
 // Author: Jonah Miller (jonahm@lanl.gov)
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -17,6 +17,7 @@
 #ifndef _SESAME2SPINER_IO_EOSPAC_HPP_
 #define _SESAME2SPINER_IO_EOSPAC_HPP_
 
+#include <string>
 #include <vector>
 
 #include <eos_Interface.h> // eospac API
@@ -26,6 +27,7 @@
 #endif
 
 #include <ports-of-call/portability.hpp>
+#include <singularity-eos/base/constants.hpp>
 #include <singularity-eos/base/fast-math/logs.hpp>
 #include <singularity-eos/base/spiner_table_utils.hpp>
 #include <spiner/databox.hpp>
@@ -34,19 +36,38 @@
 
 using EospacWrapper::Verbosity;
 constexpr int NGRIDS = 3;
+using singularity::TableSplit;
 using Bounds = singularity::table_utils::Bounds<NGRIDS>;
 using Grid_t = Spiner::PiecewiseGrid1D<Real, NGRIDS>;
 using DataBox = Spiner::DataBox<Real, Grid_t>;
 
-void eosDataOfRhoSie(int matid, const Bounds &lRhoBounds, const Bounds &leBounds,
-                     DataBox &P, DataBox &T, DataBox &bMods, DataBox &dPdRho,
-                     DataBox &dPdE, DataBox &dTdRho, DataBox &dTdE, DataBox &dEdRho,
-                     DataBox &mask, Verbosity eospacWarn = Verbosity::Quiet);
+void eosDataOfRhoSie(int matid, const TableSplit split, const Bounds &lRhoBounds,
+                     const Bounds &leBounds, DataBox &P, DataBox &T, DataBox &bMods,
+                     DataBox &dPdRho, DataBox &dPdE, DataBox &dTdRho, DataBox &dTdE,
+                     DataBox &dEdRho, DataBox &mask,
+                     Verbosity eospacWarn = Verbosity::Quiet);
+inline void eosDataOfRhoSie(int matid, const Bounds &lRhoBounds, const Bounds &leBounds,
+                            DataBox &P, DataBox &T, DataBox &bMods, DataBox &dPdRho,
+                            DataBox &dPdE, DataBox &dTdRho, DataBox &dTdE,
+                            DataBox &dEdRho, DataBox &mask,
+                            Verbosity eospacWarn = Verbosity::Quiet) {
+  eosDataOfRhoSie(matid, TableSplit::Total, lRhoBounds, leBounds, P, T, bMods, dPdRho,
+                  dPdE, dTdRho, dTdE, dEdRho, mask, eospacWarn);
+}
 
-void eosDataOfRhoT(int matid, const Bounds &lRhoBounds, const Bounds &lTBounds,
-                   DataBox &Ps, DataBox &sies, DataBox &bMods, DataBox &dPdRho,
-                   DataBox &dPdE, DataBox &dTdRho, DataBox &dTdE, DataBox &dEdRho,
-                   DataBox &dEdT, DataBox &mask, Verbosity eospacWarn = Verbosity::Quiet);
+void eosDataOfRhoT(int matid, const TableSplit split, const Bounds &lRhoBounds,
+                   const Bounds &lTBounds, DataBox &Ps, DataBox &sies, DataBox &bMods,
+                   DataBox &dPdRho, DataBox &dPdE, DataBox &dTdRho, DataBox &dTdE,
+                   DataBox &dEdRho, DataBox &dEdT, DataBox &mask,
+                   Verbosity eospacWarn = Verbosity::Quiet);
+inline void eosDataOfRhoT(int matid, const Bounds &lRhoBounds, const Bounds &lTBounds,
+                          DataBox &Ps, DataBox &sies, DataBox &bMods, DataBox &dPdRho,
+                          DataBox &dPdE, DataBox &dTdRho, DataBox &dTdE, DataBox &dEdRho,
+                          DataBox &dEdT, DataBox &mask,
+                          Verbosity eospacWarn = Verbosity::Quiet) {
+  eosDataOfRhoT(matid, TableSplit::Total, lRhoBounds, lTBounds, Ps, sies, bMods, dPdRho,
+                dPdE, dTdRho, dTdE, dEdRho, dEdT, mask, eospacWarn);
+}
 
 void eosColdCurves(int matid, const Bounds &lRhoBounds, DataBox &Ps, DataBox &sies,
                    DataBox &dPdRho, DataBox &dEdRho, DataBox &bMod, DataBox &mask,
@@ -57,5 +78,17 @@ void eosColdCurveMask(int matid, const Bounds &lRhoBounds, const int numSie,
                       Verbosity eospacWarn = Verbosity::Quiet);
 
 void makeInterpPoints(std::vector<EOS_REAL> &v, const Bounds &b);
+
+namespace impl {
+template <typename T>
+T select(TableSplit split, T a, T b, T c) {
+  if (split == TableSplit::Total) return a;
+  if (split == TableSplit::ElectronOnly)
+    return b;
+  else // if (split == TableSplit::IonCold)
+    return c;
+}
+void modifyNames(TableSplit split, std::vector<std::string> &names);
+} // namespace impl
 
 #endif // _SESAME2SPINER_IO_EOSPAC_HPP_

--- a/singularity-eos/base/constants.hpp
+++ b/singularity-eos/base/constants.hpp
@@ -34,6 +34,7 @@ constexpr unsigned long all_values = (1 << 7) - 1;
 constexpr size_t MAX_NUM_LAMBDAS = 3;
 enum class DataStatus { Deallocated = 0, OnDevice = 1, OnHost = 2, UnManaged = 3 };
 enum class TableStatus { OnTable = 0, OffBottom = 1, OffTop = 2 };
+enum class TableSplit { Total = 0, ElectronOnly = 1, IonCold = 2 };
 constexpr Real ROOM_TEMPERATURE = 293; // K
 constexpr Real ATMOSPHERIC_PRESSURE = 1e6;
 

--- a/singularity-eos/base/sp5/singularity_eos_sp5.hpp
+++ b/singularity-eos/base/sp5/singularity_eos_sp5.hpp
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 // Extra definitions to the SP5 file format required for singularity-eos
 // Author: Jonah Miller (jonahm@lanl.gov)
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -27,6 +27,11 @@ constexpr char logRhoLogSie[] = "dependsLogRhoLogSie";
 constexpr char logRhoLogT[] = "dependsLogRhoLogT";
 constexpr char coldCurve[] = "coldCurve";
 } // namespace Depends
+
+namespace SubTable {
+constexpr char electronOnly[] = "electronOnly";
+constexpr char ionCold[] = "ionCold";
+} // namespace SubTable
 
 namespace Offsets {
 constexpr char messageName[] = "interpretation";

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -1218,9 +1218,8 @@ inline EOSPAC::EOSPAC(const int matid, TableSplit split, bool invert_at_setup,
     }
   }
   eosSafeLoad(NT, matid, tableType, tablehandle, tableNames, Verbosity::Debug,
-              invert_at_setup = invert_at_setup, insert_data = insert_data,
-              monotonicity = monotonicity, apply_smoothing = apply_smoothing,
-              apply_splitting = apply_splitting, linear_interp = linear_interp);
+              invert_at_setup, insert_data, monotonicity, apply_smoothing,
+              apply_splitting, linear_interp);
   PofRT_table_ = tablehandle[0];
   TofRE_table_ = tablehandle[1];
   EofRT_table_ = tablehandle[2];

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <map>
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -129,14 +130,39 @@ inline void SetUpOutputScalingOption(EOS_INTEGER options[], EOS_REAL values[],
 class EOSPAC : public EosBase<EOSPAC> {
 
  public:
+  struct Options {
+    TableSplit split = TableSplit::Total;
+    bool invert_at_setup = false;
+    Real insert_data = 0.0;
+    eospacMonotonicity monotonicity = eospacMonotonicity::none;
+    bool apply_smoothing = false;
+    eospacSplit apply_splitting = eospacSplit::none;
+    bool linear_interp = false;
+  };
+
   inline EOSPAC() = default;
 
   ////add options here... and elsewhere
-  inline EOSPAC(int matid, bool invert_at_setup = false, Real insert_data = 0.0,
+  // Complete constructor
+  inline EOSPAC(int matid, TableSplit split, bool invert_at_setup = false,
+                Real insert_data = 0.0,
                 eospacMonotonicity monotonicity = eospacMonotonicity::none,
                 bool apply_smoothing = false,
                 eospacSplit apply_splitting = eospacSplit::none,
                 bool linear_interp = false);
+  // Overloads with fewer positional arguments
+  inline EOSPAC(int matid, bool invert_at_setup = false, Real insert_data = 0.0,
+                eospacMonotonicity monotonicity = eospacMonotonicity::none,
+                bool apply_smoothing = false,
+                eospacSplit apply_splitting = eospacSplit::none,
+                bool linear_interp = false)
+      : EOSPAC(matid, TableSplit::Total, invert_at_setup, insert_data, monotonicity,
+               apply_smoothing, apply_splitting, linear_interp) {}
+  inline EOSPAC(int matid, const Options &opts)
+      : EOSPAC(matid, opts.split, opts.invert_at_setup, opts.insert_data,
+               opts.monotonicity, opts.apply_smoothing, opts.apply_splitting,
+               opts.linear_interp) {}
+
   PORTABLE_INLINE_FUNCTION void CheckParams() const {
     // TODO(JMM): More validation checks?
     PORTABLE_ALWAYS_REQUIRE(rho_min_ >= 0, "Non-negative minimum density");
@@ -1110,6 +1136,7 @@ class EOSPAC : public EosBase<EOSPAC> {
   static constexpr const unsigned long _preferred_input =
       thermalqs::density | thermalqs::temperature;
   int matid_;
+  TableSplit split_;
   static constexpr int NT = 7;
   EOS_INTEGER PofRT_table_;
   EOS_INTEGER TofRE_table_;
@@ -1158,21 +1185,42 @@ class EOSPAC : public EosBase<EOSPAC> {
 // Implementation details below
 // ======================================================================
 
-inline EOSPAC::EOSPAC(const int matid, bool invert_at_setup, Real insert_data,
-                      EospacWrapper::eospacMonotonicity monotonicity,
+inline EOSPAC::EOSPAC(const int matid, TableSplit split, bool invert_at_setup,
+                      Real insert_data, EospacWrapper::eospacMonotonicity monotonicity,
                       bool apply_smoothing, EospacWrapper::eospacSplit apply_splitting,
                       bool linear_interp)
-    : matid_(matid) {
+    : matid_(matid), split_(split) {
   using namespace EospacWrapper;
-  EOS_INTEGER tableType[NT] = {EOS_Pt_DT, EOS_T_DUt,  EOS_Ut_DT, EOS_D_PtT,
-                               EOS_T_DPt, EOS_Pt_DUt, EOS_Uc_D};
-  eosSafeLoad(
-      NT, matid, tableType, tablehandle,
-      std::vector<std::string>({"EOS_Pt_DT", "EOS_T_DUt", "EOS_Ut_DT", "EOS_D_PtT",
-                                "EOS_T_DPt", "EOS_Pt_DUt", "EOS_Uc_D"}),
-      Verbosity::Debug, invert_at_setup = invert_at_setup, insert_data = insert_data,
-      monotonicity = monotonicity, apply_smoothing = apply_smoothing,
-      apply_splitting = apply_splitting, linear_interp = linear_interp);
+  auto TableSelect = [&](auto a, auto b, auto c) {
+    if (split == TableSplit::Total) return a;
+    if (split == TableSplit::ElectronOnly)
+      return b;
+    else // if (split == TableSplit::IonCold)
+      return c;
+  };
+  EOS_INTEGER tableType[NT] = {TableSelect(EOS_Pt_DT, EOS_Pe_DT, EOS_Pic_DT),
+                               TableSelect(EOS_T_DUt, EOS_T_DUe, EOS_T_DUic),
+                               TableSelect(EOS_Ut_DT, EOS_Ue_DT, EOS_Uic_DT),
+                               EOS_D_PtT,
+                               TableSelect(EOS_T_DPt, EOS_T_DPe, EOS_T_DPic),
+                               TableSelect(EOS_Pt_DUt, EOS_Pe_DUe, EOS_Pic_DUic),
+                               EOS_Uc_D};
+  std::vector<std::string> tableNames = {"EOS_Pt_DT", "EOS_T_DUt", "EOS_Ut_DT",
+                                         "EOS_D_PtT", "EOS_T_DPt", "EOS_Pt_DUt",
+                                         "EOS_Uc_D"};
+  if (split != TableSplit::Total) {
+    auto rt = std::regex("t");
+    std::string newstr = (split == TableSplit::ElectronOnly) ? "e" : "ic";
+    for (auto &s : tableNames) {
+      if (s != "EOS_D_PtT") {
+        s = std::regex_replace(s, rt, newstr);
+      }
+    }
+  }
+  eosSafeLoad(NT, matid, tableType, tablehandle, tableNames, Verbosity::Debug,
+              invert_at_setup = invert_at_setup, insert_data = insert_data,
+              monotonicity = monotonicity, apply_smoothing = apply_smoothing,
+              apply_splitting = apply_splitting, linear_interp = linear_interp);
   PofRT_table_ = tablehandle[0];
   TofRE_table_ = tablehandle[1];
   EofRT_table_ = tablehandle[2];
@@ -1325,6 +1373,9 @@ EOSPAC::FillEos(Real &rho, Real &temp, Real &sie, Real &press, Real &cv, Real &b
   }
   if (output & thermalqs::density) {
     if (input & thermalqs::pressure && input & thermalqs::temperature) {
+      PORTABLE_REQUIRE(split_ == TableSplit::Total,
+                       "Density of pressure and temperature only supported for total "
+                       "tables at this time");
       EOS_INTEGER table = RofPT_table_;
       eosSafeInterpolate(&table, nxypairs, P, T, R, dx, dy, "RofPT", Verbosity::Quiet);
       rho = R[0];
@@ -1560,6 +1611,10 @@ PORTABLE_INLINE_FUNCTION void EOSPAC::DensityEnergyFromPressureTemperature(
 #if SINGULARITY_ON_DEVICE
   PORTABLE_ALWAYS_ABORT("EOSPAC calls not supported on device\n");
 #else
+  PORTABLE_REQUIRE(split_ == TableSplit::Total,
+                   "Density of pressure and temperature only supported for total "
+                   "tables at this time");
+
   using namespace EospacWrapper;
   EOS_REAL P[1] = {pressureToSesame(press)};
   EOS_REAL T[1] = {temperatureToSesame(temp)};

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -82,13 +82,19 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   };
   SG_ADD_DEFAULT_MEAN_ATOMIC_FUNCTIONS(AZbar_)
   SG_ADD_BASE_CLASS_USINGS(SpinerEOSDependsRhoT);
+  inline SpinerEOSDependsRhoT(const std::string &filename, int matid, TableSplit split,
+                              bool reproducibility_mode = false);
   inline SpinerEOSDependsRhoT(const std::string &filename, int matid,
-                              TableSplit split = TableSplit::Total,
-                              bool reproduciblity_mode = false);
+                              bool reproducibility_mode = false)
+      : SpinerEOSDependsRhoT(filename, matid, TableSplit::Total, reproducibility_mode) {}
+  inline SpinerEOSDependsRhoT(const std::string &filename,
+                              const std::string &materialName, TableSplit split,
+                              bool reproducibility_mode = false);
   inline SpinerEOSDependsRhoT(const std::string &filename,
                               const std::string &materialName,
-                              TableSplit split = TableSplit::Total,
-                              bool reproducibility_mode = false);
+                              bool reproducibility_mode = false)
+      : SpinerEOSDependsRhoT(filename, materialName, TableSplit::Total,
+                             reproducibility_mode) {}
   PORTABLE_INLINE_FUNCTION
   SpinerEOSDependsRhoT()
       : memoryStatus_(DataStatus::Deallocated), split_(TableSplit::Total) {}
@@ -364,13 +370,20 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   SG_ADD_BASE_CLASS_USINGS(SpinerEOSDependsRhoSie);
   PORTABLE_INLINE_FUNCTION SpinerEOSDependsRhoSie()
       : memoryStatus_(DataStatus::Deallocated) {}
+  inline SpinerEOSDependsRhoSie(const std::string &filename, int matid, TableSplit split,
+                                bool reproducibility_mode = false);
   inline SpinerEOSDependsRhoSie(const std::string &filename, int matid,
-                                TableSplit split = TableSplit::Total,
+                                bool reproducibility_mode = false)
+      : SpinerEOSDependsRhoSie(filename, matid, TableSplit::Total, reproducibility_mode) {
+  }
+  inline SpinerEOSDependsRhoSie(const std::string &filename,
+                                const std::string &materialName, TableSplit split,
                                 bool reproducibility_mode = false);
   inline SpinerEOSDependsRhoSie(const std::string &filename,
                                 const std::string &materialName,
-                                TableSplit split = TableSplit::Total,
-                                bool reproducibility_mode = false);
+                                bool reproducibility_mode = false)
+      : SpinerEOSDependsRhoSie(filename, materialName, TableSplit::Total,
+                               reproducibility_mode) {}
   inline SpinerEOSDependsRhoSie GetOnDevice();
 
   PORTABLE_INLINE_FUNCTION void CheckParams() const {

--- a/test/profile_eospac.cpp
+++ b/test/profile_eospac.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/test/profile_eospac.cpp
+++ b/test/profile_eospac.cpp
@@ -34,8 +34,9 @@
 #include <spiner/databox.hpp>
 #include <spiner/interpolation.hpp>
 
-#include <singularity-eos/eos/eos.hpp>
 #include <singularity-eos/eos/eos_builder.hpp>
+#include <singularity-eos/eos/eos_models.hpp>
+#include <singularity-eos/eos/eos_variant.hpp>
 
 using namespace singularity;
 
@@ -57,6 +58,9 @@ constexpr Real T_MIN = 1.8e2; // Kelvin
 constexpr Real T_MAX = 1e3;
 constexpr Real E_MIN = 1e9;
 constexpr Real E_MAX = 1e13;
+using EOS = Variant<EOSPAC, UnitSystem<EOSPAC>, ShiftedEOS<EOSPAC>, ScaledEOS<EOSPAC>,
+                    ScaledEOS<ShiftedEOS<EOSPAC>>, BilinearRampEOS<EOSPAC>,
+                    BilinearRampEOS<ScaledEOS<EOSPAC>>>;
 
 inline auto now() { return std::chrono::high_resolution_clock::now(); }
 

--- a/test/test_eos_tabulated.cpp
+++ b/test/test_eos_tabulated.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This MR is in support of partial ionization and is a follow up to #444 . Here we provide the ability to request tabulated electron and ion equations of state from the sesame database either through SpinerEOS or EOSPAC backends. To do so, I add a new enum
```C++
enum class TableSplit {Total, ElectronOnly, IonCold };
```
which can be passed into the tabulated EOS constructors. `Total` is the previous behavior and is the default. `ElectronOnly` is the electron EOS and `IonCold` is the ion. As before, EOS calls are in terms of ion mass density and either electron or ion temperature. Unlike Zpslit, the ionization fraction is implicit in the model. A given electron temperature automatically implies some ionization fraction. It doesn't need to be passed in.

To enable the electron or ion tables for SpinerEOS, you must also enable them in `sesame2spiner` by setting 
```
ionization = true
```
for that material. This will trigger `sesame2spiner` to interpolate the relevant sub-tables, as well as the total. This is an *addition* not a replacement. Total tables are still available with `ionization=true`.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
