### PR TITLE
Fixed EOSPAC.cmake Install Directory

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -49,7 +49,7 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/cmake/singularity-eos
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake)
 
 install(FILES ${PROJECT_SOURCE_DIR}/cmake/FindEOSPAC.cmake
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake)
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/singularity-eos)
 
 # ----------------------------------------------------------------------------#
 # install export target


### PR DESCRIPTION
The existing install location is not added to the `CMAKE_MODULE_PATH`. Installing into `lib/cmake/singularity-eos` fixes this issue, as that location is already in the search path.