### PR TITLE
move def_en and def_v to CPP file to fix minor linking issue with singularity-eos-extra

### DIFF
--- a/singularity-eos/eos/singularity_eos.cpp
+++ b/singularity-eos/eos/singularity_eos.cpp
@@ -19,6 +19,11 @@
 #include <singularity-eos/eos/singularity_eos.hpp>
 #include <singularity-eos/eos/singularity_eos_init_utils.hpp>
 
+namespace singularity {
+int def_en[4] = {0, 0, 0, 0};
+double def_v[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+} // namespace singularity
+
 using namespace singularity;
 
 int init_sg_eos(const int nmat, EOS *&eos) {

--- a/singularity-eos/eos/singularity_eos_init_utils.hpp
+++ b/singularity-eos/eos/singularity_eos_init_utils.hpp
@@ -80,8 +80,8 @@ inline EOS applyShiftAndScaleAndBilinearRamp(T &&eos, bool scaled, bool shifted,
                                     enabled[2] == 1 || enabled[3] == 1, vals[0],         \
                                     vals[1], vals[2], vals[3], vals[4], vals[5])
 
-int def_en[4] = {0, 0, 0, 0};
-double def_v[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+extern int def_en[4];
+extern double def_v[6];
 
 } // namespace singularity
 #endif // _SINGULARITY_EOS_EOS_SINGULARITY_EOS_INIT_UTILS_HPP_


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

When adding a fortran interface to singularity-eos-extra, the `singularity_eos_init_utils.hpp` header is needed. However, it defines `def_en` and `def_v` in global scope in a header file. This produces linking errors when using plugins. Here I resolve the linking error by simply moving the *definition* of these arrays into `singularity_eos.cpp` but still make them "available" by declaring them as `extern` in the original header.

@dholladay00 should I declare them constant?

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
