### PR TITLE
Jmm/indexable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR470]](https://github.com/lanl/singularity-eos/pull/470) Add the ability to access lambda elements by named types
 - [[PR459]](https://github.com/lanl/singularity-eos/pull/459) Add electron and ion tables to EOSPAC and SpinerEOS backends
 - [[PR453]](https://github.com/lanl/singularity-eos/pull/453) A PT space PTE solver
 - [[PR444]](https://github.com/lanl/singularity-eos/pull/444) Add Z split modifier and electron ideal gas EOS

--- a/doc/sphinx/src/using-closures.rst
+++ b/doc/sphinx/src/using-closures.rst
@@ -449,32 +449,23 @@ used by the solver. There are helper routines for providing the needed
 scratch space, wich will tell you how many bytes per mixed cell are
 required. For example:
 
-.. cpp:function:: int PTESolverRhoTRequiredScratch(const int nmat, bool with_cache);
+.. cpp:function:: int PTESolverRhoTRequiredScratch(const int nmat);
 
 and
 
-.. cpp:function:: int PTESolverRhoURequiredScratch(const int nmat, bool with_cache);
+.. cpp:function:: int PTESolverRhoURequiredScratch(const int nmat);
 
 provide the number of real numbers (i.e., either ``float`` or
 ``double``) required for a single cell given a number of materials in
-equilibriun for either the ``RhoT`` or ``RhoU`` solver. The
-``with_cache`` flag specifies whether or not you'd like the PTE solver
-to manage memory for lambdas for you. This argument is optional and
-the default is true.
-
-.. note::
-
-  The pre-allocated cache is used only automatically if you pass in a
-  ``singularity::NullIndexer`` type in for the lambda indexer, which
-  returns a ``nullptr`` for all lambda access.
+equilibriun for either the ``RhoT`` or ``RhoU`` solver.
 
 The equivalent functions
 
-.. cpp:function:: size_t PTESolverRhoTRequiredScratchInBytes(const int nmat, bool with_cache);
+.. cpp:function:: size_t PTESolverRhoTRequiredScratchInBytes(const int nmat);
 
 and
 
-.. cpp:function:: int PTESolverRhoURequiredScratchInBytes(const int nmat, bool with_cache);
+.. cpp:function:: int PTESolverRhoURequiredScratchInBytes(const int nmat);
 
 give the size in bytes needed to be allocated per cell given a number
 of materials ``nmat``.

--- a/doc/sphinx/src/using-closures.rst
+++ b/doc/sphinx/src/using-closures.rst
@@ -449,22 +449,32 @@ used by the solver. There are helper routines for providing the needed
 scratch space, wich will tell you how many bytes per mixed cell are
 required. For example:
 
-.. cpp:function:: int PTESolverRhoTRequiredScratch(const int nmat);
+.. cpp:function:: int PTESolverRhoTRequiredScratch(const int nmat, bool with_cache);
 
 and
 
-.. cpp:function:: int PTESolverRhoURequiredScratch(const int nmat);
+.. cpp:function:: int PTESolverRhoURequiredScratch(const int nmat, bool with_cache);
 
 provide the number of real numbers (i.e., either ``float`` or
 ``double``) required for a single cell given a number of materials in
-equilibriun for either the ``RhoT`` or ``RhoU`` solver. The equivalent
-functions
+equilibriun for either the ``RhoT`` or ``RhoU`` solver. The
+``with_cache`` flag specifies whether or not you'd like the PTE solver
+to manage memory for lambdas for you. This argument is optional and
+the default is true.
 
-.. cpp:function:: size_t PTESolverRhoTRequiredScratchInBytes(const int nmat);
+.. note::
+
+  The pre-allocated cache is used only automatically if you pass in a
+  ``singularity::NullIndexer`` type in for the lambda indexer, which
+  returns a ``nullptr`` for all lambda access.
+
+The equivalent functions
+
+.. cpp:function:: size_t PTESolverRhoTRequiredScratchInBytes(const int nmat, bool with_cache);
 
 and
 
-.. cpp:function:: int PTESolverRhoURequiredScratchInBytes(const int nmat);
+.. cpp:function:: int PTESolverRhoURequiredScratchInBytes(const int nmat, bool with_cache);
 
 give the size in bytes needed to be allocated per cell given a number
 of materials ``nmat``.

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -745,7 +745,19 @@ As a convenience tool, the struct
 
 automatically defines an indexer that accepts all named indices in the
 variadic list ``Ts...`` and also integer indexing. It's a fixed-size
-array under the hood. All of the above functionality is available in
+array under the hood.
+
+You can check if an equation of state is compatible with a given named
+index type by calling
+
+.. code-block:: cpp
+
+   eos.NeedsLambda(NamedIndex())
+
+which returns ``true`` if the EOS is compatible with ``NamedIndex``
+and ``false`` otherwise.
+
+All of the above functionality is available in
 the header file ``singularity-eos/base/indexable_types.hpp``.
 
 EOS Modifiers

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -659,6 +659,95 @@ minimize latency due to ``malloc`` and ``free``. Several models, such
 as ``SpinerEOS`` also use the persistency of these arrays to cache
 useful quantities for a performance boost.
 
+Named Arguments to Lambda Indexers
+-----------------------------------
+
+Lambdas support a more free-form kind of indexer. In particular, you
+may define indexers that take **names** via a type system. For
+example, you can write code such as:
+
+.. code-block:: cpp
+
+  Lambda_t lambda;
+  lambda[MeanIonizationState()] = zbar;
+  Real P = eos.PressureFromDensityTemperature(rho, T, lambda);
+
+The available types currently supported by default are:
+
+.. code-block:: cpp
+
+  struct singularity::IndexableTypes::MeanIonizationState;
+  struct singularity::IndexableTypes::LogDensity;
+  struct singularity::IndexableTypes::LogTemperature;
+  struct singularity::IndexableTypes::MeanAtomicMass;
+  struct singularity::IndexableTypes::MeanAtomicNumber;
+  struct singularity::IndexableTypes::ElectronFraction;
+
+However if you are implementing your own equation of state class, you
+can define new types with the macro
+``SINGULARITY_DECLARE_INDEXABLE_TYPE``. For example:
+
+.. code-block::
+
+  namespace IndexableTypes {
+  SINGULARITY_DECLARE_INDEXABLE_TYPE(MyLambdaParameter);
+  }
+
+To use an indexable type, you must define an indexer with an overload
+of the ``[]`` operator that takes your type. For example:
+
+.. code-block:: cpp
+
+  class MyLambda_t {
+  public:
+    MyLambda_t() = default;
+    PORTABLE_FORCEINLINE_FUNCTION
+    Real &operator[](const std::size_t idx) {
+      return data_[idx];
+    }
+    PORTABLE_FORCEINLINE_FUNCTION
+    Real &operator[](const MeanIonizationState &zbar) {
+      return data_[2];
+    }
+  private:
+    std::array<Real, 3> data_;
+  };
+
+which might be used as
+
+.. code-blocK:: cpp
+
+  MyLambda_t lambda;
+  lambda[0] = lRho;
+  lambda[1] = lT;
+  lambda[MeanIonizationState()] = Z;
+
+where ``MeanIonizationState`` is shorthand for index 2, since you
+defined that overload. To more easily enable mixing and matching
+integer-based indexing with type-based indexing, the function
+
+.. code-block:: cpp
+
+  template<typename Name_t, typename Indexer_t>
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real &Get(Indexer_t &&lambda, std::size_t idx = 0);
+
+will return a reference to the value at named index ``Name_t()`` if
+that overload is defined in ``Indexer_t`` and otherwise return a
+reference at index ``idx``.
+
+As a convenience tool, the struct
+
+.. code-block:: cpp
+
+  template<typename... Ts>
+  singularity::IndexableTypes::VariadicIndexer;
+
+automatically defines an indexer that accepts all named indices in the
+variadic list ``Ts...`` and also integer indexing. It's a fixed-size
+array under the hood. All of the above functionality is available in
+the header file ``singularity-eos/base/indexable_types.hpp``.
+
 EOS Modifiers
 --------------
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -683,14 +683,13 @@ The available types currently supported by default are:
   struct singularity::IndexableTypes::MeanAtomicNumber;
   struct singularity::IndexableTypes::ElectronFraction;
 
-However if you are implementing your own equation of state class, you
-can define new types with the macro
-``SINGULARITY_DECLARE_INDEXABLE_TYPE``. For example:
+However if you are not limited to these types. Any type will do and
+you can define your own as you like. For example:
 
 .. code-block::
 
   namespace IndexableTypes {
-  SINGULARITY_DECLARE_INDEXABLE_TYPE(MyLambdaParameter);
+  struct MyLambdaParameter;
   }
 
 To use an indexable type, you must define an indexer with an overload

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -701,11 +701,11 @@ of the ``[]`` operator that takes your type. For example:
   public:
     MyLambda_t() = default;
     PORTABLE_FORCEINLINE_FUNCTION
-    Real &operator[](const std::size_t idx) {
+    Real &operator[](const std::size_t idx) const {
       return data_[idx];
     }
     PORTABLE_FORCEINLINE_FUNCTION
-    Real &operator[](const MeanIonizationState &zbar) {
+    Real &operator[](const MeanIonizationState &zbar) const {
       return data_[2];
     }
   private:
@@ -722,8 +722,9 @@ which might be used as
   lambda[MeanIonizationState()] = Z;
 
 where ``MeanIonizationState`` is shorthand for index 2, since you
-defined that overload. To more easily enable mixing and matching
-integer-based indexing with type-based indexing, the function
+defined that overload. Note that the ``operator[]`` must be marked
+``const``. To more easily enable mixing and matching integer-based
+indexing with type-based indexing, the function
 
 .. code-block:: cpp
 

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -25,6 +25,7 @@ register_headers(
 
     # Normal files
     base/fast-math/logs.hpp
+    base/indexable_types.hpp
     base/robust_utils.hpp
     base/root-finding-1d/root_finding.hpp
     base/serialization_utils.hpp

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -22,28 +22,13 @@
 #include <ports-of-call/portability.hpp>
 #include <singularity-eos/base/variadic_utils.hpp>
 
-#define SINGULARITY_DECLARE_INDEXABLE_TYPE(TYPE_NAME)                                    \
-  struct TYPE_NAME : public singularity::IndexableTypes::IndexableTypesBase<TYPE_NAME> {}
-
 namespace singularity {
-namespace IndexableTypes {
-// Base class for indexable types that uses CRTP
-template <typename CRTP>
-struct IndexableTypesBase {
-  template <typename, typename = void>
-  struct IsOverloadedIn : std::false_type {};
-  template <typename T>
-  struct IsOverloadedIn<T, std::void_t<decltype(std::declval<T>()[std::declval<CRTP>()])>>
-      : std::true_type {};
-};
-} // namespace IndexableTypes
-
 namespace IndexerUtils {
 // Convenience function for accessing an indexer by either type or
 // natural number index depending on what is available
 template <typename T, typename Indexer_t>
 PORTABLE_FORCEINLINE_FUNCTION auto &Get(Indexer_t &&lambda, std::size_t idx = 0) {
-  if constexpr (T::template IsOverloadedIn<Indexer_t>::value) {
+  if constexpr (variadic_utils::is_indexable_v<T, Indexer_t>) {
     return lambda[T()];
   } else {
     return lambda[idx];
@@ -52,39 +37,40 @@ PORTABLE_FORCEINLINE_FUNCTION auto &Get(Indexer_t &&lambda, std::size_t idx = 0)
 
 // This is a convenience struct to easily build a small indexer with
 // a set of indexable types.
-template <typename... Ts>
-class VariadicIndexer {
+template <typename Data_t, typename... Ts>
+class VariadicIndexerBase {
  public:
-  VariadicIndexer() = default;
+  VariadicIndexerBase() = default;
+  PORTABLE_FORCEINLINE_FUNCTION
+  VariadicIndexerBase(const Data_t &data) : data_(data) {}
   template <typename T,
             typename = std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
   PORTABLE_FORCEINLINE_FUNCTION Real &operator[](const T &t) {
-    // get the index of T in the variadic type list
-    std::size_t idx = 0;
-    std::size_t i = 0;
-    ((std::is_same_v<T, Ts> ? idx = i : ++i), ...);
-
+    constexpr std::size_t idx = variadic_utils::GetIndexInTL<T, Ts...>();
     return data_[idx];
   }
   PORTABLE_FORCEINLINE_FUNCTION
   Real &operator[](const std::size_t idx) { return data_[idx]; }
-  PORTABLE_FORCEINLINE_FUNCTION
-  Real &operator[](const int idx) { return data_[idx]; }
   static inline constexpr std::size_t size() { return sizeof...(Ts); }
 
  private:
-  std::array<Real, sizeof...(Ts)> data_;
+  Data_t data_;
 };
-
+// uses an array
+template <typename... Ts>
+using VariadicIndexer = VariadicIndexerBase<std::array<Real, sizeof...(Ts)>, Ts...>;
+// uses a Real*
+template <typename... Ts>
+using VariadicPointerIndexer = VariadicIndexerBase<Real *, Ts...>;
 } // namespace IndexerUtils
 
 namespace IndexableTypes {
-SINGULARITY_DECLARE_INDEXABLE_TYPE(MeanIonizationState);
-SINGULARITY_DECLARE_INDEXABLE_TYPE(LogDensity);
-SINGULARITY_DECLARE_INDEXABLE_TYPE(LogTemperature);
-SINGULARITY_DECLARE_INDEXABLE_TYPE(MeanAtomicMass);
-SINGULARITY_DECLARE_INDEXABLE_TYPE(MeanAtomicNumber);
-SINGULARITY_DECLARE_INDEXABLE_TYPE(ElectronFraction);
+struct MeanIonizationState {};
+struct LogDensity {};
+struct LogTemperature {};
+struct MeanAtomicMass {};
+struct MeanAtomicNumber {};
+struct ElectronFraction {};
 } // namespace IndexableTypes
 } // namespace singularity
 #endif // SINGULARITY_EOS_BASE_INDEXABLE_TYPES_

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -1,0 +1,94 @@
+//------------------------------------------------------------------------------
+// © 2025. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//------------------------------------------------------------------------------
+
+#ifndef SINGULARITY_EOS_BASE_INDEXABLE_TYPES_
+#define SINGULARITY_EOS_BASE_INDEXABLE_TYPES_
+
+#include <array>
+#include <type_traits>
+#include <utility>
+
+#include <ports-of-call/portability.hpp>
+
+#define SINGULARITY_DECLARE_INDEXABLE_TYPE(TYPE_NAME)                                    \
+  struct TYPE_NAME : public singularity::IndexableTypes::IndexableTypesBase<TYPE_NAME> {}
+
+namespace singularity {
+namespace IndexableTypes {
+// Base class for indexable types that uses CRTP
+template <typename CRTP>
+struct IndexableTypesBase {
+  template <typename, typename = void>
+  struct IsOverloadedIn : std::false_type {};
+  template <typename T>
+  struct IsOverloadedIn<T, std::void_t<decltype(std::declval<T>()[std::declval<CRTP>()])>>
+      : std::true_type {};
+};
+} // namespace IndexableTypes
+
+namespace IndexerUtils {
+// Convenience function for accessing an indexer by either type or
+// natural number index depending on what is available
+template <typename T, typename Indexer_t>
+inline auto &Get(Indexer_t &&lambda, std::size_t idx = 0) {
+  if constexpr (T::template IsOverloadedIn<Indexer_t>::value) {
+    return lambda[T()];
+  } else {
+    return lambda[idx];
+  }
+}
+
+// This is a convenience struct to easily build a small indexer with
+// a set of indexable types. Note however that accessing with
+// indexable types is an O(N) operation with this implementation.
+// You probably don't want to use this in real code.
+template <typename... Ts>
+class VariadicIndexer {
+ public:
+  VariadicIndexer() = default;
+  template <typename T>
+  PORTABLE_FORCEINLINE_FUNCTION Real &operator[](const T &t) {
+    constexpr bool contains_v = (std::is_same_v<T, Ts> || ...);
+    static_assert(contains_v, "Indexable type must be in indexer type list!");
+
+    // get the index of T in the variadic type list
+    constexpr std::size_t N = sizeof...(Ts);
+    std::size_t idx = 0;
+    std::size_t i = 0;
+    ((std::is_same_v<T, Ts> ? idx = i : ++i), ...);
+
+    return data_[idx];
+  }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real &operator[](const std::size_t idx) { return data_[idx]; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real &operator[](const int idx) { return data_[idx]; }
+  static inline constexpr std::size_t size() { return sizeof...(Ts); }
+
+ private:
+  std::array<Real, sizeof...(Ts)> data_;
+};
+
+} // namespace IndexerUtils
+
+namespace IndexableTypes {
+SINGULARITY_DECLARE_INDEXABLE_TYPE(MeanIonizationState);
+SINGULARITY_DECLARE_INDEXABLE_TYPE(LogDensity);
+SINGULARITY_DECLARE_INDEXABLE_TYPE(LogTemperature);
+SINGULARITY_DECLARE_INDEXABLE_TYPE(MeanAtomicMass);
+SINGULARITY_DECLARE_INDEXABLE_TYPE(MeanAtomicNumber);
+SINGULARITY_DECLARE_INDEXABLE_TYPE(ElectronFraction);
+} // namespace IndexableTypes
+} // namespace singularity
+#endif // SINGULARITY_EOS_BASE_INDEXABLE_TYPES_

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -42,7 +42,7 @@ namespace IndexerUtils {
 // Convenience function for accessing an indexer by either type or
 // natural number index depending on what is available
 template <typename T, typename Indexer_t>
-inline auto &Get(Indexer_t &&lambda, std::size_t idx = 0) {
+PORTABLE_FORCEINLINE_FUNCTION auto &Get(Indexer_t &&lambda, std::size_t idx = 0) {
   if constexpr (T::template IsOverloadedIn<Indexer_t>::value) {
     return lambda[T()];
   } else {
@@ -51,9 +51,7 @@ inline auto &Get(Indexer_t &&lambda, std::size_t idx = 0) {
 }
 
 // This is a convenience struct to easily build a small indexer with
-// a set of indexable types. Note however that accessing with
-// indexable types is an O(N) operation with this implementation.
-// You probably don't want to use this in real code.
+// a set of indexable types.
 template <typename... Ts>
 class VariadicIndexer {
  public:

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -28,7 +28,7 @@ namespace IndexerUtils {
 // natural number index depending on what is available
 template <typename T, typename Indexer_t>
 PORTABLE_FORCEINLINE_FUNCTION auto &Get(Indexer_t &&lambda, std::size_t idx = 0) {
-  if constexpr (variadic_utils::is_indexable_v<T, Indexer_t>) {
+  if constexpr (variadic_utils::is_indexable_v<Indexer_t, T>) {
     return lambda[T()];
   } else {
     return lambda[idx];

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include <ports-of-call/portability.hpp>
+#include <singularity-eos/base/variadic_utils.hpp>
 
 #define SINGULARITY_DECLARE_INDEXABLE_TYPE(TYPE_NAME)                                    \
   struct TYPE_NAME : public singularity::IndexableTypes::IndexableTypesBase<TYPE_NAME> {}
@@ -57,11 +58,9 @@ template <typename... Ts>
 class VariadicIndexer {
  public:
   VariadicIndexer() = default;
-  template <typename T>
+  template <typename T,
+            typename = std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
   PORTABLE_FORCEINLINE_FUNCTION Real &operator[](const T &t) {
-    constexpr bool contains_v = (std::is_same_v<T, Ts> || ...);
-    static_assert(contains_v, "Indexable type must be in indexer type list!");
-
     // get the index of T in the variadic type list
     constexpr std::size_t N = sizeof...(Ts);
     std::size_t idx = 0;

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -45,12 +45,20 @@ class VariadicIndexerBase {
   VariadicIndexerBase(const Data_t &data) : data_(data) {}
   template <typename T,
             typename = std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
-  PORTABLE_FORCEINLINE_FUNCTION Real &operator[](const T &t) const {
+  PORTABLE_FORCEINLINE_FUNCTION Real &operator[](const T &t) {
     constexpr std::size_t idx = variadic_utils::GetIndexInTL<T, Ts...>();
     return data_[idx];
   }
   PORTABLE_FORCEINLINE_FUNCTION
-  Real &operator[](const std::size_t idx) const { return data_[idx]; }
+  Real &operator[](const std::size_t idx) { return data_[idx]; }
+  template <typename T,
+            typename = std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
+  PORTABLE_FORCEINLINE_FUNCTION const Real &operator[](const T &t) const {
+    constexpr std::size_t idx = variadic_utils::GetIndexInTL<T, Ts...>();
+    return data_[idx];
+  }
+  PORTABLE_FORCEINLINE_FUNCTION
+  const Real &operator[](const std::size_t idx) const { return data_[idx]; }
   static inline constexpr std::size_t size() { return sizeof...(Ts); }
 
  private:

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -45,12 +45,12 @@ class VariadicIndexerBase {
   VariadicIndexerBase(const Data_t &data) : data_(data) {}
   template <typename T,
             typename = std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
-  PORTABLE_FORCEINLINE_FUNCTION Real &operator[](const T &t) {
+  PORTABLE_FORCEINLINE_FUNCTION Real &operator[](const T &t) const {
     constexpr std::size_t idx = variadic_utils::GetIndexInTL<T, Ts...>();
     return data_[idx];
   }
   PORTABLE_FORCEINLINE_FUNCTION
-  Real &operator[](const std::size_t idx) { return data_[idx]; }
+  Real &operator[](const std::size_t idx) const { return data_[idx]; }
   static inline constexpr std::size_t size() { return sizeof...(Ts); }
 
  private:

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -60,7 +60,6 @@ class VariadicIndexer {
             typename = std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
   PORTABLE_FORCEINLINE_FUNCTION Real &operator[](const T &t) {
     // get the index of T in the variadic type list
-    constexpr std::size_t N = sizeof...(Ts);
     std::size_t idx = 0;
     std::size_t i = 0;
     ((std::is_same_v<T, Ts> ? idx = i : ++i), ...);

--- a/singularity-eos/base/variadic_utils.hpp
+++ b/singularity-eos/base/variadic_utils.hpp
@@ -86,6 +86,31 @@ struct type_list {};
 template <template <typename> class... Ts>
 struct adapt_list {};
 
+// provide index of a type in a type list
+template <typename T, typename Head, typename... Ts>
+constexpr std::size_t GetIndexInTL(std::size_t current_index) {
+  if constexpr (std::is_same_v<T, Head>) {
+    return current_index;
+  } else {
+    static_assert(sizeof...(Ts) > 0, "Type T must be in type list!");
+    return GetIndexInTL<T, Ts...>(current_index + 1);
+  }
+}
+template <typename T, typename Head, typename... Ts>
+constexpr std::size_t GetIndexInTL() {
+  return GetIndexInTL<T, Head, Ts...>(0);
+}
+
+// is_indexable similar to is_invokable
+template <typename, typename, typename = void>
+struct is_indexable : std::false_type {};
+template <typename T, typename Index>
+struct is_indexable<T, Index,
+                    std::void_t<decltype(std::declval<T>()[std::declval<Index>()])>>
+    : std::true_type {};
+template <typename T, typename Index>
+constexpr bool is_indexable_v = is_indexable<T, Index>::value;
+
 // this flattens a typelist of typelists to a single typelist
 
 // first parameter - accumulator

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -474,7 +474,7 @@ class PTESolverBase {
   const RealIndexer &sie;
   const RealIndexer &temp;
   const RealIndexer &press;
-  const LambdaIndexer &lambda;
+  LambdaIndexer &lambda;
   Real *jacobian, *dx, *sol_scratch, *residual, *u, *rhobar;
   CacheAccessor Cache;
   Real rho_total, uscale, utotal_scale, Tnorm;

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -168,7 +168,7 @@ class CacheAccessor {
 // ======================================================================
 // Base class
 // ======================================================================
-template <typename EOSIndexer, typename RealIndexer>
+template <typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
 class PTESolverBase {
  public:
   PTESolverBase() = delete;
@@ -212,18 +212,21 @@ class PTESolverBase {
   PTESolverBase(std::size_t nmats, std::size_t neqs, const EOSIndexer &eos_,
                 const Real vfrac_tot, const Real sie_tot, const RealIndexer &rho_,
                 const RealIndexer &vfrac_, const RealIndexer &sie_,
-                const RealIndexer &temp_, const RealIndexer &press_, Real *&scratch,
-                Real Tnorm, const MixParams &params = MixParams())
+                const RealIndexer &temp_, const RealIndexer &press_,
+                LambdaIndexer &lambda_, Real *&scratch, Real Tnorm,
+                const MixParams &params = MixParams())
       : params_(params), nmat(nmats), neq(neqs), niter(0), vfrac_total(vfrac_tot),
         sie_total(sie_tot), eos(eos_), rho(rho_), vfrac(vfrac_), sie(sie_), temp(temp_),
-        press(press_), Tnorm(Tnorm) {
+        press(press_), lambda(lambda_), Tnorm(Tnorm) {
     jacobian = AssignIncrement(scratch, neq * neq);
     dx = AssignIncrement(scratch, neq);
     sol_scratch = AssignIncrement(scratch, 2 * neq);
     residual = AssignIncrement(scratch, neq);
     u = AssignIncrement(scratch, nmat);
     rhobar = AssignIncrement(scratch, nmat);
-    Cache = CacheAccessor(AssignIncrement(scratch, nmat * MAX_NUM_LAMBDAS));
+    if (needs_cache_) {
+      Cache = CacheAccessor(AssignIncrement(scratch, nmat * MAX_NUM_LAMBDAS));
+    }
   }
 
   PORTABLE_FORCEINLINE_FUNCTION
@@ -298,10 +301,10 @@ class PTESolverBase {
     return Tguess;
   }
 
-  template <typename EOS_t>
+  template <typename EOS_t, typename Indexer_t>
   PORTABLE_FORCEINLINE_FUNCTION static Real
   GetPressureFromPreferred(const EOS_t &eos, const Real rho, const Real T, Real sie,
-                           Real *lambda, const bool do_e_lookup) {
+                           Indexer_t lambda, const bool do_e_lookup) {
     Real P{};
     if (eos.PreferredInput() ==
         (thermalqs::density | thermalqs::specific_internal_energy)) {
@@ -338,11 +341,11 @@ class PTESolverBase {
     for (std::size_t m = 0; m < nmat; m++) {
       // scaled initial guess for temperature is just 1
       temp[m] = 1.0;
-      sie[m] = eos[m].InternalEnergyFromDensityTemperature(rho[m], Tguess, Cache[m]);
+      sie[m] = eos[m].InternalEnergyFromDensityTemperature(rho[m], Tguess, GetLambda(m));
       // note the scaling of pressure
-      press[m] = robust::ratio(
-          this->GetPressureFromPreferred(eos[m], rho[m], Tguess, sie[m], Cache[m], false),
-          uscale);
+      press[m] = robust::ratio(this->GetPressureFromPreferred(
+                                   eos[m], rho[m], Tguess, sie[m], GetLambda(m), false),
+                               uscale);
     }
 
     // note the scaling of the material internal energy densities
@@ -420,12 +423,12 @@ class PTESolverBase {
     for (std::size_t m = 0; m < nmat; ++m) {
       rho[m] = robust::ratio(rhobar[m], vfrac[m]);
 
-      const Real sie_m =
-          eos[m].InternalEnergyFromDensityTemperature(rho[m], Tnorm * Tideal, Cache[m]);
+      const Real sie_m = eos[m].InternalEnergyFromDensityTemperature(
+          rho[m], Tnorm * Tideal, GetLambda(m));
       u[m] = rhobar[m] * robust::ratio(sie_m, uscale);
       press[m] =
           robust::ratio(this->GetPressureFromPreferred(eos[m], rho[m], Tnorm * Tideal,
-                                                       sie_m, Cache[m], false),
+                                                       sie_m, GetLambda(m), false),
                         uscale);
     }
     // fill in the residual
@@ -461,6 +464,17 @@ class PTESolverBase {
     return p;
   }
 
+  PORTABLE_FORCEINLINE_FUNCTION
+  auto GetLambda(std::size_t m) const {
+    if constexpr (needs_cache_) {
+      return Cache[m];
+    } else {
+      return lambda[m];
+    }
+  }
+
+  static constexpr const bool needs_cache_ =
+      std::is_same<LambdaIndexer, NullIndexer>::value;
   const MixParams params_;
   const std::size_t nmat, neq;
   std::size_t niter;
@@ -471,6 +485,7 @@ class PTESolverBase {
   const RealIndexer &sie;
   const RealIndexer &temp;
   const RealIndexer &press;
+  const LambdaIndexer &lambda;
   Real *jacobian, *dx, *sol_scratch, *residual, *u, *rhobar;
   CacheAccessor Cache;
   Real rho_total, uscale, utotal_scale, Tnorm;
@@ -540,45 +555,49 @@ PORTABLE_INLINE_FUNCTION Real ApproxTemperatureFromRhoMatU(
 // ======================================================================
 // PTE Solver RhoT
 // ======================================================================
-inline int PTESolverRhoTRequiredScratch(const std::size_t nmat) {
+inline int PTESolverRhoTRequiredScratch(const std::size_t nmat, bool with_cache = true) {
   std::size_t neq = nmat + 1;
-  return neq * neq                 // jacobian
-         + 4 * neq                 // dx, residual, and sol_scratch
-         + 6 * nmat                // all the nmat sized arrays
-         + MAX_NUM_LAMBDAS * nmat; // the cache
+  return neq * neq                              // jacobian
+         + 4 * neq                              // dx, residual, and sol_scratch
+         + 6 * nmat                             // all the nmat sized arrays
+         + with_cache * MAX_NUM_LAMBDAS * nmat; // the cache
 }
-inline size_t PTESolverRhoTRequiredScratchInBytes(const std::size_t nmat) {
-  return PTESolverRhoTRequiredScratch(nmat) * sizeof(Real);
+inline size_t PTESolverRhoTRequiredScratchInBytes(const std::size_t nmat,
+                                                  bool with_cache = true) {
+  return PTESolverRhoTRequiredScratch(nmat, with_cache) * sizeof(Real);
 }
 
 template <typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
-class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::InitBase;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::AssignIncrement;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::nmat;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::neq;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::ResidualNorm;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::vfrac_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::sie_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::eos;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::vfrac;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::sie;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::temp;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::press;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::utotal_scale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::MatIndex;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::TryIdealPTE;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::jacobian;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::residual;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::dx;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::u;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rhobar;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::Cache;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::Tnorm;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::params_;
+class PTESolverRhoT
+    : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer> {
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::InitBase;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::AssignIncrement;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::nmat;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::neq;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::ResidualNorm;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::vfrac_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::sie_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::eos;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rho;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::vfrac;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::sie;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::temp;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::press;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rho_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::uscale;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::utotal_scale;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::MatIndex;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::TryIdealPTE;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::jacobian;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::residual;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::dx;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::u;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rhobar;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::Cache;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::Tnorm;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::params_;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::lambda;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::GetLambda;
 
  public:
   // template the ctor to get type deduction/universal references prior to c++17
@@ -588,22 +607,13 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
                 const Real sie_tot, Real_t &&rho, Real_t &&vfrac, Real_t &&sie,
                 Real_t &&temp, Real_t &&press, Lambda_t &&lambda, Real *scratch,
                 const Real Tnorm = 0.0, const MixParams &params = MixParams())
-      : mix_impl::PTESolverBase<EOSIndexer, RealIndexer>(nmat, nmat + 1, eos, vfrac_tot,
-                                                         sie_tot, rho, vfrac, sie, temp,
-                                                         press, scratch, Tnorm, params) {
+      : mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>(
+            nmat, nmat + 1, eos, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press, lambda,
+            scratch, Tnorm, params) {
     dpdv = AssignIncrement(scratch, nmat);
     dedv = AssignIncrement(scratch, nmat);
     dpdT = AssignIncrement(scratch, nmat);
     vtemp = AssignIncrement(scratch, nmat);
-    // JMM: Copy lambda data into cache. Since the cache uses
-    // pointers, it must be done this way.
-    for (std::size_t m = 0; m < nmat; ++m) {
-      if (!variadic_utils::is_nullptr(lambda[m])) {
-        for (int l = 0; l < eos[m].nlambda(); ++l) {
-          Cache[m][l] = lambda[m][l];
-        }
-      }
-    }
   }
 
   PORTABLE_INLINE_FUNCTION
@@ -662,11 +672,11 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
       const Real vf_pert = vfrac[m] + dv;
       const Real rho_pert = robust::ratio(rhobar[m], vf_pert);
 
-      Real e_pert =
-          eos[m].InternalEnergyFromDensityTemperature(rho_pert, Tnorm * Tequil, Cache[m]);
+      Real e_pert = eos[m].InternalEnergyFromDensityTemperature(rho_pert, Tnorm * Tequil,
+                                                                GetLambda(m));
       Real p_pert =
           robust::ratio(this->GetPressureFromPreferred(eos[m], rho_pert, Tnorm * Tequil,
-                                                       e_pert, Cache[m], false),
+                                                       e_pert, GetLambda(m), false),
                         uscale);
       dpdv[m] = robust::ratio((p_pert - press[m]), dv);
       dedv[m] = robust::ratio(rhobar[m] * robust::ratio(e_pert, uscale) - u[m], dv);
@@ -675,10 +685,10 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
       //////////////////////////////
       Real dT = Tequil * params_.derivative_eps;
       e_pert = eos[m].InternalEnergyFromDensityTemperature(rho[m], Tnorm * (Tequil + dT),
-                                                           Cache[m]);
+                                                           GetLambda(m));
       p_pert = robust::ratio(this->GetPressureFromPreferred(eos[m], rho[m],
                                                             Tnorm * (Tequil + dT), e_pert,
-                                                            Cache[m], false),
+                                                            GetLambda(m), false),
                              uscale);
       dpdT[m] = robust::ratio((p_pert - press[m]), dT);
       dedT_sum += robust::ratio(rhobar[m] * robust::ratio(e_pert, uscale) - u[m], dT);
@@ -753,13 +763,13 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
       vfrac[m] = vtemp[m] + scale * dx[m];
       rho[m] = robust::ratio(rhobar[m], vfrac[m]);
       u[m] = rhobar[m] * eos[m].InternalEnergyFromDensityTemperature(
-                             rho[m], Tnorm * Tequil, Cache[m]);
+                             rho[m], Tnorm * Tequil, GetLambda(m));
       sie[m] = robust::ratio(u[m], rhobar[m]);
       u[m] = robust::ratio(u[m], uscale);
       temp[m] = Tequil;
       press[m] =
           robust::ratio(this->GetPressureFromPreferred(eos[m], rho[m], Tnorm * Tequil,
-                                                       sie[m], Cache[m], false),
+                                                       sie[m], GetLambda(m), false),
                         uscale);
     }
     Residual();
@@ -774,44 +784,48 @@ class PTESolverRhoT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
 // ======================================================================
 // PT space solver
 // ======================================================================
-inline int PTESolverPTRequiredScratch(const std::size_t nmat) {
+inline int PTESolverPTRequiredScratch(const std::size_t nmat, bool with_cache = true) {
   constexpr int neq = 2;
-  return neq * neq                 // jacobian
-         + 4 * neq                 // dx, residual, and sol_scratch
-         + 2 * nmat                // all the nmat sized arrays
-         + MAX_NUM_LAMBDAS * nmat; // the cache
+  return neq * neq                              // jacobian
+         + 4 * neq                              // dx, residual, and sol_scratch
+         + 2 * nmat                             // all the nmat sized arrays
+         + with_cache * MAX_NUM_LAMBDAS * nmat; // the cache
 }
-inline size_t PTESolverPTRequiredScratchInBytes(const std::size_t nmat) {
-  return PTESolverPTRequiredScratch(nmat) * sizeof(Real);
+inline size_t PTESolverPTRequiredScratchInBytes(const std::size_t nmat,
+                                                bool with_cache = true) {
+  return PTESolverPTRequiredScratch(nmat, with_cache) * sizeof(Real);
 }
 template <typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
-class PTESolverPT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::InitBase;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::AssignIncrement;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::nmat;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::neq;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::ResidualNorm;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::vfrac_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::sie_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::eos;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::vfrac;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::sie;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::temp;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::press;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::utotal_scale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::MatIndex;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::TryIdealPTE;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::jacobian;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::residual;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::dx;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::u;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rhobar;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::Cache;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::Tnorm;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::params_;
+class PTESolverPT
+    : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer> {
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::InitBase;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::AssignIncrement;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::nmat;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::neq;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::ResidualNorm;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::vfrac_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::sie_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::eos;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rho;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::vfrac;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::sie;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::temp;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::press;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rho_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::uscale;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::utotal_scale;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::MatIndex;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::TryIdealPTE;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::jacobian;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::residual;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::dx;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::u;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rhobar;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::Cache;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::Tnorm;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::params_;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::lambda;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::GetLambda;
 
   enum RES { RV = 0, RSIE = 1 };
 
@@ -823,19 +837,9 @@ class PTESolverPT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
               const Real sie_tot, Real_t &&rho, Real_t &&vfrac, Real_t &&sie,
               Real_t &&temp, Real_t &&press, Lambda_t &&lambda, Real *scratch,
               const Real Tnorm = 0.0, const MixParams &params = MixParams())
-      : mix_impl::PTESolverBase<EOSIndexer, RealIndexer>(nmat, 2, eos, vfrac_tot, sie_tot,
-                                                         rho, vfrac, sie, temp, press,
-                                                         scratch, Tnorm, params) {
-    // JMM: Copy lambda data into cache. Since the cache uses
-    // pointers, it must be done this way.
-    for (std::size_t m = 0; m < nmat; ++m) {
-      if (!variadic_utils::is_nullptr(lambda[m])) {
-        for (int l = 0; l < eos[m].nlambda(); ++l) {
-          Cache[m][l] = lambda[m][l];
-        }
-      }
-    }
-  }
+      : mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>(
+            nmat, 2, eos, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press, lambda,
+            scratch, Tnorm, params) {}
 
   PORTABLE_INLINE_FUNCTION
   Real Init() {
@@ -860,7 +864,7 @@ class PTESolverPT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
     // Set the state based on the P/T chosen
     for (std::size_t m = 0; m < nmat; ++m) {
       eos[m].DensityEnergyFromPressureTemperature(Pequil * uscale, Tequil * Tnorm,
-                                                  Cache[m], rho[m], sie[m]);
+                                                  GetLambda(m), rho[m], sie[m]);
       vfrac[m] = robust::ratio(rhobar[m], rho[m]);
       u[m] = robust::ratio(sie[m] * rhobar[m], uscale);
       temp[m] = Tequil;
@@ -922,7 +926,7 @@ class PTESolverPT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
       //////////////////////////////
       Real dp = -Pequil * params_.derivative_eps; // always move towards phase transition
       eos[m].DensityEnergyFromPressureTemperature(uscale * (Pequil + dp), Tnorm * Tequil,
-                                                  Cache[m], r_pert, e_pert);
+                                                  GetLambda(m), r_pert, e_pert);
       Real drdp = robust::ratio(r_pert - rho[m], dp);
       Real dudp = robust::ratio(robust::ratio(rhobar[m] * e_pert, uscale) - u[m], dp);
 
@@ -934,7 +938,7 @@ class PTESolverPT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
       //////////////////////////////
       Real dT = Tequil * params_.derivative_eps;
       eos[m].DensityEnergyFromPressureTemperature(uscale * Pequil, Tnorm * (Tequil + dT),
-                                                  Cache[m], r_pert, e_pert);
+                                                  GetLambda(m), r_pert, e_pert);
       Real drdT = robust::ratio(r_pert - rho[m], dT);
       Real dudT = robust::ratio(robust::ratio(rhobar[m] * e_pert, uscale) - u[m], dT);
 
@@ -989,7 +993,7 @@ class PTESolverPT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
     Pequil = Ptemp + scale * dx[1];
     for (std::size_t m = 0; m < nmat; ++m) {
       eos[m].DensityEnergyFromPressureTemperature(Pequil * uscale, Tequil * Tnorm,
-                                                  Cache[m], rho[m], sie[m]);
+                                                  GetLambda(m), rho[m], sie[m]);
       vfrac[m] = robust::ratio(rhobar[m], rho[m]);
       u[m] = robust::ratio(sie[m] * rhobar[m], uscale);
       temp[m] = Tequil;
@@ -1024,42 +1028,47 @@ class PTESolverPT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
 // ======================================================================
 // fixed temperature solver
 // ======================================================================
-inline std::size_t PTESolverFixedTRequiredScratch(const std::size_t nmat) {
+inline std::size_t PTESolverFixedTRequiredScratch(const std::size_t nmat,
+                                                  const bool with_cache = true) {
   std::size_t neq = nmat;
-  return neq * neq                 // jacobian
-         + 4 * neq                 // dx, residual, and sol_scratch
-         + 2 * nmat                // rhobar and u in base
-         + 2 * nmat                // nmat sized arrays in fixed T solver
-         + MAX_NUM_LAMBDAS * nmat; // the cache
+  return neq * neq                              // jacobian
+         + 4 * neq                              // dx, residual, and sol_scratch
+         + 2 * nmat                             // rhobar and u in base
+         + 2 * nmat                             // nmat sized arrays in fixed T solver
+         + with_cache * MAX_NUM_LAMBDAS * nmat; // the cache
 }
-inline size_t PTESolverFixedTRequiredScratchInBytes(const std::size_t nmat) {
-  return PTESolverFixedTRequiredScratch(nmat) * sizeof(Real);
+inline size_t PTESolverFixedTRequiredScratchInBytes(const std::size_t nmat,
+                                                    const bool with_cache = true) {
+  return PTESolverFixedTRequiredScratch(nmat, with_cache) * sizeof(Real);
 }
 
 template <typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
-class PTESolverFixedT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::AssignIncrement;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::nmat;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::neq;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::ResidualNorm;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::vfrac_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::eos;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::vfrac;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::sie;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::temp;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::press;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::MatIndex;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::jacobian;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::residual;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::dx;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::u;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rhobar;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::Cache;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::Tnorm;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::params_;
+class PTESolverFixedT
+    : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer> {
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::AssignIncrement;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::nmat;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::neq;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::ResidualNorm;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::vfrac_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::eos;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rho;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::vfrac;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::sie;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::temp;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::press;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rho_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::uscale;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::MatIndex;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::jacobian;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::residual;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::dx;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::u;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rhobar;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::Cache;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::Tnorm;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::params_;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::lambda;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::GetLambda;
 
  public:
   // template the ctor to get type deduction/universal references prior to c++17
@@ -1068,25 +1077,16 @@ class PTESolverFixedT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
   PORTABLE_INLINE_FUNCTION
   PTESolverFixedT(const std::size_t nmat, EOS_t &&eos, const Real vfrac_tot,
                   const Real T_true, Real_t &&rho, Real_t &&vfrac, Real_t &&sie,
-                  CReal_t &&temp, Real_t &&press, Lambda_t &&lambda, Real *scratch,
+                  CReal_t &&temp, Real_t &&press, Lambda_t &lambda, Real *scratch,
                   const MixParams &params = MixParams())
-      : mix_impl::PTESolverBase<EOSIndexer, RealIndexer>(nmat, nmat, eos, vfrac_tot, 1.0,
-                                                         rho, vfrac, sie, temp, press,
-                                                         scratch, T_true, params) {
+      : mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>(
+            nmat, nmat, eos, vfrac_tot, 1.0, rho, vfrac, sie, temp, press, lambda,
+            scratch, T_true, params) {
     dpdv = AssignIncrement(scratch, nmat);
     vtemp = AssignIncrement(scratch, nmat);
     Tequil = T_true;
     Ttemp = T_true;
     Tnorm = 1.0;
-    // JMM: Copy lambda data into cache. Since the cache uses
-    // pointers, it must be done this way.
-    for (std::size_t m = 0; m < nmat; ++m) {
-      if (!variadic_utils::is_nullptr(lambda[m])) {
-        for (int l = 0; l < eos[m].nlambda(); ++l) {
-          Cache[m][l] = lambda[m][l];
-        }
-      }
-    }
   }
 
   PORTABLE_INLINE_FUNCTION
@@ -1104,10 +1104,10 @@ class PTESolverFixedT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
       // larger than rho(Pmin(Tequil)); set the physical density to reflect
       // this change in volume fraction
       rho[m] = robust::ratio(rhobar[m], vfrac[m]);
-      sie[m] = eos[m].InternalEnergyFromDensityTemperature(rho[m], Tequil, Cache[m]);
+      sie[m] = eos[m].InternalEnergyFromDensityTemperature(rho[m], Tequil, GetLambda(m));
       uscale += sie[m] * rho[m];
       // note the scaling of pressure
-      press[m] = eos[m].PressureFromDensityTemperature(rho[m], Tequil, Cache[m]);
+      press[m] = eos[m].PressureFromDensityTemperature(rho[m], Tequil, GetLambda(m));
     }
     for (std::size_t m = 0; m < nmat; ++m) {
       press[m] = robust::ratio(press[m], uscale);
@@ -1158,7 +1158,7 @@ class PTESolverFixedT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
       const Real rho_pert = robust::ratio(rhobar[m], vf_pert);
 
       Real p_pert = robust::ratio(
-          eos[m].PressureFromDensityTemperature(rho_pert, Tequil, Cache[m]), uscale);
+          eos[m].PressureFromDensityTemperature(rho_pert, Tequil, GetLambda(m)), uscale);
       dpdv[m] = robust::ratio((p_pert - press[m]), dv);
     }
 
@@ -1219,11 +1219,11 @@ class PTESolverFixedT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
       vfrac[m] = vtemp[m] + scale * dx[m];
       rho[m] = robust::ratio(rhobar[m], vfrac[m]);
       u[m] = rhobar[m] *
-             eos[m].InternalEnergyFromDensityTemperature(rho[m], Tequil, Cache[m]);
+             eos[m].InternalEnergyFromDensityTemperature(rho[m], Tequil, GetLambda(m));
       sie[m] = robust::ratio(u[m], rhobar[m]);
       u[m] = robust::ratio(u[m], uscale);
       press[m] = robust::ratio(
-          eos[m].PressureFromDensityTemperature(rho[m], Tequil, Cache[m]), uscale);
+          eos[m].PressureFromDensityTemperature(rho[m], Tequil, GetLambda(m)), uscale);
     }
     Residual();
     return ResidualNorm();
@@ -1237,45 +1237,50 @@ class PTESolverFixedT : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
 // ======================================================================
 // fixed P solver
 // ======================================================================
-inline std::size_t PTESolverFixedPRequiredScratch(const std::size_t nmat) {
+inline std::size_t PTESolverFixedPRequiredScratch(const std::size_t nmat,
+                                                  const bool with_cache = true) {
   std::size_t neq = nmat + 1;
-  return neq * neq                 // jacobian
-         + 4 * neq                 // dx, residual, and sol_scratch
-         + 2 * nmat                // all the nmat sized arrays in base
-         + 3 * nmat                // all the nmat sized arrays in fixedP
-         + MAX_NUM_LAMBDAS * nmat; // the cache
+  return neq * neq                              // jacobian
+         + 4 * neq                              // dx, residual, and sol_scratch
+         + 2 * nmat                             // all the nmat sized arrays in base
+         + 3 * nmat                             // all the nmat sized arrays in fixedP
+         + with_cache * MAX_NUM_LAMBDAS * nmat; // the cache
 }
-inline size_t PTESolverFixedPRequiredScratchInBytes(const std::size_t nmat) {
-  return PTESolverFixedPRequiredScratch(nmat) * sizeof(Real);
+inline size_t PTESolverFixedPRequiredScratchInBytes(const std::size_t nmat,
+                                                    const bool with_cache = true) {
+  return PTESolverFixedPRequiredScratch(nmat, with_cache) * sizeof(Real);
 }
 
 template <typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
-class PTESolverFixedP : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::InitBase;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::AssignIncrement;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::nmat;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::neq;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::ResidualNorm;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::vfrac_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::sie_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::eos;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::vfrac;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::sie;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::temp;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::press;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::MatIndex;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::TryIdealPTE;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::jacobian;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::residual;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::dx;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::u;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rhobar;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::Cache;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::Tnorm;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::params_;
+class PTESolverFixedP
+    : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer> {
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::InitBase;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::AssignIncrement;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::nmat;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::neq;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::ResidualNorm;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::vfrac_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::sie_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::eos;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rho;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::vfrac;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::sie;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::temp;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::press;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rho_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::uscale;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::MatIndex;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::TryIdealPTE;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::jacobian;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::residual;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::dx;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::u;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rhobar;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::Cache;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::Tnorm;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::params_;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::lambda;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::GetLambda;
 
  public:
   // template the ctor to get type deduction/universal references prior to c++17
@@ -1283,24 +1288,15 @@ class PTESolverFixedP : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
   PORTABLE_INLINE_FUNCTION
   PTESolverFixedP(const std::size_t nmat, EOS_t &&eos, const Real vfrac_tot, const Real P,
                   Real_t &&rho, Real_t &&vfrac, Real_t &&sie, Real_t &&temp,
-                  CReal_t &&press, Lambda_t &&lambda, Real *scratch,
+                  CReal_t &&press, Lambda_t &lambda, Real *scratch,
                   const MixParams &params = MixParams())
-      : mix_impl::PTESolverBase<EOSIndexer, RealIndexer>(nmat, nmat + 1, eos, vfrac_tot,
-                                                         1.0, rho, vfrac, sie, temp,
-                                                         press, scratch, 0.0, params) {
+      : mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>(
+            nmat, nmat + 1, eos, vfrac_tot, 1.0, rho, vfrac, sie, temp, press, lambda,
+            scratch, 0.0, params) {
     dpdv = AssignIncrement(scratch, nmat);
     dpdT = AssignIncrement(scratch, nmat);
     vtemp = AssignIncrement(scratch, nmat);
     Pequil = P;
-    // JMM: Copy lambda data into cache. Since the cache uses
-    // pointers, it must be done this way.
-    for (std::size_t m = 0; m < nmat; ++m) {
-      if (!variadic_utils::is_nullptr(lambda[m])) {
-        for (int l = 0; l < eos[m].nlambda(); ++l) {
-          Cache[m][l] = lambda[m][l];
-        }
-      }
-    }
   }
 
   PORTABLE_INLINE_FUNCTION
@@ -1320,7 +1316,7 @@ class PTESolverFixedP : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
     for (std::size_t m = 0; m < nmat; m++) {
       // scaled initial guess for temperature is just 1
       temp[m] = 1.0;
-      sie[m] = eos[m].InternalEnergyFromDensityTemperature(rho[m], Tguess, Cache[m]);
+      sie[m] = eos[m].InternalEnergyFromDensityTemperature(rho[m], Tguess, GetLambda(m));
       uscale += sie[m] * rho[m];
     }
 
@@ -1328,7 +1324,7 @@ class PTESolverFixedP : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
     for (std::size_t m = 0; m < nmat; ++m) {
       u[m] = robust::ratio(sie[m] * rhobar[m], uscale);
       press[m] = robust::ratio(
-          eos[m].PressureFromDensityTemperature(rho[m], Tguess, Cache[m]), uscale);
+          eos[m].PressureFromDensityTemperature(rho[m], Tguess, GetLambda(m)), uscale);
     }
     Residual();
     // Set the current guess for the equilibrium temperature.  Note that this is already
@@ -1379,7 +1375,7 @@ class PTESolverFixedP : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
       Real e_pert{};
       p_pert =
           robust::ratio(this->GetPressureFromPreferred(eos[m], rho_pert, Tnorm * Tequil,
-                                                       e_pert, Cache[m], true),
+                                                       e_pert, GetLambda(m), true),
                         uscale);
       dpdv[m] = robust::ratio((p_pert - press[m]), dv);
       //////////////////////////////
@@ -1389,7 +1385,7 @@ class PTESolverFixedP : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
 
       p_pert = robust::ratio(this->GetPressureFromPreferred(eos[m], rho[m],
                                                             Tnorm * (Tequil + dT), e_pert,
-                                                            Cache[m], true),
+                                                            GetLambda(m), true),
                              uscale);
       dpdT[m] = robust::ratio((p_pert - press[m]), dT);
     }
@@ -1459,9 +1455,9 @@ class PTESolverFixedP : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
       vfrac[m] = vtemp[m] + scale * dx[m];
       rho[m] = robust::ratio(rhobar[m], vfrac[m]);
       u[m] = rhobar[m] * eos[m].InternalEnergyFromDensityTemperature(
-                             rho[m], Tnorm * Tequil, Cache[m]);
+                             rho[m], Tnorm * Tequil, GetLambda(m));
       press[m] = robust::ratio(
-          eos[m].PressureFromDensityTemperature(rho[m], Tnorm * Tequil, Cache[m]),
+          eos[m].PressureFromDensityTemperature(rho[m], Tnorm * Tequil, GetLambda(m)),
           uscale);
       sie[m] = robust::ratio(u[m], rhobar[m]);
       u[m] = robust::ratio(u[m], uscale);
@@ -1479,45 +1475,50 @@ class PTESolverFixedP : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> 
 // ======================================================================
 // RhoU Solver
 // ======================================================================
-inline std::size_t PTESolverRhoURequiredScratch(const std::size_t nmat) {
+inline std::size_t PTESolverRhoURequiredScratch(const std::size_t nmat,
+                                                const bool with_cache = true) {
   std::size_t neq = 2 * nmat;
-  return neq * neq                 // jacobian
-         + 4 * neq                 // dx, residual, and sol_scratch
-         + 8 * nmat                // all the nmat sized arrays
-         + MAX_NUM_LAMBDAS * nmat; // the cache
+  return neq * neq                              // jacobian
+         + 4 * neq                              // dx, residual, and sol_scratch
+         + 8 * nmat                             // all the nmat sized arrays
+         + with_cache * MAX_NUM_LAMBDAS * nmat; // the cache
 }
-inline size_t PTESolverRhoURequiredScratchInBytes(const std::size_t nmat) {
-  return PTESolverRhoURequiredScratch(nmat) * sizeof(Real);
+inline size_t PTESolverRhoURequiredScratchInBytes(const std::size_t nmat,
+                                                  const bool with_cache = true) {
+  return PTESolverRhoURequiredScratch(nmat, with_cache) * sizeof(Real);
 }
 
 template <typename EOSIndexer, typename RealIndexer, typename LambdaIndexer>
-class PTESolverRhoU : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::InitBase;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::AssignIncrement;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::nmat;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::neq;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::ResidualNorm;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::vfrac_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::sie_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::eos;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::vfrac;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::sie;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::temp;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::press;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rho_total;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::uscale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::utotal_scale;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::TryIdealPTE;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::MatIndex;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::jacobian;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::residual;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::dx;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::u;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::rhobar;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::Cache;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::Tnorm;
-  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer>::params_;
+class PTESolverRhoU
+    : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer> {
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::InitBase;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::AssignIncrement;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::nmat;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::neq;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::ResidualNorm;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::vfrac_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::sie_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::eos;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rho;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::vfrac;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::sie;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::temp;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::press;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rho_total;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::uscale;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::utotal_scale;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::TryIdealPTE;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::MatIndex;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::jacobian;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::residual;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::dx;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::u;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::rhobar;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::Cache;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::Tnorm;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::params_;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::lambda;
+  using mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>::GetLambda;
 
  public:
   // template the ctor to get type deduction/universal references prior to c++17
@@ -1527,24 +1528,15 @@ class PTESolverRhoU : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
                 const Real sie_tot, Real_t &&rho, Real_t &&vfrac, Real_t &&sie,
                 Real_t &&temp, Real_t &&press, Lambda_t &&lambda, Real *scratch,
                 const Real Tnorm = 0.0, const MixParams &params = MixParams())
-      : mix_impl::PTESolverBase<EOSIndexer, RealIndexer>(nmat, 2 * nmat, eos, vfrac_tot,
-                                                         sie_tot, rho, vfrac, sie, temp,
-                                                         press, scratch, Tnorm, params) {
+      : mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>(
+            nmat, 2 * nmat, eos, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press, lambda,
+            scratch, Tnorm, params) {
     dpdv = AssignIncrement(scratch, nmat);
     dtdv = AssignIncrement(scratch, nmat);
     dpde = AssignIncrement(scratch, nmat);
     dtde = AssignIncrement(scratch, nmat);
     vtemp = AssignIncrement(scratch, nmat);
     utemp = AssignIncrement(scratch, nmat);
-    // JMM: Copy lambda data into cache. Since the cache uses
-    // pointers, it must be done this way.
-    for (std::size_t m = 0; m < nmat; ++m) {
-      if (!variadic_utils::is_nullptr(lambda[m])) {
-        for (int l = 0; l < eos[m].nlambda(); ++l) {
-          Cache[m][l] = lambda[m][l];
-        }
-      }
-    }
   }
 
   PORTABLE_INLINE_FUNCTION
@@ -1608,10 +1600,11 @@ class PTESolverRhoU : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
 
       Real p_pert;
       Real t_pert = robust::ratio(
-          eos[m].TemperatureFromDensityInternalEnergy(rho_pert, sie[m], Cache[m]), Tnorm);
+          eos[m].TemperatureFromDensityInternalEnergy(rho_pert, sie[m], GetLambda(m)),
+          Tnorm);
       p_pert =
           robust::ratio(this->GetPressureFromPreferred(eos[m], rho_pert, Tnorm * t_pert,
-                                                       sie[m], Cache[m], false),
+                                                       sie[m], GetLambda(m), false),
                         uscale);
       dpdv[m] = robust::ratio(p_pert - press[m], dv);
       dtdv[m] = robust::ratio(t_pert - temp[m], dv);
@@ -1621,13 +1614,13 @@ class PTESolverRhoU : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
       const Real de = std::abs(u[m]) * params_.derivative_eps;
       Real e_pert = robust::ratio(u[m] + de, rhobar[m]);
 
-      t_pert = robust::ratio(
-          eos[m].TemperatureFromDensityInternalEnergy(rho[m], uscale * e_pert, Cache[m]),
-          Tnorm);
-      p_pert =
-          robust::ratio(this->GetPressureFromPreferred(eos[m], rho[m], Tnorm * t_pert,
-                                                       uscale * e_pert, Cache[m], false),
-                        uscale);
+      t_pert = robust::ratio(eos[m].TemperatureFromDensityInternalEnergy(
+                                 rho[m], uscale * e_pert, GetLambda(m)),
+                             Tnorm);
+      p_pert = robust::ratio(
+          this->GetPressureFromPreferred(eos[m], rho[m], Tnorm * t_pert, uscale * e_pert,
+                                         GetLambda(m), false),
+          uscale);
       dpde[m] = robust::ratio(p_pert - press[m], de);
       dtde[m] = robust::ratio(t_pert - temp[m], de);
       if (std::abs(dtde[m]) < params_.min_dtde) { // must be on the cold curve
@@ -1715,10 +1708,11 @@ class PTESolverRhoU : public mix_impl::PTESolverBase<EOSIndexer, RealIndexer> {
       u[m] = utemp[m] + scale * dx[nmat + m];
       sie[m] = uscale * robust::ratio(u[m], rhobar[m]);
       temp[m] = robust::ratio(
-          eos[m].TemperatureFromDensityInternalEnergy(rho[m], sie[m], Cache[m]), Tnorm);
+          eos[m].TemperatureFromDensityInternalEnergy(rho[m], sie[m], GetLambda(m)),
+          Tnorm);
       press[m] =
           robust::ratio(this->GetPressureFromPreferred(eos[m], rho[m], Tnorm * temp[m],
-                                                       sie[m], Cache[m], false),
+                                                       sie[m], GetLambda(m), false),
                         uscale);
     }
     Residual();

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -982,6 +982,16 @@ class EosBase {
     const std::size_t tot_size = pcrtp->SerializedSizeInBytes();
     PORTABLE_ALWAYS_REQUIRE(offst == tot_size, "Deserialization failed!");
     return offst;
+  }
+
+  // Tooling for indexers
+  template <typename T>
+  static inline constexpr bool NeedsLambda() {
+    return false;
+  }
+  template <typename T>
+  static inline constexpr bool NeedsLambda(const T &t) {
+    return NeedsLambda<T>();
   }
 
   // Tooling for modifiers

--- a/singularity-eos/eos/eos_electrons.hpp
+++ b/singularity-eos/eos/eos_electrons.hpp
@@ -214,7 +214,8 @@ class IdealElectrons : public EosBase<IdealElectrons> {
  private:
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real _Cv(Indexer_t &&lambda) const {
-    const Real Z = IndexerUtils::Get<IndexableTypes::MeanIonizationState>(lambda);
+    const Real Z =
+        IndexerUtils::Get<IndexableTypes::MeanIonizationState>(lambda, Lambda::Zi);
     return _Cvbase * std::max(Z, static_cast<Real>(0.0));
   }
 

--- a/singularity-eos/eos/eos_electrons.hpp
+++ b/singularity-eos/eos/eos_electrons.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2024. Triad National Security, LLC. All rights reserved.  This
+// © 2024-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -23,6 +23,7 @@
 
 // Base stuff
 #include <singularity-eos/base/constants.hpp>
+#include <singularity-eos/base/indexable_types.hpp>
 #include <singularity-eos/base/robust_utils.hpp>
 #include <singularity-eos/eos/eos_base.hpp>
 
@@ -193,6 +194,10 @@ class IdealElectrons : public EosBase<IdealElectrons> {
   SG_ADD_BASE_CLASS_USINGS(IdealElectrons)
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 1; }
+  template <typename T>
+  static inline constexpr bool NeedsLambda() {
+    return std::is_same<T, IndexableTypes::MeanIonizationState>::value;
+  }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
   static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
     return 0;
@@ -209,8 +214,8 @@ class IdealElectrons : public EosBase<IdealElectrons> {
  private:
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real _Cv(Indexer_t &&lambda) const {
-    const Real Z = std::max(lambda[Lambda::Zi], static_cast<Real>(0.0));
-    return _Cvbase * Z;
+    const Real Z = IndexerUtils::Get<IndexableTypes::MeanIonizationState>(lambda);
+    return _Cvbase * std::max(Z, static_cast<Real>(0.0));
   }
 
   // TODO(JMM): Change gamma if needed

--- a/singularity-eos/eos/eos_helmholtz.hpp
+++ b/singularity-eos/eos/eos_helmholtz.hpp
@@ -464,7 +464,7 @@ class Helmholtz : public EosBase<Helmholtz> {
   static inline constexpr bool NeedsLambda() {
     return std::is_same<T, IndexableTypes::MeanAtomicMass>::value ||
            std::is_same<T, IndexableTypes::MeanAtomicNumber>::value ||
-           std::is_same<T, IndexableTypes::LogTemperature>::value
+           std::is_same<T, IndexableTypes::LogTemperature>::value;
   }
   static constexpr unsigned long PreferredInput() {
     return thermalqs::density | thermalqs::temperature;

--- a/singularity-eos/eos/eos_helmholtz.hpp
+++ b/singularity-eos/eos/eos_helmholtz.hpp
@@ -462,10 +462,9 @@ class Helmholtz : public EosBase<Helmholtz> {
   PORTABLE_INLINE_FUNCTION int nlambda() const noexcept { return 3; }
   template <typename T>
   static inline constexpr bool NeedsLambda() {
-    using namespace IndexableTypes;
-    return std::is_same<T, MeanAtomicMass>::value ||
-           std::is_same<T, MeanAtomicNumber>::value ||
-           std::is_same<T, LogTemperature>::value
+    return std::is_same<T, IndexableTypes::MeanAtomicMass>::value ||
+           std::is_same<T, IndexableTypes::MeanAtomicNumber>::value ||
+           std::is_same<T, IndexableTypes::LogTemperature>::value
   }
   static constexpr unsigned long PreferredInput() {
     return thermalqs::density | thermalqs::temperature;

--- a/singularity-eos/eos/eos_helmholtz.hpp
+++ b/singularity-eos/eos/eos_helmholtz.hpp
@@ -6,7 +6,7 @@
 // Original work is open-sourced under the CC-By license
 // https://creativecommons.org/licenses/by/4.0/
 //------------------------------------------------------------------------------
-// © 2023-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2023-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -43,6 +43,7 @@
 // singularity-eos
 #include <singularity-eos/base/constants.hpp>
 #include <singularity-eos/base/hermite.hpp>
+#include <singularity-eos/base/indexable_types.hpp>
 #include <singularity-eos/base/math_utils.hpp>
 #include <singularity-eos/base/robust_utils.hpp>
 #include <singularity-eos/base/root-finding-1d/root_finding.hpp>
@@ -459,6 +460,13 @@ class Helmholtz : public EosBase<Helmholtz> {
   PORTABLE_INLINE_FUNCTION void CheckParams() const { electrons_.CheckParams(); }
 
   PORTABLE_INLINE_FUNCTION int nlambda() const noexcept { return 3; }
+  template <typename T>
+  static inline constexpr bool NeedsLambda() {
+    using namespace IndexableTypes;
+    return std::is_same<T, MeanAtomicMass>::value ||
+           std::is_same<T, MeanAtomicNumber>::value ||
+           std::is_same<T, LogTemperature>::value
+  }
   static constexpr unsigned long PreferredInput() {
     return thermalqs::density | thermalqs::temperature;
   }
@@ -634,8 +642,8 @@ class Helmholtz : public EosBase<Helmholtz> {
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
     using namespace HelmUtils;
     Real p[NDERIV], e[NDERIV], s[NDERIV], etaele[NDERIV], nep[NDERIV];
-    Real abar = lambda[Lambda::Abar];
-    Real zbar = lambda[Lambda::Zbar];
+    Real abar = IndexerUtils::Get<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+    Real zbar = IndexerUtils::Get<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
     Real ytot, ye, ywot, De, lDe;
     GetElectronDensities_(rho, abar, zbar, ytot, ye, ywot, De, lDe);
     Real lT = lTFromRhoSie_(rho, sie, abar, zbar, ye, ytot, ywot, De, lDe, lambda);
@@ -661,14 +669,14 @@ class Helmholtz : public EosBase<Helmholtz> {
       const Real rho, const Real T,
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
     using namespace HelmUtils;
-    return lambda[Lambda::Abar];
+    return IndexerUtils::Get<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
   }
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real MeanAtomicNumberFromDensityTemperature(
       const Real rho, const Real T,
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
     using namespace HelmUtils;
-    return lambda[Lambda::Zbar];
+    return IndexerUtils::Get<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
   }
 
   template <typename Indexer_t = Real *>
@@ -762,10 +770,10 @@ class Helmholtz : public EosBase<Helmholtz> {
   GetFromDensityTemperature_(const Real rho, const Real temperature, Indexer_t &&lambda,
                              Real p[NDERIV], Real e[NDERIV], Real s[NDERIV],
                              Real etaele[NDERIV], Real nep[NDERIV]) const {
-    Real abar = lambda[Lambda::Abar];
-    Real zbar = lambda[Lambda::Zbar];
+    Real abar = IndexerUtils::Get<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+    Real zbar = IndexerUtils::Get<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
     Real lT = std::log10(temperature);
-    lambda[Lambda::lT] = lT;
+    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
     Real ytot, ye, ywot, De, lDe;
     GetElectronDensities_(rho, abar, zbar, ytot, ye, ywot, De, lDe);
     GetFromDensityLogTemperature_(rho, temperature, abar, zbar, ye, ytot, ywot, De, lDe,
@@ -777,8 +785,8 @@ class Helmholtz : public EosBase<Helmholtz> {
   GetFromDensityInternalEnergy_(const Real rho, const Real sie, Indexer_t &&lambda,
                                 Real p[NDERIV], Real e[NDERIV], Real s[NDERIV],
                                 Real etaele[NDERIV], Real nep[NDERIV]) const {
-    Real abar = lambda[Lambda::Abar];
-    Real zbar = lambda[Lambda::Zbar];
+    Real abar = IndexerUtils::Get<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+    Real zbar = IndexerUtils::Get<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
     Real ytot, ye, ywot, De, lDe;
     GetElectronDensities_(rho, abar, zbar, ytot, ye, ywot, De, lDe);
     Real lT = lTFromRhoSie_(rho, sie, abar, zbar, ye, ytot, ywot, De, lDe, lambda);
@@ -823,8 +831,8 @@ Helmholtz::FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, R
   PORTABLE_ALWAYS_REQUIRE(
       !(need_temp && need_sie),
       "Either specific internal energy or temperature must be provided.");
-  Real abar = lambda[Lambda::Abar];
-  Real zbar = lambda[Lambda::Zbar];
+  Real abar = IndexerUtils::Get<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+  Real zbar = IndexerUtils::Get<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
   Real ytot, ye, ywot, De, lDe, lT;
   GetElectronDensities_(rho, abar, zbar, ytot, ye, ywot, De, lDe);
   if (need_temp) {
@@ -832,7 +840,7 @@ Helmholtz::FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, R
     temp = math_utils::pow10(lT);
   } else {
     lT = std::log10(temp);
-    lambda[Lambda::lT] = lT;
+    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
   }
   Real p[NDERIV], e[NDERIV], s[NDERIV], etaele[NDERIV], nep[NDERIV];
   GetFromDensityLogTemperature_(rho, temp, abar, zbar, ye, ytot, ywot, De, lDe, p, e, s,
@@ -874,7 +882,7 @@ PORTABLE_INLINE_FUNCTION Real Helmholtz::lTFromRhoSie_(const Real rho, const Rea
 
   if (options_.ENABLE_RAD || options_.GAS_DEGENERATE ||
       options_.ENABLE_COULOMB_CORRECTIONS) {
-    Real lTguess = lambda[Lambda::lT];
+    Real lTguess = IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT);
     if (!((electrons_.lTMin() <= lTguess) && (lTguess <= electrons_.lTMax()))) {
       lTguess = lTAnalytic_(rho, e, ni, ne);
       if (!((electrons_.lTMin() <= lTguess) && (lTguess <= electrons_.lTMax()))) {
@@ -948,7 +956,7 @@ PORTABLE_INLINE_FUNCTION Real Helmholtz::lTFromRhoSie_(const Real rho, const Rea
     }
     lT = electrons_.lTMax();
   }
-  lambda[Lambda::lT] = lT;
+  IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
   return lT;
 }
 

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -36,6 +36,7 @@
 // base
 #include <singularity-eos/base/constants.hpp>
 #include <singularity-eos/base/fast-math/logs.hpp>
+#include <singularity-eos/base/indexable_types.hpp>
 #include <singularity-eos/base/robust_utils.hpp>
 #include <singularity-eos/base/root-finding-1d/root_finding.hpp>
 #include <singularity-eos/base/sp5/singularity_eos_sp5.hpp>
@@ -219,6 +220,11 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return _n_lambda; }
+  template <typename T>
+  static inline constexpr bool NeedsLambda(const T &t) {
+    using namespace IndexableTypes;
+    return std::is_same<T, LogDensity>::value || std::is_same<T, LogTemperature>::value;
+  }
   PORTABLE_INLINE_FUNCTION
   RootFinding1D::Status rootStatus() const { return status_; }
   PORTABLE_INLINE_FUNCTION
@@ -506,6 +512,10 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return _n_lambda; }
+  template <typename T>
+  static inline constexpr bool NeedsLambda() {
+    return std::is_same<T, IndexableTypes::LogDensity>::value;
+  }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     static constexpr char s1[]{"SpinerEOS Parameters:"};
     static constexpr char s2[]{"depends on log_10(rho) and log_10(sie)"};
@@ -1205,8 +1215,8 @@ SpinerEOSDependsRhoT::FillEos(Real &rho, Real &temp, Real &energy, Real &press, 
     bmod = bModFromRholRhoTlT_(rho, lRho, temp, lT, whereAmI);
   }
   if (!variadic_utils::is_nullptr(lambda)) {
-    lambda[Lambda::lRho] = lRho;
-    lambda[Lambda::lT] = lT;
+    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
+    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
   }
 }
 
@@ -1239,8 +1249,8 @@ SpinerEOSDependsRhoT::getLogsRhoT_(const Real rho, const Real temperature, Real 
   lRho = lRho_(rho);
   lT = lT_(temperature);
   if (!variadic_utils::is_nullptr(lambda)) {
-    lambda[Lambda::lRho] = lRho;
-    lambda[Lambda::lT] = lT;
+    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
+    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
   }
 }
 
@@ -1254,10 +1264,14 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lRhoFromPlT_(
   // Real lRhoGuess = lRhoMin_ + 0.9*(lRhoMax_ - lRhoMin_);
   const RootFinding1D::RootCounts *pcounts =
       (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
-  if (!variadic_utils::is_nullptr(lambda) && lRhoMin_ <= lambda[Lambda::lRho] &&
-      lambda[Lambda::lRho] <= lRhoMax_) {
-    lRhoGuess = lambda[Lambda::lRho];
+
+  if (!variadic_utils::is_nullptr(lambda)) {
+    Real lRho_cache = IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho);
+    if ((lRhoMin_ <= lRho_cache) && (lRho_cache <= lRhoMax_)) {
+      lRhoGuess = lRho_cache;
+    }
   }
+
   if (lT <= lTMin_) { // cold curve
     whereAmI = TableStatus::OffBottom;
     const callable_interp::interp PFunc(PCold_);
@@ -1293,8 +1307,8 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lRhoFromPlT_(
     lRho = reproducible_ ? lRhoMax_ : lRhoGuess;
   }
   if (!variadic_utils::is_nullptr(lambda)) {
-    lambda[Lambda::lRho] = lRho;
-    lambda[Lambda::lT] = lT;
+    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
+    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
   }
   if (memoryStatus_ != DataStatus::OnDevice) {
     status_ = status;
@@ -1330,9 +1344,12 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoSie_(
     }
   } else {
     Real lTGuess = reproducible_ ? lTMin_ : 0.5 * (lTMin_ + lTMax_);
-    if (!variadic_utils::is_nullptr(lambda) && lTMin_ <= lambda[Lambda::lT] &&
-        lambda[Lambda::lT] <= lTMax_) {
-      lTGuess = lambda[Lambda::lT];
+    if (!variadic_utils::is_nullptr(lambda)) {
+      Real lT_cache =
+          IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT);
+      if ((lTMin_ <= lT_cache) && (lT_cache <= lTMax_)) {
+        lTGuess = lT_cache;
+      }
     }
     const callable_interp::r_interp sieFunc(sie_, lRho);
     status = ROOT_FINDER(sieFunc, sie, lTGuess, lTMin_, lTMax_, ROOT_THRESH, ROOT_THRESH,
@@ -1355,8 +1372,8 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoSie_(
     }
   }
   if (!variadic_utils::is_nullptr(lambda)) {
-    lambda[Lambda::lRho] = lRho;
-    lambda[Lambda::lT] = lT;
+    IndexerUtils::Get<LogDensity>(lambda, Lambda::lRho) = lRho;
+    IndexerUtils::Get<LogTemperature>(lambda, Lambda::lT) = lT;
   }
 #ifdef PORTABILITY_STRATEGY_NONE
   if (memoryStatus_ != DataStatus::OnDevice) {
@@ -1392,11 +1409,12 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoP_(
     }
   } else {
     whereAmI = TableStatus::OnTable;
-    if (!variadic_utils::is_nullptr(lambda) && lTMin_ <= lambda[Lambda::lT] &&
-        lambda[Lambda::lT] <= lTMax_) {
-      lTGuess = lambda[Lambda::lT];
-    } else {
-      lTGuess = 0.5 * (lTMin_ + lTMax_);
+    lTGuess = 0.5 * (lTMin_ + lTMax_);
+    if (!variadic_utils::is_nullptr(lambda)) {
+      Real lT_cache = IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, lT);
+      if ((lTMin_ <= lT_cache) && (lT_cache <= lTMax_)) {
+        lTGuess = lT_cache;
+      }
     }
     const callable_interp::r_interp PFunc(P_, lRho);
     status = ROOT_FINDER(PFunc, press, lTGuess, lTMin_, lTMax_, ROOT_THRESH, ROOT_THRESH,
@@ -1415,8 +1433,8 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoP_(
     }
   }
   if (!variadic_utils::is_nullptr(lambda)) {
-    lambda[Lambda::lRho] = lRho;
-    lambda[Lambda::lT] = lT;
+    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
+    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
   }
   if (memoryStatus_ != DataStatus::OnDevice) {
     status_ = status;
@@ -1889,7 +1907,9 @@ SpinerEOSDependsRhoSie::FillEos(Real &rho, Real &temp, Real &energy, Real &press
     }
   } else {
     lRho = toLog_(rho, lRhoOffset_);
-    if (!variadic_utils::is_nullptr(lambda)) lambda[0] = lRho;
+    if (!variadic_utils::is_nullptr(lambda)) {
+      IndexerUtils::Get<IndexableTypes::LogDensity>(lambda) = lRho;
+    }
   }
   if (output & thermalqs::temperature) {
     lE = toLog_(energy, lEOffset_);
@@ -1939,7 +1959,7 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::interpRhoT_(
   const Real lRho = toLog_(rho, lRhoOffset_);
   const Real lT = toLog_(T, lTOffset_);
   if (!variadic_utils::is_nullptr(lambda)) {
-    lambda[0] = lRho;
+    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda) = lRho;
   }
   return db.interpToReal(lRho, lT);
 }
@@ -1950,7 +1970,7 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::interpRhoSie_(
   const Real lRho = toLog_(rho, lRhoOffset_);
   const Real lE = toLog_(sie, lEOffset_);
   if (!variadic_utils::is_nullptr(lambda)) {
-    lambda[0] = lRho;
+    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda) = lRho;
   }
   return db.interpToReal(lRho, lE);
 }
@@ -1971,9 +1991,11 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::lRhoFromPlT_(
     }
   } else {
     Real lRhoGuess = reproducible_ ? lRhoMin_ : 0.5 * (lRhoMin_ + lRhoMax_);
-    if (!variadic_utils::is_nullptr(lambda) && lRhoMin_ <= lambda[0] &&
-        lambda[0] <= lRhoMax_) {
-      lRhoGuess = lambda[0];
+    if (!variadic_utils::is_nullptr(lambda)) {
+      Real lRho_cache = IndexerUtils::Get<IndexableTypes::LogDensity>(lambda);
+      if ((lRhoMin_ <= lRho_cache) && (lRho_cache <= lRhoMax_)) {
+        lRhoGuess = lRho_cache;
+      }
     }
     const callable_interp::l_interp PFunc(dependsRhoT_.P, lT);
     auto status = ROOT_FINDER(PFunc, P, lRhoGuess, lRhoMin_, lRhoMax_, robust::EPS(),
@@ -1994,7 +2016,9 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::lRhoFromPlT_(
       lRho = reproducible_ ? lRhoMin_ : lRhoGuess;
     }
   }
-  if (!variadic_utils::is_nullptr(lambda)) lambda[0] = lRho;
+  if (!variadic_utils::is_nullptr(lambda)) {
+    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda) = lRho;
+  }
   return lRho;
 }
 

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -365,6 +365,9 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   friend class table_utils::SpinerTricks<SpinerEOSDependsRhoSie>;
 
  public:
+  struct Lambda {
+    enum Index { lRho = 0 };
+  };
   using Grid_t = SpinerEOSDependsRhoT::Grid_t;
   using DataBox = SpinerEOSDependsRhoT::DataBox;
   struct SP5Tables {
@@ -1908,7 +1911,7 @@ SpinerEOSDependsRhoSie::FillEos(Real &rho, Real &temp, Real &energy, Real &press
   } else {
     lRho = toLog_(rho, lRhoOffset_);
     if (!variadic_utils::is_nullptr(lambda)) {
-      IndexerUtils::Get<IndexableTypes::LogDensity>(lambda) = lRho;
+      IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
     }
   }
   if (output & thermalqs::temperature) {
@@ -1959,7 +1962,7 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::interpRhoT_(
   const Real lRho = toLog_(rho, lRhoOffset_);
   const Real lT = toLog_(T, lTOffset_);
   if (!variadic_utils::is_nullptr(lambda)) {
-    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda) = lRho;
+    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
   }
   return db.interpToReal(lRho, lT);
 }
@@ -1970,7 +1973,7 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::interpRhoSie_(
   const Real lRho = toLog_(rho, lRhoOffset_);
   const Real lE = toLog_(sie, lEOffset_);
   if (!variadic_utils::is_nullptr(lambda)) {
-    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda) = lRho;
+    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
   }
   return db.interpToReal(lRho, lE);
 }
@@ -1992,7 +1995,8 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::lRhoFromPlT_(
   } else {
     Real lRhoGuess = reproducible_ ? lRhoMin_ : 0.5 * (lRhoMin_ + lRhoMax_);
     if (!variadic_utils::is_nullptr(lambda)) {
-      Real lRho_cache = IndexerUtils::Get<IndexableTypes::LogDensity>(lambda);
+      Real lRho_cache =
+          IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho);
       if ((lRhoMin_ <= lRho_cache) && (lRho_cache <= lRhoMax_)) {
         lRhoGuess = lRho_cache;
       }
@@ -2017,7 +2021,7 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::lRhoFromPlT_(
     }
   }
   if (!variadic_utils::is_nullptr(lambda)) {
-    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda) = lRho;
+    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
   }
   return lRho;
 }

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -1372,8 +1372,8 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoSie_(
     }
   }
   if (!variadic_utils::is_nullptr(lambda)) {
-    IndexerUtils::Get<LogDensity>(lambda, Lambda::lRho) = lRho;
-    IndexerUtils::Get<LogTemperature>(lambda, Lambda::lT) = lT;
+    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
+    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
   }
 #ifdef PORTABILITY_STRATEGY_NONE
   if (memoryStatus_ != DataStatus::OnDevice) {

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -1324,6 +1324,18 @@ class Variant {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept {
     return mpark::visit([](const auto &eos) { return eos.nlambda(); }, eos_);
+  }
+
+  template <typename T>
+  PORTABLE_INLINE_FUNCTION bool NeedsLambda() const {
+    return mpark::visit([](const auto &eos) { return eos.template NeedsLambda<T>(); },
+                        eos_);
+  }
+
+  template <typename T>
+  PORTABLE_INLINE_FUNCTION bool NeedsLambda(const T &t) const {
+    return mpark::visit([](const auto &eos) { return eos.template NeedsLambda<T>(); },
+                        eos_);
   }
 
   template <typename T>

--- a/singularity-eos/eos/get_sg_eos.cpp
+++ b/singularity-eos/eos/get_sg_eos.cpp
@@ -171,7 +171,8 @@ int get_sg_eos( // sizing information
     // set rho_i = nmat / spvol * frac_mass_i
     // iterate PTE solver to obtain internal energies
     // that results in the input T
-    pte_solver_scratch_size = PTESolverFixedTRequiredScratch(nmat);
+    pte_solver_scratch_size =
+        PTESolverFixedTRequiredScratch(nmat) + nmat * MAX_NUM_LAMBDAS;
     solver_scratch = ScratchV<double>(VAWI("PTE::scratch solver"), scratch_size,
                                       pte_solver_scratch_size);
     const std::string rt_name = "PTE::solve (rho,T) input" + perf_nums;
@@ -187,7 +188,7 @@ int get_sg_eos( // sizing information
     // set rho_i = nmat / spvol * frac_mass_i
     // iterate PTE solver to obtain internal energies
     // that results in the input P
-    pte_solver_scratch_size = PTESolverRhoTRequiredScratch(nmat);
+    pte_solver_scratch_size = PTESolverRhoTRequiredScratch(nmat) + nmat * MAX_NUM_LAMBDAS;
     solver_scratch = ScratchV<double>(VAWI("PTE::scratch solver"), scratch_size,
                                       pte_solver_scratch_size);
     const std::string rp_name = "PTE::solve (rho,P) input" + perf_nums;
@@ -199,6 +200,7 @@ int get_sg_eos( // sizing information
   }
   case input_condition::P_T_INPUT: {
     // P-T input
+    // TODO(JMM): Thread through P-T solver
     const int pte_solver_scratch_size = nmat * MAX_NUM_LAMBDAS;
     solver_scratch = ScratchV<double>(VAWI("PTE::scratch solver"), scratch_size,
                                       pte_solver_scratch_size);
@@ -215,7 +217,7 @@ int get_sg_eos( // sizing information
     // no break so fallthrough to case 1
   case input_condition::RHO_E_INPUT: {
     // rho-sie input
-    pte_solver_scratch_size = PTESolverRhoTRequiredScratch(nmat);
+    pte_solver_scratch_size = PTESolverRhoTRequiredScratch(nmat) + nmat * MAX_NUM_LAMBDAS;
     solver_scratch = ScratchV<double>(VAWI("PTE::scratch solver"), scratch_size,
                                       pte_solver_scratch_size);
     const std::string re_name = "PTE::solve (rho,e) input" + perf_nums;

--- a/singularity-eos/eos/get_sg_eos_p_t.cpp
+++ b/singularity-eos/eos/get_sg_eos_p_t.cpp
@@ -44,6 +44,8 @@ void get_sg_eos_p_t(const char *name, int ncell, int nmat, indirection_v &offset
           solver_scratch(tid, idx) = 0.0;
         }
         // caching mechanism
+        // JMM: We allocate more space than needed and re-use solver
+        // scratch for the cache accessor.
         singularity::mix_impl::CacheAccessor cache(&solver_scratch(tid, 0));
         double mass_sum{0.0};
         // normalize mass fractions

--- a/singularity-eos/eos/get_sg_eos_rho_e.cpp
+++ b/singularity-eos/eos/get_sg_eos_rho_e.cpp
@@ -45,6 +45,8 @@ void get_sg_eos_rho_e(const char *name, int ncell, indirection_v &offsets_v,
           solver_scratch(tid, idx) = 0.0;
         }
         // get cache from offsets into scratch
+        // JMM: We allocate more space than needed and re-use solver
+        // scratch for the cache accessor.
         const int neq = npte + 1;
         singularity::mix_impl::CacheAccessor cache(&solver_scratch(tid, 0) +
                                                    neq * (neq + 4) + 2 * npte);

--- a/singularity-eos/eos/get_sg_eos_rho_e.cpp
+++ b/singularity-eos/eos/get_sg_eos_rho_e.cpp
@@ -63,7 +63,7 @@ void get_sg_eos_rho_e(const char *name, int ncell, indirection_v &offsets_v,
           Real *ptemp_pte = &temp_pte(tid, 0);
           Real *ppress_pte = &press_pte(tid, 0);
           Real *pscratch = &solver_scratch(tid, 0);
-          PTESolverRhoT<singularity::EOSAccessor_, Real *, Real **> method(
+          PTESolverRhoT<singularity::EOSAccessor_, Real *, decltype(cache)> method(
               npte, eos_inx, vfrac_sum, sie_v(i), prho_pte, pvfrac_pte, psie_pte,
               ptemp_pte, ppress_pte, cache, pscratch);
           auto status = PTESolver(method);

--- a/singularity-eos/eos/get_sg_eos_rho_p.cpp
+++ b/singularity-eos/eos/get_sg_eos_rho_p.cpp
@@ -47,6 +47,9 @@ void get_sg_eos_rho_p(const char *name, int ncell, indirection_v &offsets_v,
           solver_scratch(tid, idx) = 0.0;
         }
         const int neq = npte + 1;
+        // JMM: We allocate more space than needed and re-use solver
+        // scratch for the cache accessor.
+
         singularity::mix_impl::CacheAccessor cache(&solver_scratch(tid, 0) +
                                                    neq * (neq + 4) + 2 * npte);
         bool pte_converged = true;

--- a/singularity-eos/eos/get_sg_eos_rho_p.cpp
+++ b/singularity-eos/eos/get_sg_eos_rho_p.cpp
@@ -61,7 +61,7 @@ void get_sg_eos_rho_p(const char *name, int ncell, indirection_v &offsets_v,
           Real *ptemp_pte = &temp_pte(tid, 0);
           Real *ppress_pte = &press_pte(tid, 0);
           Real *pscratch = &solver_scratch(tid, 0);
-          PTESolverFixedP<singularity::EOSAccessor_, Real *, Real **> method(
+          PTESolverFixedP<singularity::EOSAccessor_, Real *, decltype(cache)> method(
               npte, eos_inx, vfrac_sum, press_pte(tid, 0), prho_pte, pvfrac_pte, psie_pte,
               ptemp_pte, ppress_pte, cache, pscratch);
           auto status = PTESolver(method);

--- a/singularity-eos/eos/get_sg_eos_rho_t.cpp
+++ b/singularity-eos/eos/get_sg_eos_rho_t.cpp
@@ -47,6 +47,8 @@ void get_sg_eos_rho_t(const char *name, int ncell, indirection_v &offsets_v,
         for (std::size_t idx = 0; idx < solver_scratch.extent(1); ++idx) {
           solver_scratch(tid, idx) = 0.0;
         }
+        // JMM: We allocate more space than needed and re-use solver
+        // scratch for the cache accessor.
         const int neq = npte;
         singularity::mix_impl::CacheAccessor cache(&solver_scratch(tid, 0) +
                                                    neq * (neq + 4) + 2 * npte);

--- a/singularity-eos/eos/get_sg_eos_rho_t.cpp
+++ b/singularity-eos/eos/get_sg_eos_rho_t.cpp
@@ -64,7 +64,7 @@ void get_sg_eos_rho_t(const char *name, int ncell, indirection_v &offsets_v,
           Real *ptemp_pte = &temp_pte(tid, 0);
           Real *ppress_pte = &press_pte(tid, 0);
           Real *pscratch = &solver_scratch(tid, 0);
-          PTESolverFixedT<singularity::EOSAccessor_, Real *, Real **> method(
+          PTESolverFixedT<singularity::EOSAccessor_, Real *, decltype(cache)> method(
               npte, eos_inx, vfrac_sum, temp_pte(tid, 0), prho_pte, pvfrac_pte, psie_pte,
               ptemp_pte, ppress_pte, cache, pscratch);
           auto status = PTESolver(method);

--- a/singularity-eos/eos/modifiers/eos_unitsystem.hpp
+++ b/singularity-eos/eos/modifiers/eos_unitsystem.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -433,6 +433,10 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return t_.nlambda(); }
+  template <typename Indexable>
+  static inline constexpr bool NeedsLambda() {
+    return T::template NeedsLambda<Indexable>();
+  }
 
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }
 

--- a/singularity-eos/eos/modifiers/ramps_eos.hpp
+++ b/singularity-eos/eos/modifiers/ramps_eos.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -444,6 +444,10 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return t_.nlambda(); }
+  template <typename Indexable>
+  static inline constexpr bool NeedsLambda() {
+    return T::template NeedsLambda<Indexable>();
+  }
 
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }
 

--- a/singularity-eos/eos/modifiers/relativistic_eos.hpp
+++ b/singularity-eos/eos/modifiers/relativistic_eos.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -148,6 +148,10 @@ class RelativisticEOS : public EosBase<RelativisticEOS<T>> {
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return t_.nlambda(); }
+  template <typename Indexable>
+  static inline constexpr bool NeedsLambda() {
+    return T::template NeedsLambda<Indexable>();
+  }
 
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const {
     return t_.MinimumDensity();

--- a/singularity-eos/eos/modifiers/scaled_eos.hpp
+++ b/singularity-eos/eos/modifiers/scaled_eos.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -311,6 +311,10 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return t_.nlambda(); }
+  template <typename Indexable>
+  static inline constexpr bool NeedsLambda() {
+    return T::template NeedsLambda<Indexable>();
+  }
 
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }
 

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -302,6 +302,10 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return t_.nlambda(); }
+  template <typename Indexable>
+  static inline constexpr bool NeedsLambda() {
+    return T::template NeedsLambda<Indexable>();
+  }
 
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }
 

--- a/singularity-eos/eos/modifiers/zsplit_eos.hpp
+++ b/singularity-eos/eos/modifiers/zsplit_eos.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2024. Triad National Security, LLC. All rights reserved.  This
+// © 2024-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -22,7 +22,9 @@
 #include <ports-of-call/portable_errors.hpp>
 #include <singularity-eos/base/constants.hpp>
 #include <singularity-eos/base/eos_error.hpp>
+#include <singularity-eos/base/indexable_types.hpp>
 #include <singularity-eos/base/robust_utils.hpp>
+#include <singularity-eos/base/variadic_utils.hpp>
 #include <singularity-eos/eos/eos_base.hpp>
 
 namespace singularity {
@@ -224,6 +226,10 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 1 + t_.nlambda(); }
+  template <typename Indexable>
+  static inline constexpr bool NeedsLambda() {
+    return std::is_same<Indexable, IndexableTypes::MeanIonizationState>::value;
+  }
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }
   static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
     return T::scratch_size(method, nelements);
@@ -268,7 +274,15 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
  private:
   template <typename Indexer_t = Real *>
   PORTABLE_FORCEINLINE_FUNCTION Real GetIonizationState_(Indexer_t &&lambda) const {
-    return std::max(0.0, lambda[t_.nlambda()]);
+    if (variadic_utils::is_nullptr(lambda)) {
+      PORTABLE_THROW_OR_ABORT(
+          "StellarCollapse: lambda must contain Ye and 1 space for caching.\n");
+    }
+    if constexpr (IndexableTypes::MeanIonizationState::IsOverloadedIn<Indexer_t>::value) {
+      return std::max(0.0, lambda[IndexableTypes::MeanIonizationState()]);
+    } else {
+      return std::max(0.0, lambda[t_.nlambda()]);
+    }
   }
   // TODO(JMM): Runtime?
   template <typename Indexer_t = Real *>

--- a/singularity-eos/eos/modifiers/zsplit_eos.hpp
+++ b/singularity-eos/eos/modifiers/zsplit_eos.hpp
@@ -274,11 +274,12 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
  private:
   template <typename Indexer_t = Real *>
   PORTABLE_FORCEINLINE_FUNCTION Real GetIonizationState_(Indexer_t &&lambda) const {
-    if (variadic_utils::is_nullptr(lambda)) {
+    using namespace variadic_utils;
+    if (is_nullptr(lambda)) {
       PORTABLE_THROW_OR_ABORT(
           "StellarCollapse: lambda must contain Ye and 1 space for caching.\n");
     }
-    if constexpr (IndexableTypes::MeanIonizationState::IsOverloadedIn<Indexer_t>::value) {
+    if constexpr (is_indexable_v<IndexableTypes::MeanIonizationState, Indexer_t>) {
       return std::max(0.0, lambda[IndexableTypes::MeanIonizationState()]);
     } else {
       return std::max(0.0, lambda[t_.nlambda()]);

--- a/singularity-eos/eos/modifiers/zsplit_eos.hpp
+++ b/singularity-eos/eos/modifiers/zsplit_eos.hpp
@@ -228,7 +228,8 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
   int nlambda() const noexcept { return 1 + t_.nlambda(); }
   template <typename Indexable>
   static inline constexpr bool NeedsLambda() {
-    return std::is_same<Indexable, IndexableTypes::MeanIonizationState>::value;
+    return std::is_same<Indexable, IndexableTypes::MeanIonizationState>::value ||
+           T::template NeedsLambda<Indexable>();
   }
   static constexpr unsigned long PreferredInput() { return T::PreferredInput(); }
   static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
@@ -276,8 +277,7 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real GetIonizationState_(Indexer_t &&lambda) const {
     using namespace variadic_utils;
     if (is_nullptr(lambda)) {
-      PORTABLE_THROW_OR_ABORT(
-          "StellarCollapse: lambda must contain Ye and 1 space for caching.\n");
+      PORTABLE_THROW_OR_ABORT("ZSplitEOS: lambda must contain mean ionization state!\n");
     }
     if constexpr (is_indexable_v<Indexer_t, IndexableTypes::MeanIonizationState>) {
       return std::max(0.0, lambda[IndexableTypes::MeanIonizationState()]);

--- a/singularity-eos/eos/modifiers/zsplit_eos.hpp
+++ b/singularity-eos/eos/modifiers/zsplit_eos.hpp
@@ -279,7 +279,7 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
       PORTABLE_THROW_OR_ABORT(
           "StellarCollapse: lambda must contain Ye and 1 space for caching.\n");
     }
-    if constexpr (is_indexable_v<IndexableTypes::MeanIonizationState, Indexer_t>) {
+    if constexpr (is_indexable_v<Indexer_t, IndexableTypes::MeanIonizationState>) {
       return std::max(0.0, lambda[IndexableTypes::MeanIonizationState()]);
     } else {
       return std::max(0.0, lambda[t_.nlambda()]);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable(
   eos_infrastructure_tests
   catch2_define.cpp
   eos_unit_test_helpers.hpp
-  #test_eos_modifiers.cpp
+  test_eos_modifiers.cpp
   test_eos_modifiers_minimal.cpp
   test_eos_vector.cpp
   test_math_utils.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   test_math_utils.cpp
   test_variadic_utils.cpp
   test_bounds.cpp
+  test_indexable_types.cpp
   )
 
 add_executable(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable(
   eos_infrastructure_tests
   catch2_define.cpp
   eos_unit_test_helpers.hpp
-  test_eos_modifiers.cpp
+  #test_eos_modifiers.cpp
   test_eos_modifiers_minimal.cpp
   test_eos_vector.cpp
   test_math_utils.cpp

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -109,7 +109,7 @@ bool run_PTE_from_state(const int num_pte, EOS *v_EOS, const Real spvol_bulk,
   portableCopyToDevice(v_pressures, pressures.data(), bytes);
 
   // Allocate scratch space for the PTE solver
-  const int pte_solver_scratch_size = RequiredScratch(num_pte, false);
+  const int pte_solver_scratch_size = RequiredScratch(num_pte);
   const size_t scratch_bytes = pte_solver_scratch_size * sizeof(Real);
   Real *scratch = (double *)PORTABLE_MALLOC(scratch_bytes);
 

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -109,14 +109,13 @@ bool run_PTE_from_state(const int num_pte, EOS *v_EOS, const Real spvol_bulk,
   portableCopyToDevice(v_pressures, pressures.data(), bytes);
 
   // Allocate scratch space for the PTE solver
-  const int pte_solver_scratch_size = RequiredScratch(num_pte, true);
+  const int pte_solver_scratch_size = RequiredScratch(num_pte, false);
   const size_t scratch_bytes = pte_solver_scratch_size * sizeof(Real);
   Real *scratch = (double *)PORTABLE_MALLOC(scratch_bytes);
 
   // Allocate lambdas for all EOS and use an accessor to index into it
   const size_t lambda_bytes = num_pte * MAX_NUM_LAMBDAS * sizeof(Real *);
   Real *lambda_memory = (Real *)PORTABLE_MALLOC(lambda_bytes);
-  CacheAccessor lambdas = CacheAccessor(lambda_memory);
 
   // Solve the PTE system on device using a one-teration portableFor
   bool pte_converged;
@@ -126,6 +125,7 @@ bool run_PTE_from_state(const int num_pte, EOS *v_EOS, const Real spvol_bulk,
   Real *pte_u_out_d = (Real *)PORTABLE_MALLOC(real_bytes);
   portableFor(
       "Device execution of PTE Test", 0, 1, PORTABLE_LAMBDA(int i) {
+        CacheAccessor lambdas(lambda_memory);
         PTESolver_t<decltype(v_EOS), Real *, decltype(lambdas)> method(
             num_pte, v_EOS, vfrac_sum, sie_bulk, v_densities, v_vol_frac, v_sies,
             v_temperatures, v_pressures, lambdas, scratch);

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -126,7 +126,7 @@ bool run_PTE_from_state(const int num_pte, EOS *v_EOS, const Real spvol_bulk,
   Real *pte_u_out_d = (Real *)PORTABLE_MALLOC(real_bytes);
   portableFor(
       "Device execution of PTE Test", 0, 1, PORTABLE_LAMBDA(int i) {
-        PTESolver_t<decltype(v_EOS), Real *, Real **> method(
+        PTESolver_t<decltype(v_EOS), Real *, decltype(lambdas)> method(
             num_pte, v_EOS, vfrac_sum, sie_bulk, v_densities, v_vol_frac, v_sies,
             v_temperatures, v_pressures, lambdas, scratch);
         auto status = PTESolver(method);

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -109,7 +109,7 @@ bool run_PTE_from_state(const int num_pte, EOS *v_EOS, const Real spvol_bulk,
   portableCopyToDevice(v_pressures, pressures.data(), bytes);
 
   // Allocate scratch space for the PTE solver
-  const int pte_solver_scratch_size = RequiredScratch(num_pte);
+  const int pte_solver_scratch_size = RequiredScratch(num_pte, true);
   const size_t scratch_bytes = pte_solver_scratch_size * sizeof(Real);
   Real *scratch = (double *)PORTABLE_MALLOC(scratch_bytes);
 

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -114,7 +114,7 @@ bool run_PTE_from_state(const int num_pte, EOS *v_EOS, const Real spvol_bulk,
   Real *scratch = (double *)PORTABLE_MALLOC(scratch_bytes);
 
   // Allocate lambdas for all EOS and use an accessor to index into it
-  const size_t lambda_bytes = num_pte * MAX_NUM_LAMBDAS * sizeof(Real *);
+  const size_t lambda_bytes = num_pte * MAX_NUM_LAMBDAS * sizeof(Real);
   Real *lambda_memory = (Real *)PORTABLE_MALLOC(lambda_bytes);
 
   // Solve the PTE system on device using a one-teration portableFor

--- a/test/test_eos_ideal.cpp
+++ b/test/test_eos_ideal.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -20,6 +20,7 @@
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
 #include <ports-of-call/portable_errors.hpp>
+#include <singularity-eos/base/indexable_types.hpp>
 #include <singularity-eos/eos/eos.hpp>
 
 #ifndef CATCH_CONFIG_FAST_COMPILE
@@ -33,6 +34,9 @@ using singularity::IdealElectrons;
 using singularity::IdealGas;
 using singularity::MeanAtomicProperties;
 using EOS = singularity::Variant<IdealGas, IdealElectrons>;
+
+using singularity::IndexableTypes::MeanIonizationState;
+using Lambda_t = singularity::IndexerUtils::VariadicIndexer<MeanIonizationState>;
 
 SCENARIO("Ideal gas entropy", "[IdealGas][Entropy][GibbsFreeEnergy]") {
   GIVEN("Parameters for an ideal gas with entropy reference states") {
@@ -297,7 +301,8 @@ SCENARIO("Ideal electron gas", "[IdealGas][IdealEelctrons]") {
       portableReduce(
           "Check Cv vs Z", 2, N,
           PORTABLE_LAMBDA(const int i, int &nw) {
-            Real ll[1] = {static_cast<Real>(i)};
+            Lambda_t ll;
+            ll[MeanIonizationState()] = static_cast<Real>(i);
             Real Cv = eos.SpecificHeatFromDensityTemperature(rho, T, ll);
             if (!isClose(Cv, i * cv1, 1e-12)) nw += 1;
           },

--- a/test/test_eos_ideal.cpp
+++ b/test/test_eos_ideal.cpp
@@ -114,7 +114,9 @@ SCENARIO("Ideal gas mean atomic properties",
             Real T = 100.0 * i;
             Real Ab_eval = device_eos.MeanAtomicMassFromDensityTemperature(rho, T);
             Real Zb_eval = device_eos.MeanAtomicNumberFromDensityTemperature(rho, T);
+            bool needs_zbar = device_eos.NeedsLambda(MeanIonizationState());
             nw += !(isClose(Ab_eval, Abar, 1e-12)) + !(isClose(Zb_eval, Zbar, 1e-12));
+            nw += needs_zbar;
           },
           nwrong);
       REQUIRE(nwrong == 0);
@@ -305,6 +307,8 @@ SCENARIO("Ideal electron gas", "[IdealGas][IdealEelctrons]") {
             ll[MeanIonizationState()] = static_cast<Real>(i);
             Real Cv = eos.SpecificHeatFromDensityTemperature(rho, T, ll);
             if (!isClose(Cv, i * cv1, 1e-12)) nw += 1;
+            bool needs_zbar = eos.NeedsLambda(MeanIonizationState());
+            nw += !needs_zbar;
           },
           nwrong);
       THEN("The specific heat should scale linearly with the ionization state") {

--- a/test/test_eos_zsplit.cpp
+++ b/test/test_eos_zsplit.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2024. Triad National Security, LLC. All rights reserved.  This
+// © 2024-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -20,6 +20,7 @@
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
 #include <ports-of-call/portable_errors.hpp>
+#include <singularity-eos/base/indexable_types.hpp>
 #include <singularity-eos/eos/eos.hpp>
 
 #ifndef CATCH_CONFIG_FAST_COMPILE
@@ -34,6 +35,9 @@ using singularity::IdealGas;
 using singularity::MeanAtomicProperties;
 using singularity::ZSplitE;
 using singularity::ZSplitI;
+
+using singularity::IndexableTypes::MeanIonizationState;
+using Lambda_t = singularity::IndexerUtils::VariadicIndexer<MeanIonizationState>;
 
 using EOS =
     singularity::Variant<IdealGas, IdealElectrons, ZSplitI<IdealGas>, ZSplitE<IdealGas>>;
@@ -71,7 +75,8 @@ SCENARIO("ZSplit of Ideal Gas", "[ZSplit][IdealGas][IdealElectrons]") {
           "Zsplit check P and sie", 0, NZ,
           PORTABLE_LAMBDA(const int i, int &nw) {
             Real Z = zmin + dz * i;
-            Real lambda[1] = {Z};
+            Lambda_t lambda;
+            lambda[MeanIonizationState()] = Z;
 
             Real Pt = eos_t.PressureFromDensityTemperature(rho, temp, lambda);
             Real Pi = eos_zi.PressureFromDensityTemperature(rho, temp, lambda);

--- a/test/test_indexable_types.cpp
+++ b/test/test_indexable_types.cpp
@@ -1,0 +1,53 @@
+//------------------------------------------------------------------------------
+// © 2025. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//------------------------------------------------------------------------------
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-eos/base/indexable_types.hpp>
+
+#ifndef CATCH_CONFIG_FAST_COMPILE
+#define CATCH_CONFIG_FAST_COMPILE
+#include <catch2/catch_test_macros.hpp>
+#endif
+
+using namespace singularity::IndexerUtils;
+using namespace singularity::IndexableTypes;
+
+using Lambda_t = VariadicIndexer<MeanIonizationState, ElectronFraction, LogDensity>;
+
+SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer]") {
+  GIVEN("A variadic indexer, filled with indices 0, 1, 2") {
+    Lambda_t lambda;
+    for (std::size_t i = 0; i < Lambda_t::size(); ++i) {
+      lambda[i] = static_cast<Real>(i);
+    }
+    WHEN("We access by index") {
+      THEN("We get the expected index") {
+        for (std::size_t i = 0; i < Lambda_t::size(); ++i) {
+          Real val = lambda[i];
+          REQUIRE(val == static_cast<Real>(i));
+        }
+      }
+    }
+    WHEN("We access by name") {
+      Real Zbar = lambda[MeanIonizationState()];
+      Real Ye = lambda[ElectronFraction()];
+      Real lRho = lambda[LogDensity()];
+      THEN("We get the expected index") {
+        REQUIRE(Zbar == static_cast<Real>(0));
+        REQUIRE(Ye == static_cast<Real>(1));
+        REQUIRE(lRho == static_cast<Real>(2));
+      }
+    }
+  }
+}

--- a/test/test_pte.cpp
+++ b/test/test_pte.cpp
@@ -24,6 +24,7 @@
 #include <ports-of-call/portable_arrays.hpp>
 #include <pte_test_3mat_analytic.hpp>
 #include <pte_test_utils.hpp>
+#include <singularity-eos/base/indexable_types.hpp>
 #include <singularity-eos/closure/mixed_cell_models.hpp>
 #include <spiner/databox.hpp>
 
@@ -159,11 +160,7 @@ auto TestPTE(const std::string name, const std::size_t nscratch_vars,
   portableReduce(
       "PTE!", 0, NTRIAL,
       PORTABLE_LAMBDA(const int &t, std::size_t &ns) {
-        Real *lambda[NMAT];
-        for (int i = 0; i < NMAT; i++) {
-          lambda[i] = nullptr;
-        }
-
+        singularity::NullIndexer lambda;
         Indexer2D<decltype(rho_d)> rho(t, rho_d);
         Indexer2D<decltype(vfrac_d)> vfrac(t, vfrac_d);
         Indexer2D<decltype(sie_d)> sie(t, sie_d);

--- a/test/test_pte_2phase.cpp
+++ b/test/test_pte_2phase.cpp
@@ -163,10 +163,7 @@ int main(int argc, char *argv[]) {
 
     portableFor(
         "PTE!", 0, NTRIAL, PORTABLE_LAMBDA(const int &t) {
-          Real *lambda[NMAT];
-          for (int i = 0; i < NMAT; i++) {
-            lambda[i] = nullptr;
-          }
+          singularity::NullIndexer lambda;
 
           Indexer2D<decltype(rho_d)> rho(t, rho_d);
           Indexer2D<decltype(vfrac_d)> vfrac(t, vfrac_d);

--- a/test/test_pte_ideal.cpp
+++ b/test/test_pte_ideal.cpp
@@ -94,8 +94,8 @@ PORTABLE_INLINE_FUNCTION Real set_state(Real rho_nom, Real sie_nom, RealIndexer 
 template <typename EOS_Indexer_t>
 int ComparePTEs(EOS_Indexer_t eoss, const std::size_t NEOS, const std::size_t NTRIAL) {
   constexpr Real EPS = 1e-5;
-  const std::size_t nscratch_rt = PTESolverRhoTRequiredScratch(NEOS, false);
-  const std::size_t nscratch_pt = PTESolverPTRequiredScratch(NEOS, false);
+  const std::size_t nscratch_rt = PTESolverRhoTRequiredScratch(NEOS);
+  const std::size_t nscratch_pt = PTESolverPTRequiredScratch(NEOS);
   const Real rho_nom = 1.0;
   const Real sie_nom = 1.0;
 

--- a/test/test_pte_ideal.cpp
+++ b/test/test_pte_ideal.cpp
@@ -53,10 +53,6 @@ struct LambdaIndexerSingle {
   Real &operator[](const int i) { return z; }
   PORTABLE_FORCEINLINE_FUNCTION
   Real &operator[](const MeanIonizationState &s) { return z; }
-  PORTABLE_FORCEINLINE_FUNCTION
-  const Real &operator[](const int i) const { return z; }
-  PORTABLE_FORCEINLINE_FUNCTION
-  const Real &operator[](const MeanIonizationState &s) const { return z; }
   Real z = 0.9;
 };
 

--- a/test/test_pte_ideal.cpp
+++ b/test/test_pte_ideal.cpp
@@ -50,9 +50,13 @@ using EOS = Variant<IdealGas, IdealElectrons>;
 using singularity::IndexableTypes::MeanIonizationState;
 struct LambdaIndexerSingle {
   PORTABLE_FORCEINLINE_FUNCTION
-  Real &operator[](const int i) const { return z; }
+  Real &operator[](const int i) { return z; }
   PORTABLE_FORCEINLINE_FUNCTION
-  Real &operator[](const MeanIonizationState &s) const { return z; }
+  Real &operator[](const MeanIonizationState &s) { return z; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  const Real &operator[](const int i) const { return z; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  const Real &operator[](const MeanIonizationState &s) const { return z; }
   Real z = 0.9;
 };
 

--- a/test/test_pte_ideal.cpp
+++ b/test/test_pte_ideal.cpp
@@ -50,9 +50,9 @@ using EOS = Variant<IdealGas, IdealElectrons>;
 using singularity::IndexableTypes::MeanIonizationState;
 struct LambdaIndexerSingle {
   PORTABLE_FORCEINLINE_FUNCTION
-  Real &operator[](const int i) { return z; }
+  Real &operator[](const int i) const { return z; }
   PORTABLE_FORCEINLINE_FUNCTION
-  Real &operator[](const MeanIonizationState &s) { return z; }
+  Real &operator[](const MeanIonizationState &s) const { return z; }
   Real z = 0.9;
 };
 

--- a/test/test_pte_ideal.cpp
+++ b/test/test_pte_ideal.cpp
@@ -22,6 +22,8 @@
 // #include <ports-of-call/array.hpp>
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
+#include <singularity-eos/base/indexable_types.hpp>
+
 #include <singularity-eos/closure/mixed_cell_models.hpp>
 
 #include <singularity-eos/eos/eos_models.hpp>
@@ -45,12 +47,21 @@ using singularity::PTESolverRhoTRequiredScratch;
 using singularity::Variant;
 using EOS = Variant<IdealGas, IdealElectrons>;
 
+using singularity::IndexableTypes::MeanIonizationState;
+struct LambdaIndexerSingle {
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real &operator[](const int i) { return z; }
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real &operator[](const MeanIonizationState &s) { return z; }
+  Real z = 0.9;
+};
+
 struct LambdaIndexer {
   PORTABLE_FORCEINLINE_FUNCTION
-  Real *operator[](const int i) { return &z; }
+  auto &operator[](const int i) { return indexer; }
   PORTABLE_FORCEINLINE_FUNCTION
-  const Real *operator[](const int i) const { return &z; }
-  Real z = 0.9;
+  const auto &operator[](const int i) const { return indexer; }
+  LambdaIndexerSingle indexer;
 };
 
 template <typename RealIndexer, typename EOSIndexer>
@@ -83,8 +94,8 @@ PORTABLE_INLINE_FUNCTION Real set_state(Real rho_nom, Real sie_nom, RealIndexer 
 template <typename EOS_Indexer_t>
 int ComparePTEs(EOS_Indexer_t eoss, const std::size_t NEOS, const std::size_t NTRIAL) {
   constexpr Real EPS = 1e-5;
-  const std::size_t nscratch_rt = PTESolverRhoTRequiredScratch(NEOS);
-  const std::size_t nscratch_pt = PTESolverPTRequiredScratch(NEOS);
+  const std::size_t nscratch_rt = PTESolverRhoTRequiredScratch(NEOS, false);
+  const std::size_t nscratch_pt = PTESolverPTRequiredScratch(NEOS, false);
   const Real rho_nom = 1.0;
   const Real sie_nom = 1.0;
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

While integrating 3T into riot, I began to encounter scenarios where the `lambda` machinery of `singularity-eos` starts to become burdensome. In particular, the z-split modifier on top of (for example) a `SpinerEOS` means that both the base/underlying EOS and the modifier require `lambda` arguments. This is fine in principle; modifier lambda arguments get "appended" on to the back of the lambda and the code traverses through it like a stack.  However, given that type is erased, it can be difficult for a host code to keep track of what lambda argument goes where, or even if a lambda argument is needed.

This MR resolves this issue by the introduction of `IndexableTypes` which may be used in indexers for lambdas. Put simply, an `IndexableType` is an empty struct that can be used to name an index, like an enum, but more free-form. If you overload the `operator[]` function for a lambda indexer to accept an `IndexableType`, most EOS classes that expect `IndexableTypes` will be able to interact with it by name, rather than position in the lambda. For example, if you define:

```C++
class MyLambda_t {
 public:
  MyLambda_t() = default;
  PORTABLE_FORCEINLINE_FUNCTION
  Real &operator[](const std::size_t idx) {
    return data_[idx];
  }
  PORTABLE_FORCEINLINE_FUNCTION
  Real &operator[](const MeanIonizationState &zbar) {
    return data_[2];
  }
 private:
  std::array<Real, 3> data_;
};
```
then you would be able to interact with it as
```C++
MyLambda_t lambda;
lambda[MeanIonizationState()] = zbar;
Real P = eos.PressureFromDensityTemperature(rho, T, lambda);
```
integer and named indexes are interchange-able and backwards compatible, and I provide the ability to create new named types for custom EOS's as well as a convenience struct that automatically builds an indexer form a variadic list of named types. This machinery is all in the `singularity-eos/base/indexable_types.hpp` header.

I also introduce the function `NeedsLambda`, which is now exposed in the variant. This function takes an indexable type and returns true if that indexable type is needed by the class for a given lambda and false otherwise. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
