### PR TITLE
memory error in eospac wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [[PR444]](https://github.com/lanl/singularity-eos/pull/444) Add Z split modifier and electron ideal gas EOS
 
 ### Fixed (Repair bugs, etc)
+- [[PR473]](https://github.com/lanl/singularity-eos/pull/473) Resolve memory issue. Thanks for the catch, Richard!
 - [[PR468]](https://github.com/lanl/singularity-eos/pull/468) Move definition of def_en and def_v to an implementation file
 - [[PR466]](https://github.com/lanl/singularity-eos/pull/466) Fully thread lambda inputs through the PTE solver
 - [[PR449]](https://github.com/lanl/singularity-eos/pull/449) Ensure that DensityEnergyFromPressureTemperature works for all equations of state and is properly tested

--- a/eospac-wrapper/eospac_wrapper.cpp
+++ b/eospac-wrapper/eospac_wrapper.cpp
@@ -33,13 +33,14 @@ void eosGetMetadata(int matid, SesameMetadata &metadata, Verbosity eospacWarn) {
   EOS_INTEGER commentsType[1] = {EOS_Comment};
 
   constexpr int numInfoTables = NT;
-  constexpr int NI[] = {5, 11, 11};
+  constexpr int NI[] = {5, 11, 2};
   std::array<std::vector<EOS_INTEGER>, numInfoTables> infoItems = {
       std::vector<EOS_INTEGER>{EOS_Exchange_Coeff, EOS_Mean_Atomic_Mass,
                                EOS_Mean_Atomic_Num, EOS_Modulus, EOS_Normal_Density},
       std::vector<EOS_INTEGER>{EOS_Rmin, EOS_Rmax, EOS_Tmin, EOS_Tmax, EOS_Fmin, EOS_Fmax,
                                EOS_NR, EOS_NT, EOS_X_Convert_Factor, EOS_Y_Convert_Factor,
-                               EOS_F_Convert_Factor}};
+                               EOS_F_Convert_Factor},
+      std::vector<EOS_INTEGER>{EOS_Fmin, EOS_Fmax}};
   std::vector<EOS_REAL> infoVals[numInfoTables];
   for (int i = 0; i < numInfoTables; i++) {
     infoVals[i].resize(NI[i]);
@@ -67,8 +68,8 @@ void eosGetMetadata(int matid, SesameMetadata &metadata, Verbosity eospacWarn) {
   metadata.TMax = temperatureFromSesame(infoVals[1][3]);
   metadata.sieMin = sieFromSesame(infoVals[1][4]);
   metadata.sieMax = sieFromSesame(infoVals[1][5]);
-  metadata.PMin = pressureFromSesame(infoVals[2][4]);
-  metadata.PMax = pressureFromSesame(infoVals[2][5]);
+  metadata.PMin = pressureFromSesame(infoVals[2][0]);
+  metadata.PMax = pressureFromSesame(infoVals[2][1]);
   metadata.numRho = static_cast<int>(infoVals[1][6]);
   metadata.numT = static_cast<int>(infoVals[1][7]);
   metadata.rhoConversionFactor = infoVals[1][8];

--- a/eospac-wrapper/eospac_wrapper.cpp
+++ b/eospac-wrapper/eospac_wrapper.cpp
@@ -32,8 +32,8 @@ void eosGetMetadata(int matid, SesameMetadata &metadata, Verbosity eospacWarn) {
   EOS_INTEGER commentsHandle[1];
   EOS_INTEGER commentsType[1] = {EOS_Comment};
 
-  constexpr int numInfoTables = 2;
-  constexpr int NI[] = {5, 11};
+  constexpr int numInfoTables = NT;
+  constexpr int NI[] = {5, 11, 11};
   std::array<std::vector<EOS_INTEGER>, numInfoTables> infoItems = {
       std::vector<EOS_INTEGER>{EOS_Exchange_Coeff, EOS_Mean_Atomic_Mass,
                                EOS_Mean_Atomic_Num, EOS_Modulus, EOS_Normal_Density},

--- a/eospac-wrapper/eospac_wrapper.cpp
+++ b/eospac-wrapper/eospac_wrapper.cpp
@@ -1,7 +1,7 @@
 //======================================================================
 // sesame2spiner tool for converting eospac to spiner
 // Author: Jonah Miller (jonahm@lanl.gov)
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -465,10 +465,7 @@ PORTABLE_INLINE_FUNCTION void DavisReactants::DensityEnergyFromPressureTemperatu
     EOS_ERROR("DavisReactants::DensityEnergyFromPressureTemperature: "
               "Root find failed to find a solution given P, T\n");
   }
-  if (rho < 0.) {
-    EOS_ERROR("DavisReactants::DensityEnergyFromPressureTemperature: "
-              "Root find resulted in a negative density\n");
-  }
+  rho = std::max(0., rho);
   sie = InternalEnergyFromDensityTemperature(rho, temp);
 }
 
@@ -546,10 +543,7 @@ PORTABLE_INLINE_FUNCTION void DavisProducts::DensityEnergyFromPressureTemperatur
     EOS_ERROR("DavisProducts::DensityEnergyFromPressureTemperature: "
               "Root find failed to find a solution given P, T\n");
   }
-  if (rho < 0.) {
-    EOS_ERROR("DavisReactants::DensityEnergyFromPressureTemperature: "
-              "Root find resulted in a negative density\n");
-  }
+  rho = std::max(rho, 0.);
   sie = InternalEnergyFromDensityTemperature(rho, temp);
 }
 template <typename Indexer_t>


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Recently when I added some additional safety features to EOSPAC and sesame2spiner, I added a memory error. It appears it caused a segfault for @rbberger (and I'm not sure why it didn't cause issues until now). This MR resolves the memory issue.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
