### PR TITLE
Shrink the default variant

### DIFF
--- a/singularity-eos/eos/eos_type_lists.hpp
+++ b/singularity-eos/eos/eos_type_lists.hpp
@@ -49,11 +49,10 @@ using singularity::variadic_utils::transform_variadic_list;
 
 // all eos's
 static constexpr const auto full_eos_list =
-    tl<IdealGas, Gruneisen, Vinet, MGUsup, PowerMG, JWL, DavisReactants, DavisProducts,
-       StiffGas
+    tl<IdealGas, Gruneisen, Vinet, MGUsup, PowerMG, JWL, DavisReactants, DavisProducts
 #ifdef SINGULARITY_USE_V_AND_V_EOS
        ,
-       SAP_Polynomial, NobleAbel, CarnahanStarling
+       SAP_Polynomial, NobleAbel, CarnahanStarling, StiffGas
 #endif // SINGULARITY_USE_V_AND_V_EOS
 #ifdef SINGULARITY_USE_SPINER_WITH_HDF5
 #ifdef SINGULARITY_USE_HELMHOLTZ
@@ -61,28 +60,8 @@ static constexpr const auto full_eos_list =
        Helmholtz
 #endif // SINGULARITY_USE_HELMHOLTZ
        ,
-       SpinerEOSDependsRhoT, SpinerEOSDependsRhoSie, StellarCollapse
+       SpinerEOSDependsRhoT, SpinerEOSDependsRhoSie
 #endif // SINGULARITY_USE_SPINER_WITH_HDF5
-#ifdef SINGULARITY_USE_EOSPAC
-       ,
-       EOSPAC
-#endif // SINGULARITY_USE_EOSPAC
-       >{};
-// eos's that get relativistic modifier
-static constexpr const auto relativistic_eos_list =
-    tl<IdealGas
-#ifdef SINGULARITY_USE_SPINER_WITH_HDF5
-       ,
-       SpinerEOSDependsRhoT, SpinerEOSDependsRhoSie, StellarCollapse
-#endif // SINGULAIRTY_USE_SPINER_WITH_HDF5
-       >{};
-// eos's that get unit system modifier
-static constexpr const auto unit_system_eos_list =
-    tl<IdealGas
-#ifdef SPINER_USE_HDF
-       ,
-       SpinerEOSDependsRhoT, SpinerEOSDependsRhoSie, StellarCollapse
-#endif // SPINER_USE_HDF
 #ifdef SINGULARITY_USE_EOSPAC
        ,
        EOSPAC
@@ -90,38 +69,20 @@ static constexpr const auto unit_system_eos_list =
        >{};
 // modifiers that get applied to all eos's
 static constexpr const auto apply_to_all = al<ScaledEOS, ShiftedEOS>{};
-// variadic list of UnitSystem<T>'s
-static constexpr const auto unit_system =
-    transform_variadic_list(unit_system_eos_list, al<UnitSystem>{});
-// variadic list of Relativistic<T>'s
-static constexpr const auto relativistic =
-    transform_variadic_list(relativistic_eos_list, al<RelativisticEOS>{});
 // variadic list of eos's with shifted or scaled modifiers
-static constexpr const auto shifted_1 =
+static constexpr const auto shifted =
     transform_variadic_list(full_eos_list, al<ShiftedEOS>{});
 static constexpr const auto scaled_1 =
     transform_variadic_list(full_eos_list, al<ScaledEOS>{});
-// relativistic and unit system modifiers
-static constexpr const auto unit_or_rel =
-    singularity::variadic_utils::concat(unit_system, relativistic);
-// variadic list of eos with shifted, relativistic or unit system modifiers
-static constexpr const auto shifted_of_unit_or_rel =
-    transform_variadic_list(unit_or_rel, al<ShiftedEOS>{});
-// combined list of all shifted EOS
-static constexpr const auto shifted =
-    singularity::variadic_utils::concat(shifted_1, shifted_of_unit_or_rel);
-// variadic list of eos with scaled, relativistic or unit system modifiers
-static constexpr const auto scaled_of_unit_or_rel =
-    transform_variadic_list(unit_or_rel, al<ScaledEOS>{});
 // variadic list of Scaled<Shifted<T>>'s
 static constexpr const auto scaled_of_shifted =
     transform_variadic_list(shifted, al<ScaledEOS>{});
 // combined list of all scaled EOS
-static constexpr const auto scaled = singularity::variadic_utils::concat(
-    scaled_1, scaled_of_unit_or_rel, scaled_of_shifted);
+static constexpr const auto scaled =
+    singularity::variadic_utils::concat(scaled_1, scaled_of_shifted);
 // create combined list
 static constexpr const auto combined_list_1 =
-    singularity::variadic_utils::concat(full_eos_list, shifted, scaled, unit_or_rel);
+    singularity::variadic_utils::concat(full_eos_list, shifted, scaled);
 // make a ramped eos of everything
 static constexpr const auto ramped_all =
     transform_variadic_list(combined_list_1, al<BilinearRampEOS>{});

--- a/singularity-eos/eos/singularity_eos.cpp
+++ b/singularity-eos/eos/singularity_eos.cpp
@@ -170,6 +170,7 @@ int init_sg_SAP_Polynomial(const int matindex, EOS *eos, const double rho0,
 int init_sg_StiffGas(const int matindex, EOS *eos, const double gm1, const double Cv,
                      const double Pinf, const double qq, int const *const enabled,
                      double *const vals) {
+#if SINGULARITY_USE_V_AND_V_EOS
   assert(matindex >= 0);
   EOS eosi = SGAPPLYMODSIMPLE(StiffGas(gm1, Cv, Pinf, qq));
   if (enabled[3] == 1) {
@@ -179,6 +180,11 @@ int init_sg_StiffGas(const int matindex, EOS *eos, const double gm1, const doubl
   EOS eos_ = SGAPPLYMOD(StiffGas(gm1, Cv, Pinf, qq));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
+#else
+  PORTABLE_THROW_OR_ABORT("Stiff Gas not currently supported. Please build with "
+                          "-DSINGULARITY_USE_V_AND_V_EOS");
+  return 1;
+#endif // SINGULARITY_USE_V_AND_V_EOS
 }
 
 int init_sg_StiffGas(const int matindex, EOS *eos, const double gm1, const double Cv,

--- a/test/test_eos_modifiers.cpp
+++ b/test/test_eos_modifiers.cpp
@@ -60,46 +60,29 @@ using al = variadic_utils::adapt_list<Ts...>;
 using variadic_utils::transform_variadic_list;
 
 static constexpr const auto full_eos_list = tl<IdealGas>{};
-static constexpr const auto relativistic_eos_list = tl<IdealGas>{};
-static constexpr const auto unit_system_eos_list = tl<IdealGas>{};
-static constexpr const auto unit_system =
-    transform_variadic_list(unit_system_eos_list, al<UnitSystem>{});
+// modifiers that get applied to all eos's
+static constexpr const auto apply_to_all = al<ScaledEOS, ShiftedEOS>{};
 // variadic list of eos's with shifted or scaled modifiers
-static constexpr const auto shifted_1 =
+static constexpr const auto shifted =
     transform_variadic_list(full_eos_list, al<ShiftedEOS>{});
 static constexpr const auto scaled_1 =
     transform_variadic_list(full_eos_list, al<ScaledEOS>{});
-// variadic list of Relativistic<T>'s
-static constexpr const auto relativistic =
-    transform_variadic_list(relativistic_eos_list, al<RelativisticEOS>{});
-// relativistic and unit system modifiers
-static constexpr const auto unit_or_rel =
-    variadic_utils::concat(unit_system, relativistic);
-// variadic list of eos with shifted, relativistic or unit system modifiers
-static constexpr const auto shifted_of_unit_or_rel =
-    transform_variadic_list(unit_or_rel, al<ShiftedEOS>{});
-// combined list of all shifted EOS
-static constexpr const auto shifted =
-    variadic_utils::concat(shifted_1, shifted_of_unit_or_rel);
-// variadic list of eos with scaled, relativistic or unit system modifiers
-static constexpr const auto scaled_of_unit_or_rel =
-    transform_variadic_list(unit_or_rel, al<ScaledEOS>{});
 // variadic list of Scaled<Shifted<T>>'s
 static constexpr const auto scaled_of_shifted =
     transform_variadic_list(shifted, al<ScaledEOS>{});
 // combined list of all scaled EOS
 static constexpr const auto scaled =
-    variadic_utils::concat(scaled_1, scaled_of_unit_or_rel, scaled_of_shifted);
+    singularity::variadic_utils::concat(scaled_1, scaled_of_shifted);
 // create combined list
 static constexpr const auto combined_list_1 =
-    variadic_utils::concat(full_eos_list, shifted, scaled, unit_or_rel);
+    singularity::variadic_utils::concat(full_eos_list, shifted, scaled);
 // make a ramped eos of everything
 static constexpr const auto ramped_all =
     transform_variadic_list(combined_list_1, al<BilinearRampEOS>{});
 // final combined list
 static constexpr const auto combined_list =
-    variadic_utils::concat(combined_list_1, ramped_all);
-using EOS = typename decltype(tl_to_Variant(combined_list))::vt;
+    singularity::variadic_utils::concat(combined_list_1, ramped_all);
+
 #endif
 
 SCENARIO("EOS Builder and Modifiers", "[EOSBuilder][Modifiers][IdealGas]") {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This is a refactor intended to help with build times, especially on GPUs. A number of EOS's in the default variant are unused by the fortran codes. To my mind, this means they should be removed, as the C++ codes can implement their own variant.

I thus shrink the default variant significantly by removing:
- The relativistic eos modifier
- The unit system modifier
- The StellarCollapse EOS

I also move `StiffGas` behind the `SINGULARITY_USE_V_AND_V_EOS` flag.

@rbberger this may help with clang builds. I wanted to split this out from the relocatable-device-code MR because I think they're orthogonal changes and the relocatable device code MR is a bigger change.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
