### PR TITLE
fix kpt test and add a more extensive clang github-ci test suite

### DIFF
--- a/.github/workflows/tests_clang.yml
+++ b/.github/workflows/tests_clang.yml
@@ -1,0 +1,54 @@
+name: Tests Clang
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+    tests:
+      name: Extensive test suite with clang, no fortran or Kokkos
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v3
+          with:
+            submodules: recursive
+        - name: Set system to non-interactive mode
+          run: export DEBIAN_FRONTEND=noninteractive
+        - name: install dependencies
+          run: |
+            sudo apt-get update -y -qq
+            sudo apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages -qq build-essential libhdf5-serial-dev binutils-gold clang llvm
+            pip install numpy
+            pip install h5py
+        - name: build and run tests
+          run: |
+            mkdir -p bin
+            cd bin
+            ulimit -m unlimited
+            ulimit -v unlimited
+            mkdir -p ${HOME}/install
+            cmake -DCMAKE_INSTALL_PREFIX=${HOME}/install \
+                  -DCMAKE_CXX_COMPILER=clang++ \
+                  -DSINGULARITY_USE_FORTRAN=OFF \
+                  -DSINGULARITY_BUILD_FORTRAN_BACKEND=ON \
+                  -DSINGULARITY_USE_SPINER=ON \
+                  -DSINGULARITY_BUILD_TESTS=ON \
+                  -DSINGULARITY_BUILD_EXAMPLES=ON \
+                  -DSINGULARITY_BUILD_PYTHON=OFF \
+                  -DSINGULARITY_TEST_SESAME=OFF \
+                  -DSINGULARITY_USE_HELMHOLTZ=ON \
+                  -DSINGULARITY_TEST_HELMHOLTZ=ON \
+                  -DSINGULARITY_FORCE_SUBMODULE_MODE=ON \
+                  -DSINGULARITY_USE_V_AND_V_EOS=OFF \
+                  -DSINGULARITY_USE_KOKKOS=OFF \
+                  -DSINGULARITY_PLUGINS=$(pwd)/../example/plugin \
+                  -DCMAKE_LINKER=ld.gold \
+                  -DCMAKE_BUILD_TYPE=Release \
+                  ..
+            make -j4
+            make install
+            ctest --output-on-failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [[PR444]](https://github.com/lanl/singularity-eos/pull/444) Add Z split modifier and electron ideal gas EOS
 
 ### Fixed (Repair bugs, etc)
+- [[PR478]](https://github.com/lanl/singularity-eos/pull/478) Fix bug in KPT test. Add more extensive clang build to github CI matrix.
 - [[PR473]](https://github.com/lanl/singularity-eos/pull/473) Resolve memory issue. Thanks for the catch, Richard!
 - [[PR468]](https://github.com/lanl/singularity-eos/pull/468) Move definition of def_en and def_v to an implementation file
 - [[PR466]](https://github.com/lanl/singularity-eos/pull/466) Fully thread lambda inputs through the PTE solver

--- a/test/test_kpt_models.cpp
+++ b/test/test_kpt_models.cpp
@@ -112,166 +112,168 @@ SCENARIO("Testing the KPT framework") {
         THEN("The returned order should be equal to the true order") {
           array_compare(num, gibbs, phaseorder, order, order_true, "Gibbs", "phase");
         }
-      }
-      // create deltagibbs and fromphasetophase
+        // create deltagibbs and fromphasetophase
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::View<Real[mnum]> v_dgibbs("dgibbs");
-      auto dgibbs = Kokkos::create_mirror_view(v_dgibbs);
-      Kokkos::View<int[mnum]> v_fromto("fromto");
-      auto fromto = Kokkos::create_mirror_view(v_fromto);
+        Kokkos::View<Real[mnum]> v_dgibbs("dgibbs");
+        auto dgibbs = Kokkos::create_mirror_view(v_dgibbs);
+        Kokkos::View<int[mnum]> v_fromto("fromto");
+        auto fromto = Kokkos::create_mirror_view(v_fromto);
 #else
-      std::array<Real, mnum> dgibbs;
-      std::array<int, mnum> fromto;
-      auto v_dgibbs = dgibbs.data();
-      auto v_fromto = fromto.data();
+        std::array<Real, mnum> dgibbs;
+        std::array<int, mnum> fromto;
+        auto v_dgibbs = dgibbs.data();
+        auto v_fromto = fromto.data();
 #endif // PORTABILITY_STRATEGY_KOKKOS
-      int ik = 0;
-      for (int i = 0; i < num - 1; i++) {
-        for (int k = num - 1; k > i; k--) {
-          v_dgibbs[ik] = v_gibbs[v_order[i]] - v_gibbs[v_order[k]];
-          ik++;
+        int ik = 0;
+        for (int i = 0; i < num - 1; i++) {
+          for (int k = num - 1; k > i; k--) {
+            v_dgibbs[ik] = v_gibbs[v_order[i]] - v_gibbs[v_order[k]];
+            ik++;
+          }
         }
-      }
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::deep_copy(dgibbs, v_dgibbs);
+        Kokkos::deep_copy(dgibbs, v_dgibbs);
 #endif // PORTABILITY_STRATEGY_KOKKOS
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-      // Create device views for outputs and mirror those views on the host
-      Kokkos::View<Real[mnum]> v_logrates("LogRates");
-      auto h_logrates = Kokkos::create_mirror_view(v_logrates);
+        // Create device views for outputs and mirror those views on the host
+        Kokkos::View<Real[mnum]> v_logrates("LogRates");
+        auto h_logrates = Kokkos::create_mirror_view(v_logrates);
 #else
-      // Create arrays for the outputs and then pointers to those arrays that
-      // will be passed to the functions in place of the Kokkos views
-      std::array<Real, mnum> h_logrates;
-      // Just alias the existing pointers
-      auto v_logrates = h_logrates.data();
+        // Create arrays for the outputs and then pointers to those arrays that
+        // will be passed to the functions in place of the Kokkos views
+        std::array<Real, mnum> h_logrates;
+        // Just alias the existing pointers
+        auto v_logrates = h_logrates.data();
 #endif // PORTABILITY_STRATEGY_KOKKOS
 
-      WHEN("A LogRij(w,b,num,gibbs,order,fromto) lookup is performed") {
-        LogRatesCGModel(w, b, num, v_gibbs, v_order, v_logrates, v_fromto);
+        WHEN("A LogRij(w,b,num,gibbs,order,fromto) lookup is performed") {
+          LogRatesCGModel(w, b, num, v_gibbs, v_order, v_logrates, v_fromto);
 
-        std::cout << "LogRates obtained with LogRatesCGModel: " << std::endl;
-        for (int l = 0; l < mnum; l++) {
-          std::cout << "From phase i to phase k, ik ( x means 0x): " << v_fromto[l]
-                    << "   LogRik: " << v_logrates[l] << std::endl;
-        }
+          std::cout << "LogRates obtained with LogRatesCGModel: " << std::endl;
+          for (int l = 0; l < mnum; l++) {
+            std::cout << "From phase i to phase k, ik ( x means 0x): " << v_fromto[l]
+                      << "   LogRik: " << v_logrates[l] << std::endl;
+          }
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-        Kokkos::fence();
-        Kokkos::deep_copy(fromto, v_fromto);
-        Kokkos::deep_copy(h_logrates, v_logrates);
+          Kokkos::fence();
+          Kokkos::deep_copy(fromto, v_fromto);
+          Kokkos::deep_copy(h_logrates, v_logrates);
 #endif // PORTABILITY_STRATEGY_KOKKOS
 
-        THEN("The returned LogRij(w,b,gibbs,order) should be equal to the true value") {
-          array_compare(mnum, dgibbs, fromto, h_logrates, logrates_true, "DeltaGibbs",
-                        "FromTo");
-        }
-      }
+          THEN("The returned LogRij(w,b,gibbs,order) should be equal to the true value") {
+            array_compare(mnum, dgibbs, fromto, h_logrates, logrates_true, "DeltaGibbs",
+                          "FromTo");
+          }
 
-      constexpr Real logmts_true = -2234.69;
+          constexpr Real logmts_true = -2234.69;
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-      // Create Kokkos views on device for the input arrays
-      // Create host-side mirrors of the inputs
-      Kokkos::View<Real[num]> v_massfractions("massfractions");
-      auto massfractions = Kokkos::create_mirror_view(v_massfractions);
+          // Create Kokkos views on device for the input arrays
+          // Create host-side mirrors of the inputs
+          Kokkos::View<Real[num]> v_massfractions("massfractions");
+          auto massfractions = Kokkos::create_mirror_view(v_massfractions);
 #else
-      // Otherwise just create arrays to contain values and create pointers to
-      // be passed to the functions in place of the Kokkos views
-      std::array<Real, num> massfractions;
-      auto v_massfractions = massfractions.data();
+          // Otherwise just create arrays to contain values and create pointers to
+          // be passed to the functions in place of the Kokkos views
+          std::array<Real, num> massfractions;
+          auto v_massfractions = massfractions.data();
 #endif // PORTABILITY_STRATEGY_KOKKOS
 
-      // Populate the input arrays
-      portableFor(
-          "Initialize mass fractions", 0, 1, PORTABLE_LAMBDA(int i) {
-            v_massfractions[0] = 0.0;
-            v_massfractions[1] = 0.5;
-            v_massfractions[2] = 0.5;
-            v_massfractions[3] = 0.0;
-            v_massfractions[4] = 0.0;
-          });
+          // Populate the input arrays
+          portableFor(
+              "Initialize mass fractions", 0, 1, PORTABLE_LAMBDA(int i) {
+                v_massfractions[0] = 0.0;
+                v_massfractions[1] = 0.5;
+                v_massfractions[2] = 0.5;
+                v_massfractions[3] = 0.0;
+                v_massfractions[4] = 0.0;
+              });
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-      // copy the inputs
-      Kokkos::deep_copy(massfractions, v_massfractions);
+          // copy the inputs
+          Kokkos::deep_copy(massfractions, v_massfractions);
 #endif // PORTABILITY_STRATEGY_KOKKOS
 
-      Real logmts;
+          Real logmts;
 
-      WHEN("A LogMaxTimeStep(num,order,logrates) lookup is performed") {
-        logmts = LogMaxTimeStep(num, v_massfractions, v_order, v_logrates);
-        for (int l = 0; l < num; l++) {
-          std::cout << "Phase: " << l
-                    << "  initial mass fractions: " << v_massfractions[l] << std::endl;
-        }
-        std::cout << "Log(MaxTimeStep) from Rates obtained with CGModel: " << logmts
-                  << std::endl;
-        for (int l = 0; l < mnum; l++) {
-          std::cout << "From phase i to phase k, ik ( x means 0x): " << v_fromto[l]
-                    << "   Max mass fraction transfer: "
-                    << std::exp(logmts + v_logrates[l]) << std::endl;
-        }
+          WHEN("A LogMaxTimeStep(num,order,logrates) lookup is performed") {
+            logmts = LogMaxTimeStep(num, v_massfractions, v_order, v_logrates);
+            for (int l = 0; l < num; l++) {
+              std::cout << "Phase: " << l
+                        << "  initial mass fractions: " << v_massfractions[l]
+                        << std::endl;
+            }
+            std::cout << "Log(MaxTimeStep) from Rates obtained with CGModel: " << logmts
+                      << std::endl;
+            for (int l = 0; l < mnum; l++) {
+              std::cout << "From phase i to phase k, ik ( x means 0x): " << v_fromto[l]
+                        << "   Max mass fraction transfer: "
+                        << std::exp(logmts + v_logrates[l]) << std::endl;
+            }
 
-        THEN("The returned Log(MaxTimeStep) should be equal to the true value") {
-          CHECK(isClose(logmts, logmts_true));
-        }
-      }
+            THEN("The returned Log(MaxTimeStep) should be equal to the true value") {
+              CHECK(isClose(logmts, logmts_true));
+            }
 
-      // reset the input massfractions arrays
-      portableFor(
-          "Initialize mass fractions", 0, 1, PORTABLE_LAMBDA(int i) {
-            v_massfractions[0] = 0.2;
-            v_massfractions[1] = 0.0;
-            v_massfractions[2] = 0.1;
-            v_massfractions[3] = 0.3;
-            v_massfractions[4] = 0.4;
-          });
+            // reset the input massfractions arrays
+            portableFor(
+                "Initialize mass fractions", 0, 1, PORTABLE_LAMBDA(int i) {
+                  v_massfractions[0] = 0.2;
+                  v_massfractions[1] = 0.0;
+                  v_massfractions[2] = 0.1;
+                  v_massfractions[3] = 0.3;
+                  v_massfractions[4] = 0.4;
+                });
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-      // Create Kokkos views on device for the input arrays
-      // Create host-side mirrors
-      Kokkos::View<Real[num]> v_newmfs("newmassfractions");
-      auto newmassfractions = Kokkos::create_mirror_view(v_newmfs);
-      Kokkos::View<Real[mnum]> v_deltamfs("massfractiontransfers");
-      auto h_deltamfs = Kokkos::create_mirror_view(v_deltamfs);
+            // Create Kokkos views on device for the input arrays
+            // Create host-side mirrors
+            Kokkos::View<Real[num]> v_newmfs("newmassfractions");
+            auto newmassfractions = Kokkos::create_mirror_view(v_newmfs);
+            Kokkos::View<Real[mnum]> v_deltamfs("massfractiontransfers");
+            auto h_deltamfs = Kokkos::create_mirror_view(v_deltamfs);
 #else
-      // Otherwise just create arrays to contain values and create pointers to
-      // be passed to the functions in place of the Kokkos views
-      std::array<Real, num> newmassfractions;
-      auto v_newmfs = newmassfractions.data();
-      std::array<Real, mnum> h_deltamfs;
-      auto v_deltamfs = h_deltamfs.data();
+            // Otherwise just create arrays to contain values and create pointers to
+            // be passed to the functions in place of the Kokkos views
+            std::array<Real, num> newmassfractions;
+            auto v_newmfs = newmassfractions.data();
+            std::array<Real, mnum> h_deltamfs;
+            auto v_deltamfs = h_deltamfs.data();
 #endif // PORTABILITY_STRATEGY_KOKKOS
 
-      constexpr std::array<Real, num> newmassfractions_true{0., 0.800012617417208613,
-                                                            0.1999873825827914, 0., 0.};
-      constexpr std::array<Real, mnum> deltamfs_true{
-          0.3, 0., 0., 0., 0.4, 0., 0., 0., 0.2, 0.100012617417208613};
+            constexpr std::array<Real, num> newmassfractions_true{
+                0., 0.800012617417208613, 0.1999873825827914, 0., 0.};
+            constexpr std::array<Real, mnum> deltamfs_true{
+                0.3, 0., 0., 0., 0.4, 0., 0., 0., 0.2, 0.100012617417208613};
 
-      WHEN("A massfraction update with SmallStepMFUpdate is performed") {
-        SmallStepMFUpdate(logmts_true, num, v_massfractions, v_order, v_logrates,
-                          v_deltamfs, v_newmfs);
-        for (int l = 0; l < num; l++) {
-          std::cout << "Phase: " << v_order[l]
-                    << "  initial mass fractions: " << v_massfractions[v_order[l]]
-                    << std::endl;
-          std::cout << "         "
-                    << "   final mass fractions: " << v_newmfs[v_order[l]] << std::endl;
-        }
-        for (int l = 0; l < mnum; l++) {
-          std::cout << "From phase i to phase k, ik ( x means 0x): " << v_fromto[l]
-                    << "   Mass fraction transfer: " << v_deltamfs[l] << std::endl;
-        }
+            WHEN("A massfraction update with SmallStepMFUpdate is performed") {
+              SmallStepMFUpdate(logmts_true, num, v_massfractions, v_order, v_logrates,
+                                v_deltamfs, v_newmfs);
+              for (int l = 0; l < num; l++) {
+                std::cout << "Phase: " << v_order[l]
+                          << "  initial mass fractions: " << v_massfractions[v_order[l]]
+                          << std::endl;
+                std::cout << "         "
+                          << "   final mass fractions: " << v_newmfs[v_order[l]]
+                          << std::endl;
+              }
+              for (int l = 0; l < mnum; l++) {
+                std::cout << "From phase i to phase k, ik ( x means 0x): " << v_fromto[l]
+                          << "   Mass fraction transfer: " << v_deltamfs[l] << std::endl;
+              }
 #ifdef PORTABILITY_STRATEGY_KOKKOS
-        Kokkos::fence();
-        Kokkos::deep_copy(newmassfractions, v_newmfs);
-        Kokkos::deep_copy(h_deltamfs, v_deltamfs);
+              Kokkos::fence();
+              Kokkos::deep_copy(newmassfractions, v_newmfs);
+              Kokkos::deep_copy(h_deltamfs, v_deltamfs);
 #endif // PORTABILITY_STRATEGY_KOKKOS
-        THEN("The new mass fractions should be equal to the true values") {
-          array_compare(num, phaseorder, massfractions, newmassfractions,
-                        newmassfractions_true, "Phase", "old massfractions");
-          array_compare(mnum, dgibbs, fromto, h_deltamfs, deltamfs_true, "DeltaGibbs",
-                        "FromTo");
+              THEN("The new mass fractions should be equal to the true values") {
+                array_compare(num, phaseorder, massfractions, newmassfractions,
+                              newmassfractions_true, "Phase", "old massfractions");
+                array_compare(mnum, dgibbs, fromto, h_deltamfs, deltamfs_true,
+                              "DeltaGibbs", "FromTo");
+              }
+            }
+          }
         }
       }
     }

--- a/test/test_kpt_models.cpp
+++ b/test/test_kpt_models.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2024. Triad National Security, LLC. All rights reserved.  This
+// © 2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

When adding clang builds to the re-git CI, @rbberger noticed that some tests were failing in the KPT test suite. This appears to be because the test cases were not properly nested. I have resolved that issue.

I am not sure why clang catches this issue but gnu does not. Indeed, neither code calls it undefined behavior, although I think it is by the documentation of the catch2 library. To help us catch similar issues in the future, I also add a more extensive "pure clang" build to the github CI build matrix.

@rbberger you're probably the only one who needs to review. @aematts and @jhp-lanl pinging you so you're aware. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
