### PR TITLE
Remove mutable from spiner-eos and fillin docs a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR481]](https://github.com/lanl/singularity-eos/pull/481) Move mutable diagnostic variables in singularity-eos into optional indexable types in a lambda.
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/doc/sphinx/src/models.rst
+++ b/doc/sphinx/src/models.rst
@@ -622,6 +622,9 @@ which must be passed in the ``lambda`` parameter, e.g.,
   Real lambda[1] = {Z};
   Real P = eos.PressureFromDensityTemperature(rho, T, lambda);
 
+If you use the indexable types machinery, this is named
+``IndexableTypes::MeanIonizationState``.
+
 .. note::
 
   For now, the ideal electron gas is not in the default variant
@@ -1673,6 +1676,15 @@ an array of size 2 is passed in to the scalar call (or one per point
 for the vector call), the model will leverage this scratch space to
 cache initial guesses for root finds.
 
+.. note::
+
+  If you are using indexable types for your lambda, you may use
+  ``IndexableTypes::LogDensity`` and
+  ``IndexableTypes::LogTemperature`` for these cache
+  variables. Optionally, you may also expose
+  ``IndexableTypes::RootStatus`` and ``IndexableTypes::TableStatus``
+  for optional diagnostic variables used in root-finding.
+
 To avoid race conditions, at least one array should be allocated per
 thread. Depending on the call pattern, one per point may be best. In
 the vector case, one per point is necessary.
@@ -1952,6 +1964,12 @@ element of the ``lambda`` array contains the electron fraction. The
 first element is reserved for caching. It currently contains the
 log of the temperature, but this should not be assumed.
 
+.. note::
+
+  If you are using the indexable type machinery, you may use
+  ``IndexableTypes::ElectronFraction`` and
+  ``IndexableTypes::LogTemperature``.
+
 To avoid race conditions, at least one array should be allocated per
 thread. Depending on the call pattern, one per point may be best. In
 the vector case, one per point is necessary.
@@ -2068,6 +2086,13 @@ into the lambda:
   the lambda array.
 * ``Helmholtz::Lambda::lT`` indexes into the log temperature cache
   inside the lambda array.
+
+.. note::
+
+  If you are using the indexable types machinery, you may use
+  ``IndexableTypes::MeanAtomicMass``,
+  ``IndexableTypes::MeanAtomicNumber``, and
+  ``IndexableTypes::LogTemperature``.
 
 The degenerate electron term is computed via thermodynamic derivatives
 of the Helmholtz free energy (hence the name Helmholtz EOS). The free

--- a/doc/sphinx/src/modifiers.rst
+++ b/doc/sphinx/src/modifiers.rst
@@ -284,6 +284,9 @@ parameter via the lambda. For example:
   Real lambda[1] = {Z};
   Real Pe = electron_eos.PressureFromDensityTemperature(rho, temperature, lambda);
 
+If you use the indexable types infrastructure, the name is
+``IndexableTypes::MeanIonizationState``.
+
 .. warning::
 
   Several thermodynamic properties are approximated in the z-split

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -79,6 +79,8 @@ struct LogTemperature {};
 struct MeanAtomicMass {};
 struct MeanAtomicNumber {};
 struct ElectronFraction {};
+struct RootStatus {};
+struct TableStatus {};
 } // namespace IndexableTypes
 } // namespace singularity
 #endif // SINGULARITY_EOS_BASE_INDEXABLE_TYPES_

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -225,10 +225,6 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
     using namespace IndexableTypes;
     return std::is_same<T, LogDensity>::value || std::is_same<T, LogTemperature>::value;
   }
-  PORTABLE_INLINE_FUNCTION
-  RootFinding1D::Status rootStatus() const { return status_; }
-  PORTABLE_INLINE_FUNCTION
-  TableStatus tableStatus() const { return whereAmI_; }
   RootFinding1D::RootCounts counts;
   inline void Finalize();
   static std::string EosType() { return std::string("SpinerEOSDependsRhoT"); }
@@ -332,9 +328,6 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   int matid_;
   TableSplit split_;
   bool reproducible_;
-  // whereAmI_ and status_ used only for reporting. They are not thread-safe.
-  mutable TableStatus whereAmI_ = TableStatus::OnTable;
-  mutable RootFinding1D::Status status_ = RootFinding1D::Status::SUCCESS;
   static constexpr const Real ROOT_THRESH = 1e-14; // TODO: experiment
   static constexpr const Real SOFT_THRESH = 1e-8;
   DataStatus memoryStatus_ = DataStatus::Deallocated;
@@ -526,8 +519,6 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
     printf("%s\n\t%s\n\t%s%i\n", s1, s2, s3, matid_);
     return;
   }
-  PORTABLE_INLINE_FUNCTION
-  RootFinding1D::Status rootStatus() const { return status_; }
   RootFinding1D::RootCounts counts;
   static std::string EosType() { return std::string("SpinerEOSDependsRhoSie"); }
   static std::string EosPyType() { return EosType(); }
@@ -590,7 +581,6 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   TableSplit split_;
   MeanAtomicProperties AZbar_;
   bool reproducible_;
-  mutable RootFinding1D::Status status_;
   static constexpr const int _n_lambda = 1;
   static constexpr const char *_lambda_names[1] = {"log(rho)"};
   DataStatus memoryStatus_ = DataStatus::Deallocated;
@@ -667,7 +657,7 @@ inline SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string &filename, i
                                                   TableSplit split,
                                                   bool reproducibility_mode)
     : matid_(matid), split_(split), reproducible_(reproducibility_mode),
-      status_(RootFinding1D::Status::SUCCESS), memoryStatus_(DataStatus::OnHost) {
+      memoryStatus_(DataStatus::OnHost) {
 
   std::string matid_str = std::to_string(matid);
   hid_t file, matGroup, lTGroup, coldGroup;
@@ -712,7 +702,7 @@ inline SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string &filename,
                                                   TableSplit split,
                                                   bool reproducibility_mode)
     : split_(split), reproducible_(reproducibility_mode),
-      status_(RootFinding1D::Status::SUCCESS), memoryStatus_(DataStatus::OnHost) {
+      memoryStatus_(DataStatus::OnHost) {
 
   std::string matid_str;
   hid_t file, matGroup, lTGroup, subGroup, coldGroup;
@@ -1312,10 +1302,13 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lRhoFromPlT_(
   if (!variadic_utils::is_nullptr(lambda)) {
     IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
     IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
-  }
-  if (memoryStatus_ != DataStatus::OnDevice) {
-    status_ = status;
-    whereAmI_ = whereAmI;
+    if constexpr (variadic_utils::is_indexable_v<Indexer_t, IndexableTypes::RootStatus>) {
+      lambda[IndexableTypes::RootStatus()] = static_cast<Real>(status);
+    }
+    if constexpr (variadic_utils::is_indexable_v<Indexer_t,
+                                                 IndexableTypes::TableStatus>) {
+      lambda[IndexableTypes::TableStatus()] = static_cast<Real>(whereAmI);
+    }
   }
   return lRho;
 }
@@ -1377,13 +1370,14 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoSie_(
   if (!variadic_utils::is_nullptr(lambda)) {
     IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
     IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
+    if constexpr (variadic_utils::is_indexable_v<Indexer_t, IndexableTypes::RootStatus>) {
+      lambda[IndexableTypes::RootStatus()] = static_cast<Real>(status);
+    }
+    if constexpr (variadic_utils::is_indexable_v<Indexer_t,
+                                                 IndexableTypes::TableStatus>) {
+      lambda[IndexableTypes::TableStatus()] = static_cast<Real>(whereAmI);
+    }
   }
-#ifdef PORTABILITY_STRATEGY_NONE
-  if (memoryStatus_ != DataStatus::OnDevice) {
-    status_ = status;
-    whereAmI_ = whereAmI;
-  }
-#endif // PORTABILITY_STRATEGY_NONE
   return lT;
 }
 
@@ -1438,10 +1432,13 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoP_(
   if (!variadic_utils::is_nullptr(lambda)) {
     IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
     IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
-  }
-  if (memoryStatus_ != DataStatus::OnDevice) {
-    status_ = status;
-    whereAmI_ = whereAmI;
+    if constexpr (variadic_utils::is_indexable_v<Indexer_t, IndexableTypes::RootStatus>) {
+      lambda[IndexableTypes::RootStatus()] = static_cast<Real>(status);
+    }
+    if constexpr (variadic_utils::is_indexable_v<Indexer_t,
+                                                 IndexableTypes::TableStatus>) {
+      lambda[IndexableTypes::TableStatus()] = static_cast<Real>(whereAmI);
+    }
   }
   return lT;
 }
@@ -1530,11 +1527,6 @@ TableStatus SpinerEOSDependsRhoT::getLocDependsRhoSie_(const Real lRho,
   } else {
     whereAmI = TableStatus::OnTable;
   }
-#ifdef PORTABILITY_STRATEGY_NONE
-  if (memoryStatus_ != DataStatus::OnDevice) {
-    whereAmI_ = whereAmI;
-  }
-#endif // PORTABILITY_STRATEGY_NONE
   return whereAmI;
 }
 
@@ -1547,11 +1539,6 @@ SpinerEOSDependsRhoT::getLocDependsRhoT_(const Real lRho, const Real lT) const {
     whereAmI = TableStatus::OffTop;
   else
     whereAmI = TableStatus::OnTable;
-#ifdef PORTABILITY_STRATEGY_NONE
-  if (memoryStatus_ != DataStatus::OnDevice) {
-    whereAmI_ = whereAmI;
-  }
-#endif // PORTABILITY_STRATEGY_NONE
   return whereAmI;
 }
 
@@ -1559,7 +1546,7 @@ inline SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string &filenam
                                                       int matid, TableSplit split,
                                                       bool reproducibility_mode)
     : matid_(matid), split_(split), reproducible_(reproducibility_mode),
-      status_(RootFinding1D::Status::SUCCESS), memoryStatus_(DataStatus::OnHost) {
+      memoryStatus_(DataStatus::OnHost) {
 
   std::string matid_str = std::to_string(matid);
   hid_t file, matGroup, lTGroup, lEGroup;
@@ -1598,7 +1585,7 @@ inline SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string &filenam
                                                       TableSplit split,
                                                       bool reproducibility_mode)
     : split_(split), reproducible_(reproducibility_mode),
-      status_(RootFinding1D::Status::SUCCESS), memoryStatus_(DataStatus::OnHost) {
+      memoryStatus_(DataStatus::OnHost) {
 
   std::string matid_str;
   hid_t file, matGroup, lTGroup, lEGroup;
@@ -1983,6 +1970,7 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::lRhoFromPlT_(
     const Real P, const Real lT, Indexer_t &&lambda) const {
   const RootFinding1D::RootCounts *pcounts =
       (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
+  RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
   Real lRho;
   Real dPdRhoMax = dPdRhoMax_.interpToReal(lT);
   Real PMax = PlRhoMax_.interpToReal(lT);
@@ -2002,11 +1990,8 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::lRhoFromPlT_(
       }
     }
     const callable_interp::l_interp PFunc(dependsRhoT_.P, lT);
-    auto status = ROOT_FINDER(PFunc, P, lRhoGuess, lRhoMin_, lRhoMax_, robust::EPS(),
-                              robust::EPS(), lRho, pcounts);
-    if (memoryStatus_ != DataStatus::OnDevice) {
-      status_ = status;
-    }
+    status = ROOT_FINDER(PFunc, P, lRhoGuess, lRhoMin_, lRhoMax_, robust::EPS(),
+                         robust::EPS(), lRho, pcounts);
     if (status != RootFinding1D::Status::SUCCESS) {
 #if SPINER_EOS_VERBOSE
       std::stringstream errorMessage;
@@ -2022,6 +2007,9 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::lRhoFromPlT_(
   }
   if (!variadic_utils::is_nullptr(lambda)) {
     IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
+    if constexpr (variadic_utils::is_indexable_v<Indexer_t, IndexableTypes::RootStatus>) {
+      lambda[IndexableTypes::RootStatus()] = static_cast<Real>(status);
+    }
   }
   return lRho;
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@dholladay00 note that the `mutable` members in the `Spiner` equations of state might still cause problems. I don't know if this is happening, but it's about time we remove the undefined behavior.

The recent PR #470 that introduced indexable types suggests another way to retain diagnostic capability without relying on unsafe paradigms. I optionally add indexable types for the two diagnostic variables which were mutable. They can now optionally be written to the lambda if the lambda is overloaded for them. Unlike other variables, which have backwards compatibility with integer-based indexing, these diagnostics are *only* available if the lambda supports the indexable type for them. This reflects that this isn't really intended to be a public facing API--it's a diagnostic tool used for developers to debug.

I considered completely deleting the logic and just using print statements if we ever need this optionality again. But this seemed like a relatively simple, thread-safe way to stash information. So I went with that.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
