### PR TITLE
Move scratch_size and max_scratch_size into base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Infrastructure (changes irrelevant to downstream codes)
 - [[PR481]](https://github.com/lanl/singularity-eos/pull/481) Move mutable diagnostic variables in singularity-eos into optional indexable types in a lambda.
+- [[PR486]](https://github.com/lanl/singularity-eos/pull/486) Use default behavior for max_scratch_size and scratch_size in the eos base class
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -86,7 +86,9 @@ char *StrCat(char *destination, const char *source) {
   using EosBase<__VA_ARGS__>::EntropyFromDensityTemperature;                             \
   using EosBase<__VA_ARGS__>::EntropyFromDensityInternalEnergy;                          \
   using EosBase<__VA_ARGS__>::GibbsFreeEnergyFromDensityTemperature;                     \
-  using EosBase<__VA_ARGS__>::GibbsFreeEnergyFromDensityInternalEnergy;
+  using EosBase<__VA_ARGS__>::GibbsFreeEnergyFromDensityInternalEnergy;                  \
+  using EosBase<__VA_ARGS__>::scratch_size;                                              \
+  using EosBase<__VA_ARGS__>::max_scratch_size;
 
 // This macro adds these methods to a derived class. Due to scope,
 // these can't be implemented in the base class, unless we make
@@ -803,6 +805,14 @@ class EosBase {
 
   PORTABLE_INLINE_FUNCTION
   Real RhoPmin(const Real temp) const { return 0.0; }
+
+  static inline unsigned long scratch_size(const std::string method,
+                                           const unsigned int nelements) {
+    return 0;
+  }
+  static inline unsigned long max_scratch_size(const unsigned int nelements) {
+    return 0;
+  }
 
   // JMM: EOS's which encapsulate a mix or reactions may wish to vary
   // this.  For example, Helmholtz and StellarCollapse. This isn't the

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -810,9 +810,7 @@ class EosBase {
                                            const unsigned int nelements) {
     return 0;
   }
-  static inline unsigned long max_scratch_size(const unsigned int nelements) {
-    return 0;
-  }
+  static inline unsigned long max_scratch_size(const unsigned int nelements) { return 0; }
 
   // JMM: EOS's which encapsulate a mix or reactions may wish to vary
   // this.  For example, Helmholtz and StellarCollapse. This isn't the

--- a/singularity-eos/eos/eos_carnahan_starling.hpp
+++ b/singularity-eos/eos/eos_carnahan_starling.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/eos/eos_carnahan_starling.hpp
+++ b/singularity-eos/eos/eos_carnahan_starling.hpp
@@ -233,10 +233,6 @@ class CarnahanStarling : public EosBase<CarnahanStarling> {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     printf("Carnahan-Starling Parameters:\nGamma = %g\nCv    = %g\nb     = %g\nq     = "
            "%g\n",

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -170,10 +170,6 @@ class DavisReactants : public EosBase<DavisReactants> {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     static constexpr char s1[]{"DavisReactants Params: "};
     printf("%srho0:%e e0:%e P0:%e\nT0:%e A:%e B:%e\nC:%e G0:%e Z:%e\nalpha:%e "

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/eos/eos_electrons.hpp
+++ b/singularity-eos/eos/eos_electrons.hpp
@@ -199,10 +199,6 @@ class IdealElectrons : public EosBase<IdealElectrons> {
     return std::is_same<T, IndexableTypes::MeanIonizationState>::value;
   }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     printf("Ideal Electrons Parameters:\n");
     _AZbar.PrintParams();

--- a/singularity-eos/eos/eos_gruneisen.hpp
+++ b/singularity-eos/eos/eos_gruneisen.hpp
@@ -159,10 +159,6 @@ class Gruneisen : public EosBase<Gruneisen> {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     static constexpr char s1[]{"Gruneisen Params: "};
     printf("%s C0:%e s1:%e s2:%e s3:%e\n  G0:%e b:%e rho0:%e T0:%e\n  P0:%eCv:%e "

--- a/singularity-eos/eos/eos_helmholtz.hpp
+++ b/singularity-eos/eos/eos_helmholtz.hpp
@@ -469,10 +469,6 @@ class Helmholtz : public EosBase<Helmholtz> {
   static constexpr unsigned long PreferredInput() {
     return thermalqs::density | thermalqs::temperature;
   }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
 
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     printf("Helmholtz Parameters:\n"

--- a/singularity-eos/eos/eos_ideal.hpp
+++ b/singularity-eos/eos/eos_ideal.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/eos/eos_ideal.hpp
+++ b/singularity-eos/eos/eos_ideal.hpp
@@ -176,10 +176,6 @@ class IdealGas : public EosBase<IdealGas> {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     printf("Ideal Gas Parameters:\nGamma = %g\nCv    = %g\n", _gm1 + 1.0, _Cv);
     _AZbar.PrintParams();

--- a/singularity-eos/eos/eos_jwl.hpp
+++ b/singularity-eos/eos/eos_jwl.hpp
@@ -121,10 +121,6 @@ class JWL : public EosBase<JWL> {
                          Real &bmod, Real &dpde, Real &dvdt,
                          Indexer_t &&lambda = static_cast<Real *>(nullptr)) const;
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     static constexpr char s1[]{"JWL Params: "};
     printf("%sA:%e B:%e R1: %e\nR2:%e w:%e rho0:%e\nCv:%e\n", s1, _A, _B, _R1, _R2, _w,

--- a/singularity-eos/eos/eos_mgusup.hpp
+++ b/singularity-eos/eos/eos_mgusup.hpp
@@ -155,10 +155,6 @@ class MGUsup : public EosBase<MGUsup> {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     static constexpr char st[]{"MGUsup Params: "};
     printf("%s rho0:%e T0:%e Cs:%e s:%e\n  G0:%e Cv0:%e E0:%e S0:%e\n", st, _rho0, _T0,

--- a/singularity-eos/eos/eos_noble_abel.hpp
+++ b/singularity-eos/eos/eos_noble_abel.hpp
@@ -183,10 +183,6 @@ class NobleAbel : public EosBase<NobleAbel> {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     printf("Noble-Abel Parameters:\nGamma = %g\nCv    = %g\nb     = %g\nq     = "
            "%g\n",

--- a/singularity-eos/eos/eos_powermg.hpp
+++ b/singularity-eos/eos/eos_powermg.hpp
@@ -140,10 +140,6 @@ class PowerMG : public EosBase<PowerMG> {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     static constexpr char st[]{"PowerMG Params: "};
     printf("%s rho0:%e T0:%e G0:%e Cv0:%e E0:%e S0:%e Pmin:%e\n"

--- a/singularity-eos/eos/eos_sap_polynomial.hpp
+++ b/singularity-eos/eos/eos_sap_polynomial.hpp
@@ -189,10 +189,6 @@ class SAP_Polynomial : public EosBase<SAP_Polynomial> {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     printf("SAP_Polynomial EOS Parameters:\n");
     printf("    rho0  = %g\n", _rho0);

--- a/singularity-eos/eos/eos_spiner.hpp
+++ b/singularity-eos/eos/eos_spiner.hpp
@@ -192,10 +192,6 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   Real RhoPmin(const Real temp) const;
 
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   int matid() const { return matid_; }
   PORTABLE_FORCEINLINE_FUNCTION Real lRhoOffset() const { return lRhoOffset_; }
   PORTABLE_FORCEINLINE_FUNCTION Real lTOffset() const { return lTOffset_; }
@@ -471,10 +467,6 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
                          Indexer_t &&lambda = static_cast<Real *>(nullptr)) const;
 
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   int matid() const { return matid_; }
   PORTABLE_FORCEINLINE_FUNCTION Real lRhoOffset() const { return lRhoOffset_; }
   PORTABLE_FORCEINLINE_FUNCTION Real lTOffset() const { return lTOffset_; }

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -215,10 +215,6 @@ class StellarCollapse : public EosBase<StellarCollapse> {
   // Generic functions provided by the base class. These contain e.g. the vector
   // overloads that use the scalar versions declared here
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_FORCEINLINE_FUNCTION Real rhoMin() const { return rho_(lRhoMin_); }
   PORTABLE_FORCEINLINE_FUNCTION Real rhoMax() const { return rho_(lRhoMax_); }
   PORTABLE_FORCEINLINE_FUNCTION Real TMin() const { return T_(lTMin_); }

--- a/singularity-eos/eos/eos_stiff.hpp
+++ b/singularity-eos/eos/eos_stiff.hpp
@@ -169,10 +169,6 @@ class StiffGas : public EosBase<StiffGas> {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     printf("Stiff Gas Parameters:\nGamma = %g\nCv    = %g\nPinf  = %g\nq     = "
            "%g\n",

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -1310,13 +1310,13 @@ class Variant {
   }
 
   PORTABLE_INLINE_FUNCTION
-  unsigned long scratch_size(std::string method, unsigned int nelements) {
+  unsigned long scratch_size(const std::string method, const unsigned int nelements) {
     return mpark::visit(
         [&](const auto &eos) { return eos.scratch_size(method, nelements); }, eos_);
   }
 
   PORTABLE_INLINE_FUNCTION
-  unsigned long max_scratch_size(unsigned int nelements) {
+  unsigned long max_scratch_size(const unsigned int nelements) {
     return mpark::visit([&](const auto &eos) { return eos.max_scratch_size(nelements); },
                         eos_);
   }

--- a/singularity-eos/eos/eos_vinet.hpp
+++ b/singularity-eos/eos/eos_vinet.hpp
@@ -147,10 +147,6 @@ class Vinet : public EosBase<Vinet> {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   static constexpr unsigned long PreferredInput() { return _preferred_input; }
-  static inline unsigned long scratch_size(std::string method, unsigned int nelements) {
-    return 0;
-  }
-  static inline unsigned long max_scratch_size(unsigned int nelements) { return 0; }
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     static constexpr char st[]{"Vinet Params: "};
     printf("%s rho0:%e T0:%e B0:%e BP0:%e\n  A0:%e Cv0:%e E0:%e S0:%e\n"


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Moves the `scratch_size()` and `max_scratch_size()` from the EOS to the base class.

For almost all EOS, these are zero, and we don't need to keep duplicating this as we add EOS. It makes more sense to just add special versions for specific use cases.

I also made the inputs const for possible performance benefits

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- N/A Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- N/A Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
