### PR TITLE
Add some informational member functions for closure models

### DIFF
--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -216,7 +216,7 @@ class PTESolverBase {
                 const Real vfrac_tot, const Real sie_tot, const RealIndexer &rho_,
                 const RealIndexer &vfrac_, const RealIndexer &sie_,
                 const RealIndexer &temp_, const RealIndexer &press_,
-                LambdaIndexer &lambda_, Real *&scratch, Real Tnorm,
+                LambdaIndexer &lambda_, Real *scratch, Real Tnorm,
                 const MixParams &params = MixParams())
       : params_(params), nmat(nmats), neq(neqs), niter(0), vfrac_total(vfrac_tot),
         sie_total(sie_tot), eos(eos_), rho(rho_), vfrac(vfrac_), sie(sie_), temp(temp_),
@@ -602,6 +602,18 @@ class PTESolverRhoT
     vtemp = AssignIncrement(scratch, nmat);
   }
 
+  static inline std::string MethodType() {
+    return std::string("PTESolveRhoT");
+  }
+
+  // Create static member functions bound to the class for ease of use
+  static inline int RequiredScratch(const std::size_t nmat) {
+    return PTESolverRhoTRequiredScratch(nmat);
+  }
+  static inline size_t RequiredScratchInBytes(const std::size_t nmat) {
+    return PTESolverRhoTRequiredScratchInBytes(nmat);
+  }
+
   PORTABLE_INLINE_FUNCTION
   Real Init() {
     InitBase();
@@ -823,6 +835,18 @@ class PTESolverPT
       : mix_impl::PTESolverBase<EOSIndexer, RealIndexer, LambdaIndexer>(
             nmat, 2, eos, vfrac_tot, sie_tot, rho, vfrac, sie, temp, press, lambda,
             scratch, Tnorm, params) {}
+
+  static inline std::string MethodType() {
+    return std::string("PTESolverPT");
+  }
+
+  // Create a static member function bound to the class for ease of use
+  static inline int RequiredScratch(const std::size_t nmat) {
+    return PTESolverPTRequiredScratch(nmat);
+  }
+  static inline size_t RequiredScratchInBytes(const std::size_t nmat) {
+    return PTESolverPTRequiredScratchInBytes(nmat);
+  }
 
   PORTABLE_INLINE_FUNCTION
   Real Init() {
@@ -1068,6 +1092,18 @@ class PTESolverFixedT
     Tnorm = 1.0;
   }
 
+  static inline std::string MethodType() {
+    return std::string("PTESolverFixedT");
+  }
+
+  // Create a static member function bound to the class for ease of use
+  static inline int RequiredScratch(const std::size_t nmat) {
+    return PTESolverFixedTRequiredScratch(nmat);
+  }
+  static inline size_t RequiredScratchInBytes(const std::size_t nmat) {
+    return PTESolverFixedTRequiredScratchInBytes(nmat);
+  }
+
   PORTABLE_INLINE_FUNCTION
   Real Init() {
     // InitBase();
@@ -1272,6 +1308,18 @@ class PTESolverFixedP
     dpdT = AssignIncrement(scratch, nmat);
     vtemp = AssignIncrement(scratch, nmat);
     Pequil = P;
+  }
+
+  static inline std::string MethodType() {
+    return std::string("PTESolverFixedP");
+  }
+
+  // Create a static member function bound to the class for ease of use
+  static inline int RequiredScratch(const std::size_t nmat) {
+    return PTESolverFixedPRequiredScratch(nmat);
+  }
+  static inline size_t RequiredScratchInBytes(const std::size_t nmat) {
+    return PTESolverFixedPRequiredScratchInBytes(nmat);
   }
 
   PORTABLE_INLINE_FUNCTION
@@ -1508,6 +1556,18 @@ class PTESolverRhoU
     dtde = AssignIncrement(scratch, nmat);
     vtemp = AssignIncrement(scratch, nmat);
     utemp = AssignIncrement(scratch, nmat);
+  }
+
+  static inline std::string MethodType() {
+    return std::string("PTESolverRhoU");
+  }
+
+  // Create a static member function bound to the class for ease of use
+  static inline int RequiredScratch(const std::size_t nmat) {
+    return PTESolverRhoURequiredScratch(nmat);
+  }
+  static inline size_t RequiredScratchInBytes(const std::size_t nmat) {
+    return PTESolverRhoURequiredScratchInBytes(nmat);
   }
 
   PORTABLE_INLINE_FUNCTION


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This simply adds some convenience static member functions to the closure models. The `RequiredScratch` member functions avoid bugs associated with accidentally calling the wrong scratch calculation function for the wrong method, especially in templated code.

Honestly I would have preferred that these have been static member functions all along so that they're connected with the types, but I didn't delete the old functions to preserve backwards compatibility.

The `MethodType` member function is just for printing purposes, especially with an eye towards the python interface. I'm using it as part of my mixed EOS type where I want to differentiate types based on the closure model used.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- N/A Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
