### PR TITLE
[trivial] fix stellarcollapse2spiner in cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Added (new features/APIs/variables/...)
 
 ### Fixed (Repair bugs, etc)
-- [[PR496]](https://github.com/lanl/singularity-eos/pull/495) Fix bug related to MinimumTemperature and MinimumDensity in SpinerEOSDependsRhoSie
+- [[PR495]](https://github.com/lanl/singularity-eos/pull/495) Fix bug related to MinimumTemperature and MinimumDensity in SpinerEOSDependsRhoSie
+- [[PR496]](https://github.com/lanl/singularity-eos/pull/496) Re-enable stellarcollapse2spiner, which was disabled.
 
 ### Changed (changing behavior/API/variables/...)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,10 @@ if(SINGULARITY_BUILD_SESAME2SPINER)
   add_subdirectory(sesame2spiner)
 endif()
 
+if(SINGULARITY_BUILD_STELLARCOLLAPSE2SPINER)
+  add_subdirectory(stellarcollapse2spiner)
+endif()
+
 # Define the full version as a string macro
 target_compile_definitions(singularity-eos_Interface INTERFACE
     SINGULARITY_VERSION=\"${PROJECT_VERSION}\"

--- a/doc/sphinx/src/building.rst
+++ b/doc/sphinx/src/building.rst
@@ -773,3 +773,17 @@ portability strategies.
    $> spack build-env singularity-eos@main%gcc@12+hdf5+eospac+mpi+kokkos+kokkos-kernels+openmp^eospac@6.4.0 -- bash
    $> mkdir -p build_gpu_mpi ; cd build_gpu_mpi
    $> cmake .. --preset="kokkos_nogpu_with_testing"
+
+Some Recipes
+-------------
+
+- Building stellar collapse and stellarcollapse2spiner without pre-installing dependencies:
+
+.. code:: bash
+
+  git clone --recursive https://github.com/lanl/singularity-eos.git
+  mkdir -p singularity-eos/build
+  cd singularity-eos/build
+  cmake -DSINGULARITY_FORCE_SUBMODULE_MODE=ON -DSINGULARITY_USE_SPINER=ON -DSINGULARITY_USE_FORTRAN=OFF -DSINGULARITY_BUILD_CLOSURE=OFF -DSINGULARITY_USE_STELLAR_COLLAPSE=ON -DSINGULARITY_BUILD_STELLARCOLLAPSE2SPINER=ON -DSINGULARITY_USE_TRUE_LOG_GRIDDING=ON ..
+  make -j8
+


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

For whatever reason, the `stellarcollapse2spiner` option in `CMakeLists.txt` was missing. It must have been dropped during a rewrite. This re-enables it.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
