### PR TITLE
Move the binutils dependency into the cmake debug build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Date: 4/7/2025
 - [[PR491]](https://github.com/lanl/singularity-eos/pull/491) Fixed spackage logic to point at correct spiner version for piecewise grids
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR499]](https://github.com/lanl/singularity-eos/pull/499) Hide binutils behind cmake debug build
 - [[PR475]](https://github.com/lanl/singularity-eos/pull/475) Shrink the default variant. Notably moved Stiff Gas behind a flag.
 - [[PR487]](https://github.com/lanl/singularity-eos/pull/487) Added static member functions to closures for scratch size interrogation
 

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -150,6 +150,7 @@ class SingularityEos(CMakePackage, CudaPackage, ROCmPackage):
         when="+rocm",
     )
     depends_on("binutils@:2.39,2.42:+ld", when="build_type=Debug")
+    depends_on("binutils@:2.39,2.42:+ld", when="build_type=RelWithDebInfo")
 
 
     #TODO: do we need kokkos,kokkoskernels the exact same version?

--- a/spack-repo/packages/singularity-eos/package.py
+++ b/spack-repo/packages/singularity-eos/package.py
@@ -149,7 +149,7 @@ class SingularityEos(CMakePackage, CudaPackage, ROCmPackage):
         ),
         when="+rocm",
     )
-    depends_on("binutils@:2.39,2.42:+ld")
+    depends_on("binutils@:2.39,2.42:+ld", when="build_type=Debug")
 
 
     #TODO: do we need kokkos,kokkoskernels the exact same version?


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As suggested by @thenders10 and @jhp-lanl in support of SAP.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
