### PR TITLE
Add TableSplit parameter to Fortran interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [[PR496]](https://github.com/lanl/singularity-eos/pull/496) Re-enable stellarcollapse2spiner, which was disabled.
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR502]](https://github.com/lanl/singularity-eos/pull/502) Expose split tables to Fortran interface
 
 ### Infrastructure (changes irrelevant to downstream codes)
 

--- a/singularity-eos/eos/singularity_eos.cpp
+++ b/singularity-eos/eos/singularity_eos.cpp
@@ -298,46 +298,60 @@ int init_sg_Helmholtz(const int matindex, EOS *eos, const char *filename, const 
 #endif
 
 int init_sg_SpinerDependsRhoT(const int matindex, EOS *eos, const char *filename,
-                              const int matid, int const *const enabled,
-                              double *const vals) {
+                              const int matid, const TableSplit split,
+                              int const *const enabled, double *const vals) {
   assert(matindex >= 0);
-  EOS eosi = SGAPPLYMODSIMPLE(SpinerEOSDependsRhoT(std::string(filename), matid));
+  EOS eosi = SGAPPLYMODSIMPLE(SpinerEOSDependsRhoT(std::string(filename), matid, split));
   if (enabled[3] == 1) {
     singularity::pAlpha2BilinearRampParams(eosi, vals[2], vals[3], vals[4], vals[2],
                                            vals[3], vals[4], vals[5]);
   }
-  EOS eos_ = SGAPPLYMOD(SpinerEOSDependsRhoT(std::string(filename), matid));
+  EOS eos_ = SGAPPLYMOD(SpinerEOSDependsRhoT(std::string(filename), matid, split));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 
 int init_sg_SpinerDependsRhoT(const int matindex, EOS *eos, const char *filename,
+                              const int matid, const TableSplit split) {
+  return init_sg_SpinerDependsRhoT(matindex, eos, filename, matid, split, def_en, def_v);
+}
+
+int init_sg_SpinerDependsRhoT(const int matindex, EOS *eos, const char *filename,
                               const int matid) {
-  return init_sg_SpinerDependsRhoT(matindex, eos, filename, matid, def_en, def_v);
+  return init_sg_SpinerDependsRhoT(matindex, eos, filename, matid, TableSplit::Total);
 }
 
 int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filename,
-                                const int matid, int const *const enabled,
-                                double *const vals) {
+                                const int matid, const TableSplit split,
+                                int const *const enabled, double *const vals) {
   assert(matindex >= 0);
-  EOS eosi = SGAPPLYMODSIMPLE(SpinerEOSDependsRhoSie(std::string(filename), matid));
+  EOS eosi = SGAPPLYMODSIMPLE(
+      SpinerEOSDependsRhoSie(std::string(filename), matid, split));
   if (enabled[3] == 1) {
     singularity::pAlpha2BilinearRampParams(eosi, vals[2], vals[3], vals[4], vals[2],
                                            vals[3], vals[4], vals[5]);
   }
-  EOS eos_ = SGAPPLYMOD(SpinerEOSDependsRhoSie(std::string(filename), matid));
+  EOS eos_ = SGAPPLYMOD(SpinerEOSDependsRhoSie(std::string(filename), matid, split));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
+
+int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filename,
+                                const int matid, const TableSplit split) {
+  return init_sg_SpinerDependsRhoSie(
+      matindex, eos, filename, matid, split, def_en, def_v);
+}
+
 int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filename,
                                 const int matid) {
-  return init_sg_SpinerDependsRhoSie(matindex, eos, filename, matid, def_en, def_v);
+  return init_sg_SpinerDependsRhoSie(matindex, eos, filename, matid, TableSplit::Total);
 }
 #endif
 
 #ifdef SINGULARITY_USE_EOSPAC
-int init_sg_eospac(const int matindex, EOS *eos, const int id, double *const eospac_vals,
-                   int const *const enabled, double *const vals) {
+int init_sg_eospac(const int matindex, EOS *eos, const int id, const TableSplit split,
+                   double *const eospac_vals, int const *const enabled,
+                   double *const vals) {
 
   using namespace EospacWrapper;
   assert(matindex >= 0);
@@ -349,23 +363,26 @@ int init_sg_eospac(const int matindex, EOS *eos, const int id, double *const eos
   bool linear_interp = eospac_vals[5];
 
   EOS eosi = SGAPPLYMODSIMPLE(
-      EOSPAC(id, invert_at_setup = invert_at_setup, insert_data = insert_data,
-             monotonicity = monotonicity, apply_smoothing = apply_smoothing,
-             apply_splitting = apply_splitting, linear_interp = linear_interp));
+      EOSPAC(id, split, invert_at_setup = invert_at_setup,
+             insert_data = insert_data, monotonicity = monotonicity,
+             apply_smoothing = apply_smoothing, apply_splitting = apply_splitting,
+             linear_interp = linear_interp));
   if (enabled[3] == 1) {
     singularity::pAlpha2BilinearRampParams(eosi, vals[2], vals[3], vals[4], vals[2],
                                            vals[3], vals[4], vals[5]);
   }
   EOS eos_ = SGAPPLYMOD(
-      EOSPAC(id, invert_at_setup = invert_at_setup, insert_data = insert_data,
-             monotonicity = monotonicity, apply_smoothing = apply_smoothing,
-             apply_splitting = apply_splitting, linear_interp = linear_interp));
+      EOSPAC(id, split, invert_at_setup = invert_at_setup,
+             insert_data = insert_data, monotonicity = monotonicity,
+             apply_smoothing = apply_smoothing, apply_splitting = apply_splitting,
+             linear_interp = linear_interp));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
+
 int init_sg_eospac(const int matindex, EOS *eos, const int id,
-                   double *const eospac_vals) {
-  return init_sg_eospac(matindex, eos, id, eospac_vals, def_en, def_v);
+                   const TableSplit split, double *const eospac_vals) {
+  return init_sg_eospac(matindex, eos, id, split, eospac_vals, def_en, def_v);
 }
 #endif // SINGULARITY_USE_EOSPAC
 

--- a/singularity-eos/eos/singularity_eos.cpp
+++ b/singularity-eos/eos/singularity_eos.cpp
@@ -325,8 +325,8 @@ int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filena
                                 const int matid, const TableSplit split,
                                 int const *const enabled, double *const vals) {
   assert(matindex >= 0);
-  EOS eosi = SGAPPLYMODSIMPLE(
-      SpinerEOSDependsRhoSie(std::string(filename), matid, split));
+  EOS eosi =
+      SGAPPLYMODSIMPLE(SpinerEOSDependsRhoSie(std::string(filename), matid, split));
   if (enabled[3] == 1) {
     singularity::pAlpha2BilinearRampParams(eosi, vals[2], vals[3], vals[4], vals[2],
                                            vals[3], vals[4], vals[5]);
@@ -338,8 +338,8 @@ int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filena
 
 int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filename,
                                 const int matid, const TableSplit split) {
-  return init_sg_SpinerDependsRhoSie(
-      matindex, eos, filename, matid, split, def_en, def_v);
+  return init_sg_SpinerDependsRhoSie(matindex, eos, filename, matid, split, def_en,
+                                     def_v);
 }
 
 int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filename,
@@ -363,25 +363,23 @@ int init_sg_eospac(const int matindex, EOS *eos, const int id, const TableSplit 
   bool linear_interp = eospac_vals[5];
 
   EOS eosi = SGAPPLYMODSIMPLE(
-      EOSPAC(id, split, invert_at_setup = invert_at_setup,
-             insert_data = insert_data, monotonicity = monotonicity,
-             apply_smoothing = apply_smoothing, apply_splitting = apply_splitting,
-             linear_interp = linear_interp));
+      EOSPAC(id, split, invert_at_setup = invert_at_setup, insert_data = insert_data,
+             monotonicity = monotonicity, apply_smoothing = apply_smoothing,
+             apply_splitting = apply_splitting, linear_interp = linear_interp));
   if (enabled[3] == 1) {
     singularity::pAlpha2BilinearRampParams(eosi, vals[2], vals[3], vals[4], vals[2],
                                            vals[3], vals[4], vals[5]);
   }
   EOS eos_ = SGAPPLYMOD(
-      EOSPAC(id, split, invert_at_setup = invert_at_setup,
-             insert_data = insert_data, monotonicity = monotonicity,
-             apply_smoothing = apply_smoothing, apply_splitting = apply_splitting,
-             linear_interp = linear_interp));
+      EOSPAC(id, split, invert_at_setup = invert_at_setup, insert_data = insert_data,
+             monotonicity = monotonicity, apply_smoothing = apply_smoothing,
+             apply_splitting = apply_splitting, linear_interp = linear_interp));
   eos[matindex] = eos_.GetOnDevice();
   return 0;
 }
 
-int init_sg_eospac(const int matindex, EOS *eos, const int id,
-                   const TableSplit split, double *const eospac_vals) {
+int init_sg_eospac(const int matindex, EOS *eos, const int id, const TableSplit split,
+                   double *const eospac_vals) {
   return init_sg_eospac(matindex, eos, id, split, eospac_vals, def_en, def_v);
 }
 #endif // SINGULARITY_USE_EOSPAC

--- a/singularity-eos/eos/singularity_eos.f90
+++ b/singularity-eos/eos/singularity_eos.f90
@@ -212,11 +212,11 @@ module singularity_eos
 
   interface
     integer(kind=c_int) function &
-      init_sg_SpinerDependsRhoT(matindex, eos, filename, id, sg_mods_enabled, &
-                                sg_mods_values) &
+      init_sg_SpinerDependsRhoT(matindex, eos, filename, id, split, &
+                                sg_mods_enabled, sg_mods_values) &
       bind(C, name='init_sg_SpinerDependsRhoT')
       import
-      integer(c_int), value, intent(in)      :: matindex, id
+      integer(c_int), value, intent(in)      :: matindex, id, split
       type(c_ptr), value, intent(in)         :: eos
       character(kind=c_char), intent(in)     :: filename(*)
       type(c_ptr), value, intent(in)         :: sg_mods_enabled, sg_mods_values
@@ -225,11 +225,11 @@ module singularity_eos
 
   interface
     integer(kind=c_int) function &
-      init_sg_SpinerDependsRhoSie(matindex, eos, filename, id, &
+      init_sg_SpinerDependsRhoSie(matindex, eos, filename, id, split, &
                                   sg_mods_enabled, sg_mods_values) &
       bind(C, name='init_sg_SpinerDependsRhoSie')
       import
-      integer(c_int), value, intent(in)      :: matindex, id
+      integer(c_int), value, intent(in)      :: matindex, id, split
       type(c_ptr), value, intent(in)         :: eos
       character(kind=c_char), intent(in)     :: filename(*)
       type(c_ptr), value, intent(in)         :: sg_mods_enabled, sg_mods_values
@@ -241,11 +241,11 @@ module singularity_eos
 #ifdef SINGULARITY_USE_EOSPAC
   interface
     integer(kind=c_int) function &
-      init_sg_eospac(matindex, eos, id, eospac_opts_values, sg_mods_enabled, &
+      init_sg_eospac(matindex, eos, id, split, eospac_opts_values, sg_mods_enabled, &
                      sg_mods_values) &
       bind(C, name='init_sg_eospac')
       import
-      integer(c_int), value, intent(in) :: matindex, id
+      integer(c_int), value, intent(in) :: matindex, id, split
       type(c_ptr), value, intent(in)    :: eos
       type(c_ptr), value, intent(in)    :: sg_mods_enabled, sg_mods_values
       type(c_ptr), value, intent(in)    :: eospac_opts_values
@@ -644,7 +644,7 @@ contains
 #endif
 ! SINGULARITY_USE_HELMHOLTZ
 
-  integer function init_sg_SpinerDependsRhoT_f(matindex, eos, filename, id, &
+  integer function init_sg_SpinerDependsRhoT_f(matindex, eos, filename, id, split, &
                                                sg_mods_enabled, &
                                                sg_mods_values) &
     result(err)
@@ -652,43 +652,51 @@ contains
     type(sg_eos_ary_t), intent(in)            :: eos
     character(len=*, kind=c_char), intent(in) :: filename
     integer(c_int), intent(inout)             :: id
+    integer(c_int), optional, value, intent(in)                        :: split
     integer(kind=c_int), dimension(:), target, optional, intent(inout) :: sg_mods_enabled
     real(kind=8), dimension(:), target, optional, intent(inout)        :: sg_mods_values
     ! local vars
     integer(kind=c_int), target, dimension(4) :: sg_mods_enabled_use
     real(kind=8), target, dimension(6)        :: sg_mods_values_use
+    integer(c_int)                            :: split_use
 
     sg_mods_enabled_use = 0
     sg_mods_values_use = 0.d0
+    split_use = 0
     if(present(sg_mods_enabled)) sg_mods_enabled_use = sg_mods_enabled
     if(present(sg_mods_values)) sg_mods_values_use = sg_mods_values
+    if(present(split)) split_use = split
 
     err = init_sg_SpinerDependsRhoT(matindex-1, eos%ptr,&
-                                    trim(filename)//C_NULL_CHAR, id, &
+                                    trim(filename)//C_NULL_CHAR, id, split_use, &
                                     c_loc(sg_mods_enabled_use), &
                                     c_loc(sg_mods_values_use))
   end function init_sg_SpinerDependsRhoT_f
 
-  integer function init_sg_SpinerDependsRhoSie_f(matindex, eos, filename, id, &
+  integer function init_sg_SpinerDependsRhoSie_f(matindex, eos, filename, id, split, &
                                                  sg_mods_enabled, &
                                                  sg_mods_values) &
     result(err)
     integer(c_int), value, intent(in)         :: matindex, id
     type(sg_eos_ary_t), intent(in)            :: eos
     character(len=*, kind=c_char), intent(in) :: filename
+    integer(c_int), optional, value, intent(in)                        :: split
     integer(kind=c_int), dimension(:), target, optional, intent(inout) :: sg_mods_enabled
     real(kind=8), dimension(:), target, optional, intent(inout)        :: sg_mods_values
     ! local vars
     integer(kind=c_int), target, dimension(4) :: sg_mods_enabled_use
     real(kind=8), target, dimension(6)        :: sg_mods_values_use
+    integer(c_int)                            :: split_use
 
     sg_mods_enabled_use = 0
     sg_mods_values_use = 0.d0
+    split_use = 0
     if(present(sg_mods_enabled)) sg_mods_enabled_use = sg_mods_enabled
     if(present(sg_mods_values)) sg_mods_values_use = sg_mods_values
+    if(present(split)) split_use = split
 
     err = init_sg_SpinerDependsRhoSie(matindex-1, eos%ptr,&
-                                      trim(filename)//C_NULL_CHAR, id, &
+                                      trim(filename)//C_NULL_CHAR, id, split_use, &
                                       c_loc(sg_mods_enabled_use), &
                                       c_loc(sg_mods_values_use))
   end function init_sg_SpinerDependsRhoSie_f
@@ -696,11 +704,12 @@ contains
 ! SINGULARITY_USE_SPINER_WITH_HDF5
 
 #ifdef SINGULARITY_USE_EOSPAC
-  integer function init_sg_eospac_f(matindex, eos, id, eospac_opts_values, &
+  integer function init_sg_eospac_f(matindex, eos, id, split, eospac_opts_values, &
                                     sg_mods_enabled, sg_mods_values) &
     result(err)
     integer(c_int), value, intent(in) :: matindex, id
     type(sg_eos_ary_t), intent(in)    :: eos
+    integer(c_int), optional, value, intent(in)                        :: split
     real(kind=8),        dimension(:), target, optional, intent(inout) :: eospac_opts_values
     integer(kind=c_int), dimension(:), target, optional, intent(inout) :: sg_mods_enabled
     real(kind=8),        dimension(:), target, optional, intent(inout) :: sg_mods_values
@@ -709,15 +718,18 @@ contains
     integer(kind=c_int), target, dimension(4) :: sg_mods_enabled_use
     real(kind=8), target, dimension(6)        :: sg_mods_values_use
     real(kind=8), target, dimension(6)        :: eospac_opts_values_use
+    integer(c_int)                            :: split_use
 
     sg_mods_enabled_use = 0
     sg_mods_values_use = 0.d0
     eospac_opts_values_use = 0.d0
+    split_use = 0
     if(present(eospac_opts_values)) eospac_opts_values_use = eospac_opts_values
     if(present(sg_mods_enabled)) sg_mods_enabled_use = sg_mods_enabled
     if(present(sg_mods_values)) sg_mods_values_use = sg_mods_values
+    if(present(split)) split_use = split
 
-    err = init_sg_eospac(matindex-1, eos%ptr, id, c_loc(eospac_opts_values_use), &
+    err = init_sg_eospac(matindex-1, eos%ptr, id, split, c_loc(eospac_opts_values_use), &
                          c_loc(sg_mods_enabled_use), c_loc(sg_mods_values_use))
   end function init_sg_eospac_f
 #endif

--- a/singularity-eos/eos/singularity_eos.hpp
+++ b/singularity-eos/eos/singularity_eos.hpp
@@ -16,8 +16,10 @@
 #define _SINGULARITY_EOS_EOS_SINGULARITY_EOS_HPP_
 
 #include <singularity-eos/eos/eos.hpp>
+#include <singularity-eos/base/constants.hpp>
 
 using singularity::EOS;
+using singularity::TableSplit;
 
 #if defined(__cplusplus)
 extern "C" {
@@ -76,17 +78,19 @@ int init_sg_Helmholtz(const int matindex, EOS *eos, const char *filename, const 
 #endif
 
 int init_sg_SpinerDependsRhoT(const int matindex, EOS *eos, const char *filename,
-                              const int id, int const *const enabled, double *const vals);
+                              const int id, const TableSplit split,
+                              int const *const enabled, double *const vals);
 
 int init_sg_SpinerDependsRhoSie(const int matindex, EOS *eos, const char *filename,
-                                const int id, int const *const enabled,
-                                double *const vals);
+                                const int id, const TableSplit split,
+                                int const *const enabled, double *const vals);
 #endif
 
 #ifdef SINGULARITY_USE_EOSPAC
 // capitalize? eospaceos Eospac Eospaceos EOSPAC EOSPACeos?
-int init_sg_eospac(const int matindex, EOS *eos, const int id, double *const eospac_vals,
-                   int const *const enabled, double *const vals);
+int init_sg_eospac(const int matindex, EOS *eos, const int id, const TableSplit split,
+                   double *const eospac_vals, int const *const enabled,
+                   double *const vals);
 #endif // SINGULARITY_USE_EOSPAC
 
 int get_sg_PressureFromDensityInternalEnergy(int matindex, EOS *eos, const double *rhos,

--- a/singularity-eos/eos/singularity_eos.hpp
+++ b/singularity-eos/eos/singularity_eos.hpp
@@ -15,8 +15,8 @@
 #ifndef _SINGULARITY_EOS_EOS_SINGULARITY_EOS_HPP_
 #define _SINGULARITY_EOS_EOS_SINGULARITY_EOS_HPP_
 
-#include <singularity-eos/eos/eos.hpp>
 #include <singularity-eos/base/constants.hpp>
+#include <singularity-eos/eos/eos.hpp>
 
 using singularity::EOS;
 using singularity::TableSplit;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->
Add TableSplit parameter to Spiner and EOSPAC EOS initializers to Fortran interface

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
This pull request introduces a `TableSplit` parameter to the initialization functions for Spiner EOS (both `SpinerEOSDependsRhoT` and `SpinerEOSDependsRhoSie`) and EOSPAC EOS models in the Fortran interface.

The `TableSplit` parameter has been integrated into:
- C++ functions:
    - `init_sg_SpinerDependsRhoT`
    - `init_sg_SpinerDependsRhoSie`
    - `init_sg_eospac`
- Corresponding Fortran interface functions:
    - `init_sg_SpinerDependsRhoT_f`
    - `init_sg_SpinerDependsRhoSie_f`
    - `init_sg_eospac_f`

For backward compatibility, overloaded versions of the C++ functions have been added that default to `TableSplit::Total` when the `split` parameter is not provided. Similarly, the Fortran interface functions now treat the `split` argument as optional, defaulting to a value that corresponds to `TableSplit::Total`.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
