### PR TITLE
rename LogType::TRUE to LogType::DOUBLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added (new features/APIs/variables/...)
 
 ### Fixed (Repair bugs, etc)
+- [[PR505]](https://github.com/lanl/singularity-eos/pull/505) rename LogType::TRUE to LogType::DOUBLE
 - [[PR495]](https://github.com/lanl/singularity-eos/pull/495) Fix bug related to MinimumTemperature and MinimumDensity in SpinerEOSDependsRhoSie
 - [[PR496]](https://github.com/lanl/singularity-eos/pull/496) Re-enable stellarcollapse2spiner, which was disabled.
 

--- a/singularity-eos/base/fast-math/logs.hpp
+++ b/singularity-eos/base/fast-math/logs.hpp
@@ -1,5 +1,5 @@
 //======================================================================
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/base/fast-math/logs.hpp
+++ b/singularity-eos/base/fast-math/logs.hpp
@@ -63,7 +63,7 @@ namespace singularity {
 namespace FastMath {
 
 // TODO(JMM): switch from preprocessor macros to CMake generated C++
-enum LogType { SINGLE = -1, TRUE = 0, NQT1 = 1, NQT2 = 2 };
+enum LogType { SINGLE = -1, DOUBLE = 0, NQT1 = 1, NQT2 = 2 };
 namespace Settings {
 #ifdef SINGULARITY_USE_TRUE_LOG_GRIDDING
 constexpr bool TRUE_LOGS = true;
@@ -91,7 +91,7 @@ constexpr bool NQT_O1 = true;
 constexpr bool NQT_O1 = false;
 #endif // SINGULARITY_NQT_O1
 constexpr LogType log_type = (TRUE_LOGS && FP32)   ? LogType::SINGLE
-                             : (TRUE_LOGS && FP64) ? LogType::TRUE
+                             : (TRUE_LOGS && FP64) ? LogType::DOUBLE
                              : NQT_O1              ? LogType::NQT1
                                                    : LogType::NQT2;
 } // namespace Settings


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

A downstream user pointed out that `TRUE` is sometimes defined as a preprocessor macro by (leaky) libraries. This eliminates potential overlap with that macro in our enum.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
