### PR TITLE
[WIP] pte example and robustness fix

### DIFF
--- a/doc/sphinx/src/using-closures.rst
+++ b/doc/sphinx/src/using-closures.rst
@@ -17,6 +17,9 @@ compute the pressure response of the flow and how to partition the volume and
 energy between the individual materials. In this situation, one must decide how
 to compute thermodynamic quantities in that cell for each material.
 
+For an example of how to use the PTE solvers, see
+``examples/pte_2mat.cpp`` in the ``examples`` folder.
+
 Governing Equations and Assumptions
 ------------------------------------
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -21,6 +21,12 @@ if (SINGULARITY_USE_SPINER_WITH_HDF5)
   add_executable(eos_grid eos_grid.cpp)
   target_link_libraries(eos_grid PRIVATE
     singularity-eos::singularity-eos)
+  add_executable(map_pt_space map_pt_space.cpp)
+  target_link_libraries(map_pt_space PRIVATE
+    singularity-eos::singularity-eos)
+  add_executable(pte_2mat pte_2mat.cpp)
+  target_link_libraries(pte_2mat PRIVATE
+    singularity-eos::singularity-eos)
 endif()
 
 if(SINGULARITY_USE_EOSPAC AND SINGULARITY_USE_SPINER_WITH_HDF5)

--- a/example/map_pt_space.cpp
+++ b/example/map_pt_space.cpp
@@ -1,0 +1,275 @@
+//------------------------------------------------------------------------------
+// © 2025. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//------------------------------------------------------------------------------
+
+// C headers
+#include <cmath>
+#include <cstdio>
+
+// C++ headers
+#include <iostream>
+#include <memory>
+#include <string>
+
+// This library contains portable utilities
+#include <ports-of-call/portability.hpp>
+#include <ports-of-call/portable_errors.hpp>
+
+// This contains useful tools for preventing things like divide by zero
+#include <singularity-eos/base/robust_utils.hpp>
+// 1D root finding
+#include <singularity-eos/base/root-finding-1d/root_finding.hpp>
+// Needed to import the eos models
+#include <singularity-eos/eos/eos.hpp>
+
+// This library contains the spiner table object, which we will use to
+// store our output
+#include <spiner/databox.hpp>
+#include <spiner/interpolation.hpp>
+
+// These are the specializations of spiner we will use
+using DataBox = Spiner::DataBox<Real>;
+using RegularGrid1D = Spiner::RegularGrid1D<Real>;
+using Spiner::DBDeleter;
+
+// Number of equations of state to use, always 2
+constexpr std::size_t NEOS = 2;
+
+// Set the EOS you want to use here.
+using EOS = singularity::SpinerEOSDependsRhoT;
+
+int main(int argc, char *argv[]) {
+  if (argc < 6) {
+    std::cerr << "Usage: " << argv[0]
+              << " residual_savename rhobar1 rhobar2 sietot nvfrac eosargs..."
+              << std::endl;
+    std::exit(1);
+  }
+
+  // This is needed for Kokkos
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  Kokkos::initialize();
+#endif
+  {
+    // File we'll save the residual map to, in ascii. P/T trajectories will be printed to
+    // to stdout
+    const std::string savename = argv[1];
+    // alpha rho for each material where here alpha is volume
+    // fraction and rho is microphysical material density.
+    const Real rhobar1 = atof(argv[2]);
+    const Real rhobar2 = atof(argv[3]);
+    // total specific internal energy in the problem.
+    const Real sietot = atof(argv[4]);
+    // number of vfrac points
+    const std::size_t nvfrac = atoi(argv[5]);
+
+    // Below are the arguments for an individual equation of
+    // state. Here I'm assuming SpinerEOSDependsRhoT but you could
+    // modify for your needs.
+    const std::string materialsfile = argv[6];
+    const int matids[] = {atoi(argv[7]), atoi(argv[8])};
+
+    // Now let's load up the EOS's.
+    EOS eos1 = EOS(materialsfile, matids[0]);
+    EOS eos2 = EOS(materialsfile, matids[1]);
+
+    // The total bulk density
+    const Real rhotot = rhobar1 + rhobar2;
+    const Real utot = rhotot * sietot;
+
+    // We will be walking through volume fractions so let's grid that
+    // up using a Spiner RegularGrid1D. This is the grid of alpha1s. alpha2 = 1 - alpha1.
+    constexpr Real lvfrac_min = -5;
+    constexpr Real lvfrac_max = -0.5;
+    RegularGrid1D lvfracs(lvfrac_min, lvfrac_max, nvfrac);
+
+    // We will be doing root finds in T space so we need to know what
+    // our bounds are. There is often a minimum temperature for an EOS
+    // but not a maximum.
+    const Real Tmin = std::max(eos1.MinimumTemperature(), eos2.MinimumTemperature());
+    const Real Tmax = 1e10; // change this if needed
+
+    // We also want to store quantities of interest as we walk the volume fractions
+    // This is a way of managing databoxes so that memory is automatically managed
+    // Temperature
+    std::unique_ptr<DataBox, DBDeleter> pTs(
+        new DataBox(Spiner::AllocationTarget::Device, nvfrac));
+    DataBox Ts = *pTs; // A shallow coppy of pTs. Unmanaged memory.
+    // Pressure for materials 1 and 2
+    std::unique_ptr<DataBox, DBDeleter> pPs(
+        new DataBox(Spiner::AllocationTarget::Device, nvfrac, NEOS));
+    DataBox Ps = *pPs;
+    // vfrac, energy, and pressure residuals for the trajectory
+    std::unique_ptr<DataBox, DBDeleter> pTrajRes(
+        new DataBox(Spiner::AllocationTarget::Device, nvfrac, 3));
+    DataBox trajRes = *pTrajRes;
+
+    // We also need to ensure whatever internal tabulated data for
+    // each EOS is available on device.
+    eos1 = eos1.GetOnDevice();
+    eos2 = eos2.GetOnDevice();
+
+    // Ok let's walk the grid. We will do so on device with a portableFor loop
+    portableFor(
+        "Compute P and T for each alpha", 0, nvfrac, PORTABLE_LAMBDA(const int i) {
+          // volume fractions
+          const Real lvfrac = lvfracs.x(i);
+          const Real vfrac = std::pow(10., lvfrac);
+          const Real alpha1 = vfrac;
+          const Real alpha2 = 1. - vfrac;
+
+          // microphysical densities
+          Real rho1 = singularity::robust::ratio(rhobar1, alpha1);
+          Real rho2 = singularity::robust::ratio(rhobar2, alpha2);
+          const Real Tguess = 1500; // just an initial guess
+
+          // solve for the temperature such that sum of internal
+          // energies is the total energy given microphysical densities rho
+          auto fu = [=](const Real T) {
+            return rhobar1 * eos1.InternalEnergyFromDensityTemperature(rho1, T) +
+                   rhobar2 * eos2.InternalEnergyFromDensityTemperature(rho2, T);
+          };
+          // sets the T variable by reference
+          auto root_status = RootFinding1D::regula_falsi(fu, utot, Tguess, Tmin, Tmax,
+                                                         1e-16, 1e-16, Ts(i));
+          if (root_status != RootFinding1D::Status::SUCCESS) {
+            printf("# Root finder failed! "
+                   "alpha1 alpha2, rho1, rho2, sie1(rho1,Tguess), sie2(rho2,Tguess) sietot = "
+                   "%.14e %.14e %.14e %.14e %.14e %.14e %.14e\n",
+                   alpha1, alpha2, rho1, rho2,
+                   eos1.InternalEnergyFromDensityTemperature(rho1, Tguess),
+                   eos2.InternalEnergyFromDensityTemperature(rho2, Tguess),
+                   sietot);
+            Ts(i) = Ps(i, 0) = Ps(i, 1) = -1;
+            trajRes(i, 0) = trajRes(i, 1) = trajRes(i, 2) = -1;
+          } else {
+            // compute the pressures
+            Ps(i, 0) = eos1.PressureFromDensityTemperature(rho1, Ts(i));
+            Ps(i, 1) = eos2.PressureFromDensityTemperature(rho2, Ts(i));
+            
+            trajRes(i, 0) = alpha1 + alpha2 - 1.0;
+
+            const Real u1 = rhobar1 * eos1.InternalEnergyFromDensityTemperature(rho1, Ts(i));
+            const Real u2 = rhobar2 * eos2.InternalEnergyFromDensityTemperature(rho2, Ts(i));
+            trajRes(i, 1) = singularity::robust::ratio(u1 + u2 - utot, utot);
+            trajRes(i, 2) = singularity::robust::ratio(Ps(i, 1) - Ps(i, 0), utot);
+
+          }
+        });
+    // wait for completion
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+    Kokkos::fence();
+#endif
+
+    // Copy the Ts array to host
+    std::unique_ptr<DataBox, DBDeleter> pTs_h(
+        new DataBox(Spiner::AllocationTarget::Host, nvfrac));
+    DataBox Ts_h = *pTs_h;
+    portableCopyToHost(Ts_h.data(), Ts.data(), Ts.sizeBytes());
+
+    // Get max temperature achieved. Note this could have been done in
+    // a single step via a portableReduce, but we split it out for clarity.
+    Real Tmax_walked = Ts_h.max();
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+    Kokkos::fence();
+#endif
+
+    // Let's make a T grid
+    const Real nT = nvfrac + 1;
+    
+    RegularGrid1D gTs(Tmin, Tmax_walked, nT);
+
+    // Now we can do one more loop where we compute the energy and
+    // pressure residuals as a function of T and alpha
+    std::unique_ptr<DataBox, DBDeleter> p_residuals(
+        new DataBox(Spiner::AllocationTarget::Device, nT, nvfrac, NEOS));
+    DataBox residuals = *p_residuals;
+
+    portableFor(
+        "Compute residual", 0, nT, 0, nvfrac, PORTABLE_LAMBDA(const int j, const int i) {
+          // Temperature
+          const Real T = gTs.x(j);
+
+          // volume fractions
+          const Real lvfrac = lvfracs.x(i);
+          const Real vfrac = std::pow(10., lvfrac);
+          const Real alpha1 = vfrac;
+          const Real alpha2 = 1. - vfrac;
+
+          // microphysical densities
+          Real rho1 = singularity::robust::ratio(rhobar1, alpha1);
+          Real rho2 = singularity::robust::ratio(rhobar2, alpha2);
+
+          const Real u1 = rhobar1 * eos1.InternalEnergyFromDensityTemperature(rho1, T);
+          const Real u2 = rhobar2 * eos2.InternalEnergyFromDensityTemperature(rho2, T);
+          residuals(j, i, 0) = u1 + u2 - utot, utot;
+
+          const Real P1 = eos1.PressureFromDensityTemperature(rho1, T);
+          const Real P2 = eos2.PressureFromDensityTemperature(rho2, T);
+          residuals(j, i, 1) = P1 - P2;
+        });
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+    Kokkos::fence();
+#endif
+
+    // Now we need to copy all of this data to host so we can output it
+    std::unique_ptr<DataBox, DBDeleter> pPs_h(
+        new DataBox(Spiner::AllocationTarget::Host, nvfrac, NEOS));
+    auto Ps_h = *pPs_h;
+    portableCopyToHost(Ps_h.data(), Ps.data(), Ps.sizeBytes());
+
+    std::unique_ptr<DataBox, DBDeleter> pTrajRes_h(
+        new DataBox(Spiner::AllocationTarget::Host, nvfrac, 3));
+    auto trajRes_h = *pTrajRes_h;
+    portableCopyToHost(trajRes_h.data(), trajRes.data(), trajRes.sizeBytes());
+
+    std::unique_ptr<DataBox, DBDeleter> p_residuals_h(
+        new DataBox(Spiner::AllocationTarget::Host, nT, nvfrac, NEOS));
+    auto residuals_h = *p_residuals_h;
+    portableCopyToHost(residuals_h.data(), residuals.data(), residuals.sizeBytes());
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+    Kokkos::fence();
+#endif
+
+    FILE *file = fopen(savename.c_str(), "w");
+    PORTABLE_REQUIRE(file != nullptr, "Unable to open file");
+    // Now lets save the residuals
+    fprintf(file, "# j i T alpha_1 res_sie res_P\n");
+    for (std::size_t j = 0; j < nT; ++j) {
+      for (std::size_t i = 0; i < nvfrac; ++i) {
+        Real lvfrac = lvfracs.x(i);
+        Real vfrac = std::pow(10.,lvfrac);
+        fprintf(file, "%ld %ld %.14e %.14e %.14e %.14e\n", j, i, gTs.x(j), vfrac,
+                residuals_h(j, i, 0), residuals_h(j, i, 1));
+      }
+    }
+    fclose(file);
+
+    printf("# sie and P residuals normalized by total energy\n");
+    printf("# i alpha_1 T P_1 P_2 res_alpha res_sie res_P\n");
+    for (std::size_t i = 0; i < nvfrac; ++i) {
+      Real lvfrac = lvfracs.x(i);
+      Real vfrac = std::pow(10.,lvfrac);
+      printf("%ld %.14e %.14e %.14e %.14e %.14e %.14e %.14e\n", i, vfrac, Ts_h(i), Ps_h(i, 0),
+             Ps_h(i, 1), trajRes(i, 0), trajRes(i, 1), trajRes(i, 2));
+    }
+
+    eos1.Finalize();
+    eos2.Finalize();
+  }
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  Kokkos::finalize();
+#endif
+  return 0;
+}

--- a/example/map_pt_space.cpp
+++ b/example/map_pt_space.cpp
@@ -144,26 +144,27 @@ int main(int argc, char *argv[]) {
                                                          1e-16, 1e-16, Ts(i));
           if (root_status != RootFinding1D::Status::SUCCESS) {
             printf("# Root finder failed! "
-                   "alpha1 alpha2, rho1, rho2, sie1(rho1,Tguess), sie2(rho2,Tguess) sietot = "
+                   "alpha1 alpha2, rho1, rho2, sie1(rho1,Tguess), sie2(rho2,Tguess) "
+                   "sietot = "
                    "%.14e %.14e %.14e %.14e %.14e %.14e %.14e\n",
                    alpha1, alpha2, rho1, rho2,
                    eos1.InternalEnergyFromDensityTemperature(rho1, Tguess),
-                   eos2.InternalEnergyFromDensityTemperature(rho2, Tguess),
-                   sietot);
+                   eos2.InternalEnergyFromDensityTemperature(rho2, Tguess), sietot);
             Ts(i) = Ps(i, 0) = Ps(i, 1) = -1;
             trajRes(i, 0) = trajRes(i, 1) = trajRes(i, 2) = -1;
           } else {
             // compute the pressures
             Ps(i, 0) = eos1.PressureFromDensityTemperature(rho1, Ts(i));
             Ps(i, 1) = eos2.PressureFromDensityTemperature(rho2, Ts(i));
-            
+
             trajRes(i, 0) = alpha1 + alpha2 - 1.0;
 
-            const Real u1 = rhobar1 * eos1.InternalEnergyFromDensityTemperature(rho1, Ts(i));
-            const Real u2 = rhobar2 * eos2.InternalEnergyFromDensityTemperature(rho2, Ts(i));
+            const Real u1 =
+                rhobar1 * eos1.InternalEnergyFromDensityTemperature(rho1, Ts(i));
+            const Real u2 =
+                rhobar2 * eos2.InternalEnergyFromDensityTemperature(rho2, Ts(i));
             trajRes(i, 1) = singularity::robust::ratio(u1 + u2 - utot, utot);
             trajRes(i, 2) = singularity::robust::ratio(Ps(i, 1) - Ps(i, 0), utot);
-
           }
         });
     // wait for completion
@@ -187,7 +188,7 @@ int main(int argc, char *argv[]) {
 
     // Let's make a T grid
     const Real nT = nvfrac + 1;
-    
+
     RegularGrid1D gTs(Tmin, Tmax_walked, nT);
 
     // Now we can do one more loop where we compute the energy and
@@ -249,7 +250,7 @@ int main(int argc, char *argv[]) {
     for (std::size_t j = 0; j < nT; ++j) {
       for (std::size_t i = 0; i < nvfrac; ++i) {
         Real lvfrac = lvfracs.x(i);
-        Real vfrac = std::pow(10.,lvfrac);
+        Real vfrac = std::pow(10., lvfrac);
         fprintf(file, "%ld %ld %.14e %.14e %.14e %.14e\n", j, i, gTs.x(j), vfrac,
                 residuals_h(j, i, 0), residuals_h(j, i, 1));
       }
@@ -260,9 +261,9 @@ int main(int argc, char *argv[]) {
     printf("# i alpha_1 T P_1 P_2 res_alpha res_sie res_P\n");
     for (std::size_t i = 0; i < nvfrac; ++i) {
       Real lvfrac = lvfracs.x(i);
-      Real vfrac = std::pow(10.,lvfrac);
-      printf("%ld %.14e %.14e %.14e %.14e %.14e %.14e %.14e\n", i, vfrac, Ts_h(i), Ps_h(i, 0),
-             Ps_h(i, 1), trajRes(i, 0), trajRes(i, 1), trajRes(i, 2));
+      Real vfrac = std::pow(10., lvfrac);
+      printf("%ld %.14e %.14e %.14e %.14e %.14e %.14e %.14e\n", i, vfrac, Ts_h(i),
+             Ps_h(i, 0), Ps_h(i, 1), trajRes(i, 0), trajRes(i, 1), trajRes(i, 2));
     }
 
     eos1.Finalize();

--- a/example/pte_2mat.cpp
+++ b/example/pte_2mat.cpp
@@ -1,0 +1,200 @@
+//------------------------------------------------------------------------------
+// © 2025. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//------------------------------------------------------------------------------
+
+// C headers
+#include <cmath>
+#include <cstdio>
+
+// C++ headers
+#include <iostream>
+#include <memory>
+#include <string>
+
+// This library contains portable utilities
+#include <ports-of-call/portability.hpp>
+#include <ports-of-call/portable_errors.hpp>
+
+// This contains logic for indexers
+#include <singularity-eos/base/indexable_types.hpp>
+// This contains useful tools for preventing things like divide by zero
+#include <singularity-eos/base/robust_utils.hpp>
+// 1D root finding
+#include <singularity-eos/base/root-finding-1d/root_finding.hpp>
+// The PTE closures
+#include <singularity-eos/closure/mixed_cell_models.hpp>
+// Needed to import the eos models
+#include <singularity-eos/eos/eos.hpp>
+
+// This library contains the spiner table object, which we will use to
+// store our output
+#include <spiner/databox.hpp>
+#include <spiner/interpolation.hpp>
+
+// Number of equations of state to use, always 2
+constexpr std::size_t NEOS = 2;
+// Number of PTE solves to do
+constexpr std::size_t NTRIAL = 1;
+
+// Set the EOSs you want to use here.
+// using EOS = singularity::Variant<singularity::SpinerEOSDependsRhoT>;
+using EOS = singularity::SpinerEOSDependsRhoT;
+
+// An LAMBDA contains additional arguments to an EOS, such as cached
+// variables.  It accepts TYPES rather than integers, kind of like a
+// map, as described in `IndexableTypes`. Here we use it and create a
+// pair of these.
+template <typename... Ts>
+struct LambdaIndexer {
+ public:
+  using Lambda_t = singularity::IndexerUtils::VariadicPointerIndexer<Ts...>;
+  LambdaIndexer(Real *data) : data_(data) {}
+  PORTABLE_FORCEINLINE_FUNCTION
+  auto operator[](const std::size_t m) { return Lambda_t(data_ + Lambda_t::size() * m); }
+  static inline constexpr std::size_t size() { return NEOS * Lambda_t::size(); }
+
+ private:
+  Real *data_;
+};
+// Specialized to the EOSs we actually want
+using MyLambdaIndexer = LambdaIndexer<
+    singularity::IndexableTypes::LogDensity, singularity::IndexableTypes::LogTemperature,
+    singularity::IndexableTypes::RootStatus, singularity::IndexableTypes::TableStatus>;
+
+int main(int argc, char *argv[]) {
+  if (argc < 8) {
+    std::cerr << "Usage: " << argv[0]
+              << " rhobar1 rhobar2 vfrac_guess 1 vfrac_guess_2 sietot Tguess eosargs..."
+              << std::endl;
+    std::exit(1);
+  }
+
+  // This is needed for Kokkos
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  Kokkos::initialize();
+#endif
+  {
+    const Real rhobar1 = atof(argv[1]);
+    const Real rhobar2 = atof(argv[2]);
+    const Real alpha_guess1 = atof(argv[3]);
+    const Real alpha_guess2 = atof(argv[4]);
+    const Real sietot = atof(argv[5]);
+    const Real Tguess = atof(argv[6]);
+
+    const Real rhotot = rhobar1 + rhobar2;
+    const Real utot = sietot * rhotot;
+
+    // state. Here I'm assuming SpinerEOSDependsRhoT but you could
+    // modify for your needs.
+    const std::string materialsfile = argv[7];
+    const int matids[] = {atoi(argv[8]), atoi(argv[9])};
+
+    // Now let's load up the EOS's.
+    EOS eos1 = singularity::SpinerEOSDependsRhoT(materialsfile, matids[0]);
+    EOS eos2 = singularity::SpinerEOSDependsRhoT(materialsfile, matids[1]);
+
+    // and move them to device
+    eos1 = eos1.GetOnDevice();
+    eos2 = eos2.GetOnDevice();
+
+    // We'll also need a device pointer for our EOS objects as the PTE
+    // solver expects an array-like data structure. We're only going
+    // to modify these arrays on device, however.
+    EOS *eos = (EOS *)PORTABLE_MALLOC(NEOS * sizeof(EOS));
+
+    // The volume fractions and microphysical material densities will
+    // be modified "in place" on device. So lets create some data
+    // structures for that.
+    // PORTABLE_MALLOC is just like Malloc but for GPUs
+    Real *rho = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
+    Real *alpha = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
+    // we need sie, temperature, pressure arrays
+    Real *sie = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
+    Real *temp = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
+    Real *press = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
+
+    // The memory for the lambda array
+    Real *plambda = (Real *)PORTABLE_MALLOC(MyLambdaIndexer::size() * sizeof(Real));
+
+    // PTE solvers require internal scratch space. However, the solver
+    // doesn't manage memory. We must provide it ourselves.
+    const std::size_t pte_scratch_size = singularity::PTESolverRhoTRequiredScratch(NEOS);
+    Real *pscratch = (Real *)PORTABLE_MALLOC(pte_scratch_size * sizeof(Real));
+
+    // The pte_params object contains a number of settings you can
+    // modify for the PTE solver, such as tolerances.
+    singularity::MixParams pte_params;
+    pte_params.pte_rel_tolerance_p = 1e-12;
+    pte_params.pte_rel_tolerance_e = 1e-12;
+    pte_params.pte_abs_tolerance_p = 0;
+
+    // Now we call the device kernel
+    portableFor(
+        "Run a PTE solve", 0, NTRIAL, PORTABLE_LAMBDA(const int i) {
+          // Prepare microphysical densities and initial guesses.  We
+          // want to normalize initial guess volume fractions so they
+          // sum to 1.
+          Real vfrac_sum = alpha_guess1 + alpha_guess2;
+          alpha[0] = alpha_guess1 / vfrac_sum;
+          alpha[1] = alpha_guess2 / vfrac_sum;
+          rho[0] = vfrac_sum * rhobar1 / alpha_guess1;
+          rho[1] = vfrac_sum * rhobar2 / alpha_guess2;
+
+          // Asign the EOS objects to the array
+          eos[0] = eos1;
+          eos[1] = eos2;
+
+          const Real Tmin = 1;
+          const Real Tmax = 1e10;
+          
+          // Repeare lambda indexer
+          MyLambdaIndexer lambda(plambda);
+
+          // Create PTE solver object
+          // There are many different solvers available. Here we use the RhoT solver.
+          singularity::PTESolverRhoT<EOS *, Real *, MyLambdaIndexer> method(
+              NEOS, eos,
+              1.0, // the 1 here is because we normalized volume fractions to sum to 1
+              sietot, rho,
+              alpha, // alpha is just an initial guess, but rho * alpha MUST equal rhobar
+              sie, temp, press, // The PTE solver sets these. They're outputs.
+              lambda, pscratch, // scratch and lambda
+              Tguess,           // Initial guess for temperature. Also used
+                                // as a normalization factor internal to
+                                // the solver.
+              pte_params);
+          // Run the solver
+          auto status = singularity::PTESolver(method);
+          printf("Solver succeeded: %d\n"
+                 "Volume fractions: %.14e %.14e\n"
+                 "Temperature:      %.14e\n"
+                 "Pressure:         %.14e\n",
+                 status.converged, alpha[0], alpha[1], temp[0], press[0]);
+        });
+
+    eos1.Finalize();
+    eos2.Finalize();
+    PORTABLE_FREE(eos);
+    PORTABLE_FREE(rho);
+    PORTABLE_FREE(alpha);
+    PORTABLE_FREE(sie);
+    PORTABLE_FREE(temp);
+    PORTABLE_FREE(press);
+    PORTABLE_FREE(plambda);
+    PORTABLE_FREE(pscratch);
+  }
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  Kokkos::finalize();
+#endif
+  return 0;
+}

--- a/example/pte_2mat.cpp
+++ b/example/pte_2mat.cpp
@@ -156,7 +156,7 @@ int main(int argc, char *argv[]) {
 
           const Real Tmin = 1;
           const Real Tmax = 1e10;
-          
+
           // Repeare lambda indexer
           MyLambdaIndexer lambda(plambda);
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Recently I was asked for a C++ example of how to use the PTE solvers, which is sorely lacking. I have also been recently chasing down some robustness issues in the PTE for an HEDP problem run in riot. I decided to kill two birds with one stone. This MR adds two new examples to the examples folder:
- `pte_2mat.cpp` sets up and runs the PTE solver on two materials specified by the user on a single cell. It is commented to explain what's going on. I wrote it for use with Spiner but it is easy to modify to use with eospac.
- `map_pt_space.cpp` takes two materials and walks through valid sets of volume fractions. At each one, it computes the temperature so that the total energy is correct, and outputs the residual as well as the P/T of each material at each point. This produces a "map" of the PT landscape for the material pair.

Exploration of this space revealed two "failure modes" of the PTE solvers, which I also resolve in this MR:
1. In the line search, because we also look at physical ranges of validity, it's possible for the solver to take steps of size zero for many iterations. I add a check that now catches this case and fails out early.
2. When there is a saddle point in the residual, the PTE solver can fail to converge as it will travel down the wrong path through the space. Empirically, it seems to help to have a better (and usually larger) temperature guess. To help with that, I added a routine that takes one (or more) newton-step towards finding 
$u_{tot} - \sum_m \alpha_m \rho_m \varepsilon_m (\rho_m, T_{guess}) = 0$
to modify the initial temperature guess, where $\rho_m$ is the set of initial density guesses. The update is only accepted if the temperature increases due to the Newton step. This one extra 1D Newton step seems to work shockingly well. Convergence appears faster and PTE inputs that previously failed to converge now do converge successfully. I suspect part of the secret sauce here is that pressure structure is reduced at high temperature, so you can escape structure that would otherwise trap you in a local extremum.

This should still probably be tested a bit to check robustness, but I think it will help in situations that the solvers previously struggled in.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
