### PR TITLE
switch to const ref for CRTP then allow lambda to copy capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [[PR502]](https://github.com/lanl/singularity-eos/pull/502) Expose split tables to Fortran interface
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR509]](https://github.com/lanl/singularity-eos/pull/509) Remove extraneous copies in base class
 - [[PR504]](https://github.com/lanl/singularity-eos/pull/504) Add Fortran interface documentation
 
 ### Removed (removing behavior/API/varaibles/...)

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -200,12 +200,12 @@ class EosBase {
   // Generic evaluator
   template <typename Functor_t>
   PORTABLE_INLINE_FUNCTION void EvaluateDevice(const Functor_t f) const {
-    const CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     f(copy);
   }
   template <typename Functor_t>
   void EvaluateHost(Functor_t &f) const {
-    const CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     f(copy);
   }
 
@@ -247,7 +247,7 @@ class EosBase {
   PORTABLE_INLINE_FUNCTION Real GibbsFreeEnergyFromDensityTemperature(
       const Real rho, const Real T,
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
-    const CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     Real sie = copy.InternalEnergyFromDensityTemperature(rho, T, lambda);
     Real P = copy.PressureFromDensityTemperature(rho, T, lambda);
     Real S = copy.EntropyFromDensityTemperature(rho, T, lambda);
@@ -257,7 +257,7 @@ class EosBase {
   PORTABLE_INLINE_FUNCTION Real GibbsFreeEnergyFromDensityInternalEnergy(
       const Real rho, const Real sie,
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
-    const CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     Real T = copy.TemperatureFromDensityInternalEnergy(rho, sie, lambda);
     Real P = copy.PressureFromDensityTemperature(rho, T, lambda);
     Real S = copy.EntropyFromDensityTemperature(rho, T, lambda);
@@ -272,7 +272,7 @@ class EosBase {
                                        LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           temperatures[i] =
@@ -307,7 +307,7 @@ class EosBase {
                                                    LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           sies[i] = copy.InternalEnergyFromDensityTemperature(rhos[i], temperatures[i],
@@ -342,7 +342,7 @@ class EosBase {
                                              LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           pressures[i] =
@@ -375,7 +375,7 @@ class EosBase {
                                                 LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           pressures[i] =
@@ -406,7 +406,7 @@ class EosBase {
                                            const int num, LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           sies[i] = copy.MinInternalEnergyFromDensity(rhos[i], lambdas[i]);
@@ -436,7 +436,7 @@ class EosBase {
                                             LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           entropies[i] =
@@ -469,7 +469,7 @@ class EosBase {
                                                LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           entropies[i] =
@@ -501,7 +501,7 @@ class EosBase {
                                                  LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           cvs[i] = copy.SpecificHeatFromDensityTemperature(rhos[i], temperatures[i],
@@ -536,7 +536,7 @@ class EosBase {
                                                     LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           cvs[i] =
@@ -569,7 +569,7 @@ class EosBase {
                                                 LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           bmods[i] = copy.BulkModulusFromDensityTemperature(rhos[i], temperatures[i],
@@ -604,7 +604,7 @@ class EosBase {
                                                    LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
+    const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
         cname, 0, num, PORTABLE_LAMBDA(const int i) {
           bmods[i] =


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@Yannicked reported in issue #508 that the copies int he base class were impacting the vector API performance. One copy is necessary (on GPUs) as the EOS object, rather than the pointer, must be captured by value. This requires either pulling out the object or capturing `*this` with, e.g., `KOKKOS_CLASS_LAMBDA`. 

However, we are currently performing two copies: 1 when we perform `CRTP` to typecast the object to the child type, and one when we capture. It turns out the first copy can be eliminated. We can simply create the CRTP by reference, as `[=]` in the lambda [implies assignment operator](https://en.cppreference.com/w/cpp/language/lambda) and so the underlying object is captured by value even if it is a reference in scope. See [here](https://godbolt.org/z/71Ghb9PWT) for an example.

This MR eliminates that extraneous copy.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
