### PR TITLE
move to_log and from_log, wrap in singularity namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [[PR519]] (https://github.com/lanl/singularity-eos/pull/519) Split eos_spiner.hpp into eos_spiner_rho_sie.hpp and eos_spiner_rho_temp.hpp files.  
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR522]](https://github.com/lanl/singularity-eos/pull/522) Move more common functionality into spiner_eos_common.hpp
 - [[PR510]](https://github.com/lanl/singularity-eos/pull/510) Make Davis EOS faster and more robust
 - [[PR509]](https://github.com/lanl/singularity-eos/pull/509) Remove extraneous copies in base class
 - [[PR504]](https://github.com/lanl/singularity-eos/pull/504) Add Fortran interface documentation

--- a/singularity-eos/eos/eos_spiner_common.hpp
+++ b/singularity-eos/eos/eos_spiner_common.hpp
@@ -27,8 +27,28 @@
 #include <spiner/sp5.hpp>
 #include <spiner/spiner_types.hpp>
 
-// implementation details below
-// ======================================================================
+// singularity-eos
+#include <singularity-eos/base/fast-math/logs.hpp>
+#include <singularity-eos/base/robust_utils.hpp>
+
+#define SPINER_EOS_VERBOSE (0)
+#define SP_ROOT_FINDER (RootFinding1D::regula_falsi)
+
+namespace singularity {
+namespace spiner_common {
+
+static constexpr int NGRIDS = 3;
+using Grid_t = Spiner::PiecewiseGrid1D<Real, NGRIDS>;
+using DataBox = Spiner::DataBox<Real, Grid_t>;
+
+PORTABLE_FORCEINLINE_FUNCTION Real to_log(const Real x, const Real offset) {
+  return FastMath::log10(std::abs(std::max(x, -offset) + offset) + robust::EPS());
+}
+PORTABLE_FORCEINLINE_FUNCTION Real from_log(const Real lx, const Real offset) {
+  return FastMath::pow10(lx) - offset;
+}
+
+} // namespace spiner_common
 
 // TODO: we're using log-linear interpolation, not log-log
 // this may be suboptimal. We may want a way to do some variables
@@ -40,9 +60,7 @@
 
 namespace callable_interp {
 
-static constexpr int NGRIDS = 3;
-using Grid_t = Spiner::PiecewiseGrid1D<Real, NGRIDS>;
-using DataBox = Spiner::DataBox<Real, Grid_t>;
+using namespace spiner_common;
 
 class l_interp {
  private:
@@ -98,6 +116,7 @@ class interp {
   }
 };
 } // namespace callable_interp
+} // namespace singularity
 
 #endif // SINGULARITY_USE_SPINER_WITH_HDF5
 #endif // _SINGULARITY_EOS_EOS_EOS_SPINER_COMMON_HPP_

--- a/singularity-eos/eos/eos_spiner_rho_sie.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_sie.hpp
@@ -53,9 +53,6 @@
 #include <spiner/sp5.hpp>
 #include <spiner/spiner_types.hpp>
 
-#define SPINER_EOS_VERBOSE (0)
-#define ROOT_FINDER (RootFinding1D::regula_falsi)
-
 namespace singularity {
 
 using namespace eos_base;
@@ -85,9 +82,8 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   struct Lambda {
     enum Index { lRho = 0 };
   };
-  static constexpr int NGRIDS = 3;
-  using Grid_t = Spiner::PiecewiseGrid1D<Real, NGRIDS>;
-  using DataBox = Spiner::DataBox<Real, Grid_t>;
+  using Grid_t = spiner_common::Grid_t;
+  using DataBox = spiner_common::DataBox;
 
   struct SP5Tables {
     DataBox P, bMod, dPdRho, dPdE, dTdRho, dTdE, dEdRho;
@@ -202,20 +198,20 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   PORTABLE_FORCEINLINE_FUNCTION Real lTOffset() const { return lTOffset_; }
   PORTABLE_FORCEINLINE_FUNCTION Real lEOffset() const { return lEOffset_; }
   PORTABLE_FORCEINLINE_FUNCTION Real rhoMin() const {
-    return fromLog_(lRhoMin_, lRhoOffset_);
+    return spiner_common::from_log(lRhoMin_, lRhoOffset_);
   }
   PORTABLE_FORCEINLINE_FUNCTION Real rhoMax() const { return rhoMax_; }
   PORTABLE_FORCEINLINE_FUNCTION Real TMin() const {
-    return fromLog_(sie_.range(0).min(), lTOffset_);
+    return spiner_common::from_log(sie_.range(0).min(), lTOffset_);
   }
   PORTABLE_FORCEINLINE_FUNCTION Real TMax() const {
-    return fromLog_(sie_.range(0).max(), lTOffset_);
+    return spiner_common::from_log(sie_.range(0).max(), lTOffset_);
   }
   PORTABLE_FORCEINLINE_FUNCTION Real sieMin() const {
-    return fromLog_(T_.range(0).min(), lEOffset_);
+    return spiner_common::from_log(T_.range(0).min(), lEOffset_);
   }
   PORTABLE_FORCEINLINE_FUNCTION Real sieMax() const {
-    return fromLog_(T_.range(0).max(), lEOffset_);
+    return spiner_common::from_log(T_.range(0).max(), lEOffset_);
   }
 
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rhoMin(); }
@@ -225,7 +221,7 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
   Real MinimumPressure() const { return PMin_; }
   PORTABLE_INLINE_FUNCTION
   Real RhoPmin(const Real temp) const {
-    return rho_at_pmin_.interpToReal(toLog_(temp, lTOffset_));
+    return rho_at_pmin_.interpToReal(spiner_common::to_log(temp, lTOffset_));
   }
 
   constexpr static inline int nlambda() noexcept { return _n_lambda; }
@@ -250,13 +246,6 @@ class SpinerEOSDependsRhoSie : public EosBase<SpinerEOSDependsRhoSie> {
                                hid_t lEGroup, hid_t coldGroupd);
   inline void calcBMod_(SP5Tables &tables);
 
-  static PORTABLE_FORCEINLINE_FUNCTION Real toLog_(const Real x, const Real offset) {
-    // return std::log10(std::abs(std::max(x,-offset) + offset)+robust::EPS());
-    return FastMath::log10(std::abs(std::max(x, -offset) + offset) + robust::EPS());
-  }
-  static PORTABLE_FORCEINLINE_FUNCTION Real fromLog_(const Real lx, const Real offset) {
-    return FastMath::pow10(lx) - offset;
-  }
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real
   interpRhoT_(const Real rho, const Real T, const DataBox &db,
@@ -358,6 +347,7 @@ inline SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string &filenam
 herr_t SpinerEOSDependsRhoSie::loadDataboxes_(const std::string &matid_str, hid_t file,
                                               hid_t lTGroup, hid_t lEGroup,
                                               hid_t coldGroup) {
+  using namespace spiner_common;
   herr_t status = H5_SUCCESS;
 
   // offsets
@@ -418,7 +408,7 @@ herr_t SpinerEOSDependsRhoSie::loadDataboxes_(const std::string &matid_str, hid_
   numT_ = sie_.dim(1);
   lRhoMin_ = sie_.range(1).min();
   lRhoMax_ = sie_.range(1).max();
-  rhoMax_ = fromLog_(lRhoMax_, lRhoOffset_);
+  rhoMax_ = from_log(lRhoMax_, lRhoOffset_);
 
   // slice to maximum of rho
   PlRhoMax_ = dependsRhoT_.P.slice(numRho_ - 1);
@@ -437,24 +427,24 @@ herr_t SpinerEOSDependsRhoSie::loadDataboxes_(const std::string &matid_str, hid_
       }
     }
     if (jmax < 0) printf("Failed to find minimum pressure.\n");
-    rho_at_pmin_(i) = fromLog_(dependsRhoT_.P.range(1).x(jmax), lRhoOffset_);
+    rho_at_pmin_(i) = from_log(dependsRhoT_.P.range(1).x(jmax), lRhoOffset_);
   }
 
   // reference state
-  Real lRhoNormal = toLog_(rhoNormal_, lRhoOffset_);
+  Real lRhoNormal = to_log(rhoNormal_, lRhoOffset_);
   // if rho normal not on the table, set it to the middle
   if (!(lRhoMin_ < lRhoNormal && lRhoNormal < lRhoMax_)) {
     lRhoNormal = 0.5 * (lRhoMin_ + lRhoMax_);
-    rhoNormal_ = fromLog_(lRhoNormal, lRhoOffset_);
+    rhoNormal_ = from_log(lRhoNormal, lRhoOffset_);
   }
   // Same for temperature. Use room temperature if it's available
   TNormal_ = ROOM_TEMPERATURE;
-  Real lTNormal = toLog_(TNormal_, lTOffset_);
+  Real lTNormal = to_log(TNormal_, lTOffset_);
   Real lTMin = sie_.range(0).min();
   Real lTMax = sie_.range(0).max();
   if (!(lTMin < lTNormal && lTNormal < lTMax)) {
     lTNormal = 0.5 * (lTMin + lTMax);
-    TNormal_ = fromLog_(lTNormal, lTOffset_);
+    TNormal_ = from_log(lTNormal, lTOffset_);
   }
   sieNormal_ = sie_.interpToReal(lRhoNormal, lTNormal);
   PNormal_ = dependsRhoT_.P.interpToReal(lRhoNormal, lTNormal);
@@ -470,7 +460,7 @@ herr_t SpinerEOSDependsRhoSie::loadDataboxes_(const std::string &matid_str, hid_
 inline void SpinerEOSDependsRhoSie::calcBMod_(SP5Tables &tables) {
   for (int j = 0; j < tables.bMod.dim(2); j++) {
     Real lRho = tables.bMod.range(1).x(j);
-    Real rho = fromLog_(lRho, lRhoOffset_);
+    Real rho = spiner_common::from_log(lRho, lRhoOffset_);
     for (int i = 0; i < tables.bMod.dim(1); i++) {
       Real press = tables.P(j, i);
       Real DPDR_E = tables.dPdRho(j, i);
@@ -539,7 +529,7 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::PressureFromDensityInterna
 template <typename Indexer_t>
 PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::MinInternalEnergyFromDensity(
     const Real rho, Indexer_t &&lambda) const {
-  Real lRho = toLog_(rho, lRhoOffset_);
+  Real lRho = spiner_common::to_log(rho, lRhoOffset_);
   return sieCold_.interpToReal(lRho);
 }
 
@@ -596,8 +586,8 @@ template <typename Indexer_t>
 PORTABLE_INLINE_FUNCTION Real
 SpinerEOSDependsRhoSie::GruneisenParamFromDensityInternalEnergy(
     const Real rho, const Real sie, Indexer_t &&lambda) const {
-  const Real lRho = toLog_(rho, lRhoOffset_);
-  const Real lE = toLog_(sie, lEOffset_);
+  const Real lRho = spiner_common::to_log(rho, lRhoOffset_);
+  const Real lE = spiner_common::to_log(sie, lEOffset_);
   const Real dpde = dependsRhoSie_.dPdE.interpToReal(lRho, lE);
   return dpde / rho;
 }
@@ -608,9 +598,9 @@ SpinerEOSDependsRhoSie::DensityEnergyFromPressureTemperature(const Real press,
                                                              const Real temp,
                                                              Indexer_t &&lambda,
                                                              Real &rho, Real &sie) const {
-  Real lT = toLog_(temp, lTOffset_);
+  Real lT = spiner_common::to_log(temp, lTOffset_);
   Real lRho = lRhoFromPlT_(press, lT, lambda);
-  rho = fromLog_(lRho, lRhoOffset_);
+  rho = spiner_common::from_log(lRho, lRhoOffset_);
   sie = sie_.interpToReal(lRho, lT);
 }
 
@@ -619,6 +609,7 @@ PORTABLE_INLINE_FUNCTION void
 SpinerEOSDependsRhoSie::FillEos(Real &rho, Real &temp, Real &energy, Real &press,
                                 Real &cv, Real &bmod, const unsigned long output,
                                 Indexer_t &&lambda) const {
+  using namespace spiner_common;
   Real lRho, lT, lE;
   if (output == thermalqs::none) {
     UNDEFINED_ERROR;
@@ -628,20 +619,20 @@ SpinerEOSDependsRhoSie::FillEos(Real &rho, Real &temp, Real &energy, Real &press
   }
   if (output & thermalqs::density) {
     if (!(output & thermalqs::pressure || output & thermalqs::temperature)) {
-      lT = toLog_(temp, lTOffset_);
+      lT = to_log(temp, lTOffset_);
       lRho = lRhoFromPlT_(press, lT, lambda);
-      rho = fromLog_(lRho, lRhoOffset_);
+      rho = from_log(lRho, lRhoOffset_);
     } else {
       UNDEFINED_ERROR;
     }
   } else {
-    lRho = toLog_(rho, lRhoOffset_);
+    lRho = to_log(rho, lRhoOffset_);
     if (!variadic_utils::is_nullptr(lambda)) {
       IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
     }
   }
   if (output & thermalqs::temperature) {
-    lE = toLog_(energy, lEOffset_);
+    lE = to_log(energy, lEOffset_);
     temp = T_.interpToReal(lRho, lE);
     if (output & thermalqs::pressure) {
       press = dependsRhoSie_.P.interpToReal(lRho, lE);
@@ -654,7 +645,7 @@ SpinerEOSDependsRhoSie::FillEos(Real &rho, Real &temp, Real &energy, Real &press
     }
   }
   if (output & thermalqs::specific_internal_energy) {
-    lT = toLog_(temp, lTOffset_);
+    lT = to_log(temp, lTOffset_);
     energy = sie_.interpToReal(lRho, lT);
     if (output & thermalqs::pressure) {
       press = dependsRhoT_.P.interpToReal(lRho, lT);
@@ -685,8 +676,8 @@ PORTABLE_INLINE_FUNCTION void SpinerEOSDependsRhoSie::ValuesAtReferenceState(
 template <typename Indexer_t>
 PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::interpRhoT_(
     const Real rho, const Real T, const DataBox &db, Indexer_t &&lambda) const {
-  const Real lRho = toLog_(rho, lRhoOffset_);
-  const Real lT = toLog_(T, lTOffset_);
+  const Real lRho = spiner_common::to_log(rho, lRhoOffset_);
+  const Real lT = spiner_common::to_log(T, lTOffset_);
   if (!variadic_utils::is_nullptr(lambda)) {
     IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
   }
@@ -696,8 +687,8 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::interpRhoT_(
 template <typename Indexer_t>
 PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::interpRhoSie_(
     const Real rho, const Real sie, const DataBox &db, Indexer_t &&lambda) const {
-  const Real lRho = toLog_(rho, lRhoOffset_);
-  const Real lE = toLog_(sie, lEOffset_);
+  const Real lRho = spiner_common::to_log(rho, lRhoOffset_);
+  const Real lE = spiner_common::to_log(sie, lEOffset_);
   if (!variadic_utils::is_nullptr(lambda)) {
     IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
   }
@@ -715,7 +706,7 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::lRhoFromPlT_(
   Real PMax = PlRhoMax_.interpToReal(lT);
   if (dPdRhoMax > 0 && P > PMax) {
     Real rho = (P - PMax) / dPdRhoMax + rhoMax_;
-    lRho = toLog_(rho, lRhoOffset_);
+    lRho = spiner_common::to_log(rho, lRhoOffset_);
     if (pcounts != nullptr) {
       pcounts->increment(0);
     }
@@ -729,8 +720,8 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoSie::lRhoFromPlT_(
       }
     }
     const callable_interp::l_interp PFunc(dependsRhoT_.P, lT);
-    status = ROOT_FINDER(PFunc, P, lRhoGuess, lRhoMin_, lRhoMax_, robust::EPS(),
-                         robust::EPS(), lRho, pcounts);
+    status = SP_ROOT_FINDER(PFunc, P, lRhoGuess, lRhoMin_, lRhoMax_, robust::EPS(),
+                            robust::EPS(), lRho, pcounts);
     if (status != RootFinding1D::Status::SUCCESS) {
 #if SPINER_EOS_VERBOSE
       std::stringstream errorMessage;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This MR continues #519 / #517 and moves toLog and fromLog into `spiner_eos_common.hpp`. I'm not sure what the problem you encountered was, @jbasabe but in cases like this, I find the best thing to do is start from a known point and incrementally make changes. This MR is the result. If this resolves your issue, I suggest we merge it into main and then into your branch.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
