### PR TITLE
bugfix for HDF5 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [[PR517]](https://github.com/lanl/singularity-eos/pull/517) Added Coldcurve to SpinerEOSDependsRhoSie, added functionaliuty to MinInternalEnergyFromDensity in SpinerEOSDependsRhoSie, added test to test_eos_tabulated.cpp
 
 ### Fixed (Repair bugs, etc)
+- [[PR523]](https://github.com/lanl/singularity-eos/pull/523) Fix reading order in SpinerEOSDependsRhoSie
 - [[PR506]](https://github.com/lanl/singularity-eos/pull/506) Added some robustness checks to the PTE solvers
 - [[PR505]](https://github.com/lanl/singularity-eos/pull/505) rename LogType::TRUE to LogType::DOUBLE
 - [[PR495]](https://github.com/lanl/singularity-eos/pull/495) Fix bug related to MinimumTemperature and MinimumDensity in SpinerEOSDependsRhoSie

--- a/singularity-eos/eos/eos_spiner_common.hpp
+++ b/singularity-eos/eos/eos_spiner_common.hpp
@@ -17,6 +17,9 @@
 
 #ifdef SINGULARITY_USE_SPINER_WITH_HDF5
 
+#include <hdf5.h>
+#include <hdf5_hl.h>
+
 // ports-of-call
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_errors.hpp>
@@ -46,6 +49,11 @@ PORTABLE_FORCEINLINE_FUNCTION Real to_log(const Real x, const Real offset) {
 }
 PORTABLE_FORCEINLINE_FUNCTION Real from_log(const Real lx, const Real offset) {
   return FastMath::pow10(lx) - offset;
+}
+
+inline herr_t aborting_error_handler(hid_t stack, void *client_data) {
+  H5Eprint2(stack, stderr);
+  PORTABLE_ALWAYS_THROW_OR_ABORT("HDF5 error detected! Erroring out\n");
 }
 
 } // namespace spiner_common

--- a/singularity-eos/eos/eos_spiner_common.hpp
+++ b/singularity-eos/eos/eos_spiner_common.hpp
@@ -53,7 +53,7 @@ PORTABLE_FORCEINLINE_FUNCTION Real from_log(const Real lx, const Real offset) {
 
 inline herr_t aborting_error_handler(hid_t stack, void *client_data) {
   H5Eprint2(stack, stderr);
-  PORTABLE_ALWAYS_THROW_OR_ABORT("HDF5 error detected! Erroring out\n");
+  PORTABLE_ALWAYS_THROW_OR_ABORT("HDF5 error detected! Erroring out!");
 }
 
 } // namespace spiner_common

--- a/singularity-eos/eos/eos_spiner_rho_sie.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_sie.hpp
@@ -336,8 +336,8 @@ inline SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string &filenam
   status += H5Gclose(lTGroup);
   status += H5Gclose(lEGroup);
   status += H5Gclose(matGroup);
-  status += H5Fclose(file);
   status += H5Gclose(coldGroup);
+  status += H5Fclose(file);
 
   if (status != H5_SUCCESS) {
     EOS_ERROR("SpinerDependsRhoSie: HDF5 error\n");
@@ -776,8 +776,8 @@ inline SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string &filenam
   status += H5Gclose(lTGroup);
   status += H5Gclose(lEGroup);
   status += H5Gclose(matGroup);
+  status += H5Gclose(coldGroup);
   status += H5Fclose(file);
-  status += H5Fclose(coldGroup);
 
   if (status != H5_SUCCESS) {
     EOS_ERROR("SpinerDependsRhoSIE: HDF5 error\n");

--- a/singularity-eos/eos/eos_spiner_rho_sie.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_sie.hpp
@@ -310,6 +310,8 @@ inline SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string &filenam
   hid_t file, matGroup, lTGroup, lEGroup, coldGroup;
   herr_t status = H5_SUCCESS;
 
+  H5Eset_auto(H5E_DEFAULT, spiner_common::aborting_error_handler, NULL);
+
   file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   matGroup = H5Gopen(file, materialName.c_str(), H5P_DEFAULT);
 
@@ -753,6 +755,8 @@ inline SpinerEOSDependsRhoSie::SpinerEOSDependsRhoSie(const std::string &filenam
   std::string matid_str = std::to_string(matid);
   hid_t file, matGroup, lTGroup, lEGroup, coldGroup;
   herr_t status = H5_SUCCESS;
+
+  H5Eset_auto(H5E_DEFAULT, spiner_common::aborting_error_handler, NULL);
 
   file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   matGroup = H5Gopen(file, matid_str.c_str(), H5P_DEFAULT);

--- a/singularity-eos/eos/eos_spiner_rho_temp.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_temp.hpp
@@ -332,6 +332,8 @@ inline SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string &filename, i
   hid_t file, matGroup, lTGroup, coldGroup;
   herr_t status = H5_SUCCESS;
 
+  H5Eset_auto(H5E_DEFAULT, spiner_common::aborting_error_handler, NULL);
+
   file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   int log_type = FastMath::LogType::NQT1;
   if (H5LTfind_attribute(file, SP5::logType)) {
@@ -376,6 +378,8 @@ inline SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string &filename,
   std::string matid_str;
   hid_t file, matGroup, lTGroup, subGroup, coldGroup;
   herr_t status = H5_SUCCESS;
+
+  H5Eset_auto(H5E_DEFAULT, spiner_common::aborting_error_handler, NULL);
 
   file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   matGroup = H5Gopen(file, materialName.c_str(), H5P_DEFAULT);

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -42,6 +42,7 @@
 #include <singularity-eos/base/spiner_table_utils.hpp>
 #include <singularity-eos/base/variadic_utils.hpp>
 #include <singularity-eos/eos/eos_base.hpp>
+#include <singularity-eos/eos/eos_spiner_common.hpp>
 
 // spiner
 #include <spiner/databox.hpp>
@@ -475,6 +476,8 @@ inline StellarCollapse::StellarCollapse(const std::string &filename, bool use_sp
 
 // Saves to an SP5 file
 inline void StellarCollapse::Save(const std::string &filename) {
+  H5Eset_auto(H5E_DEFAULT, spiner_common::aborting_error_handler, NULL);
+
   herr_t status = H5_SUCCESS;
   hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -764,8 +767,9 @@ StellarCollapse::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &
 }
 
 inline void StellarCollapse::LoadFromSP5File_(const std::string &filename) {
-  herr_t status = H5_SUCCESS;
+  H5Eset_auto(H5E_DEFAULT, spiner_common::aborting_error_handler, NULL);
 
+  herr_t status = H5_SUCCESS;
   hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
 
   // Offsets
@@ -822,6 +826,7 @@ inline void StellarCollapse::LoadFromStellarCollapseFile_(const std::string &fil
                                                           bool filter_bmod) {
   // Start HDF5 stuff
   // ---------------------------------------------------------------------
+  H5Eset_auto(H5E_DEFAULT, spiner_common::aborting_error_handler, NULL);
   hid_t file_id = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   herr_t status = H5_SUCCESS;
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

#519 #521 added the cold curve to SpinerEOSDependsRhoSie. In the process, the HDF5 reading got a bit messed up. This MR resolves the issue.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
