### PR TITLE
Update clang format script to be closer to CI

### DIFF
--- a/utils/scripts/format.sh
+++ b/utils/scripts/format.sh
@@ -15,7 +15,7 @@
 #------------------------------------------------------------------------------
 
 
-: ${CFM:=clang-format}
+: ${CFM:=clang-format-12}
 : ${VERBOSE:=0}
 
 if ! command -v ${CFM} &> /dev/null; then
@@ -34,11 +34,5 @@ echo "You are using ${CF_VRSN}."
 echo "If these differ, results may not be stable."
 
 echo "Formatting..."
-REPO=$(git rev-parse --show-toplevel)
-for f in $(git grep --untracked -ail res -- :/*.hpp :/*.cpp); do
-    if [ ${VERBOSE} -ge 1 ]; then
-       echo ${f}
-    fi
-    ${CFM} -style=file -i ${REPO}/${f}
-done
+git ls-files -z '*.cpp' '*.hpp' | xargs -0 ${CFM} -style=file -i
 echo "...Done"


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

For whatever reason, the `format.sh` script that we've been using has been failing to properly format files recently. I edited the script to use something a bit closer to the CI.

Note that while the CI uses `find`, I'm using `git ls-files` in attempt to not dive into submodules or `.git` files or anything like that. Using `git ls-files` is _much_ faster as well.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- N/A Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- N/A Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
