### PR TITLE
Another robustness fix for the PTE solvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [[PR517]](https://github.com/lanl/singularity-eos/pull/517) Added Coldcurve to SpinerEOSDependsRhoSie, added functionaliuty to MinInternalEnergyFromDensity in SpinerEOSDependsRhoSie, added test to test_eos_tabulated.cpp
 
 ### Fixed (Repair bugs, etc)
+- [[PR537]](https://github.com/lanl/singularity-eos/pull/537) Fix pathological initial guesses in PTE solvers
 - [[PR523]](https://github.com/lanl/singularity-eos/pull/523) Fix reading order in SpinerEOSDependsRhoSie
 - [[PR506]](https://github.com/lanl/singularity-eos/pull/506) Added some robustness checks to the PTE solvers
 - [[PR505]](https://github.com/lanl/singularity-eos/pull/505) rename LogType::TRUE to LogType::DOUBLE

--- a/sesame2spiner/examples/unit_tests/foam.dat
+++ b/sesame2spiner/examples/unit_tests/foam.dat
@@ -17,3 +17,5 @@
 
 matid=7592
 name=Foam
+numrho/decade = 200
+numT/decade = 200

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -298,9 +298,14 @@ class PTESolverBase {
 
     // Do an initial sweep of volume fractions to account for missing
     // initial guesses
+    // TODO(JMM): I'm not sure it's possible to pass in a missing
+    // initial guess, since then rhobar would be undefined, which
+    // would make the system underconstrained.
     Real vfrac_max_sum = 0;
     for (std::size_t m = 0; m < nmat; ++m) {
       const Real vfrac_max = get_vfrac_max(m);
+      // This chooses the smallest allowed density, since vfrac is
+      // inversely proportional to rho.
       if (vfrac[m] <= 0) vfrac[m] = vfrac_max;
       // Tally this to check if a valid non-tension state is possible
       vfrac_max_sum += vfrac_max;

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -276,6 +276,7 @@ class PTESolverBase {
   bool SetVfracFromT(const Real T) {
     constexpr bool FAIL = true;
     constexpr bool SUCCESS = false;
+    constexpr Real min_dv = 1e-12;
 
     // TODO(JMM): Stash this somewhere rather than recomputing it?
     auto get_vmax = [=](const std::size_t m) {
@@ -320,13 +321,13 @@ class PTESolverBase {
         const Real dv = get_dv(m);
         vfrac[m] -= dv;
         remaining_vfrac += dv;
-        n_uncapped_materials -= (dv > 0);
+        n_uncapped_materials -= (dv > min_dv);
       }
-      if (std::abs(remaining_vfrac) < 1e-12) {
+      if (std::abs(remaining_vfrac) < min_dv) {
         break;
       }
       for (std::size_t m = 0; m < nmat; ++m) {
-        const bool uncapped = ((get_vmax(m) - vfrac[m]) > 1e-12);
+        const bool uncapped = ((get_vmax(m) - vfrac[m]) > min_dv);
         if (uncapped) {
           vfrac[m] += robust::ratio(remaining_vfrac, n_uncapped_materials);
         }

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -304,10 +304,15 @@ class PTESolverBase {
       // fraction that sums to 1
       return FAIL;
     }
+
     // start normalized
     NormalizeVfrac();
 
-    // JMM: Formal maximum number of iterations required is nmat
+    // JMM: Idea here is keep a running tally of how much volume we've
+    // had to subtract from a given material to keep vfrac <
+    // vfrac_max. We will distribute this excess volume accross all
+    // materials that haven't hit their max yet, and then
+    // repeat. Formal maximum number of iterations required is nmat
     for (std::size_t niter = 0; niter < nmat; ++niter) {
       Real remaining_vfrac = 0;
       std::size_t n_uncapped_materials = nmat;

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -142,8 +142,9 @@ bool solve_Ax_b_wscr(const std::size_t n, Real *a, Real *b, Real *scr) {
 #warning "Eigen should not be used with Kokkos."
 #endif
   // Eigen VERSION
-  Eigen::Map<Eigen::Matrix<Real, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> A(a, n,
-                                                                                     n);
+  using Matrix_t = Eigen::Matrix<Real, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+  Eigen::Map<Matrix_t> A(a, n, n);
+
   Eigen::Map<Eigen::VectorXd> B(b, n);
   Eigen::Map<Eigen::VectorXd> X(scr, n);
   X = A.lu().solve(B);
@@ -248,19 +249,89 @@ class PTESolverBase {
   }
 
   PORTABLE_FORCEINLINE_FUNCTION
-  void SetVfracFromT(const Real T) {
-    Real vsum = 0.0;
-    // set volume fractions
+  void NormalizeVfrac() {
+    Real vfrac_sum = 0;
     for (std::size_t m = 0; m < nmat; ++m) {
+      vfrac_sum += vfrac[m];
+    }
+    for (std::size_t m = 0; m < nmat; ++m) {
+      vfrac[m] *= robust::ratio(vfrac_total, vfrac_sum);
+    }
+  }
+
+  /* JMM: Find the volume fractions that:
+   * 1) Best respect initial guesses
+   * 2) Sum to 1
+   * 3) Are bounded from above such that no material is in tension (if
+   * possible)
+   *
+   * If these are not all possible to respect, error out and expect
+   * the GetTguess function to save us by picking a higher
+   * temperature.
+   *
+   * If this is possible to achieve, we can do so by using the "water
+   * filling" algorithm. See, e.g., Gallager, 1968.
+   */
+  PORTABLE_FORCEINLINE_FUNCTION
+  bool SetVfracFromT(const Real T) {
+    constexpr bool FAIL = true;
+    constexpr bool SUCCESS = false;
+
+    // TODO(JMM): Stash this somewhere rather than recomputing it?
+    auto get_vmax = [=](const std::size_t m) {
       const Real rho_min = eos[m].RhoPmin(T);
       const Real vmax = std::min(0.9 * robust::ratio(rhobar[m], rho_min), 1.0);
-      vfrac[m] = (vfrac[m] > 0.0 ? std::min(vmax, vfrac[m]) : vmax);
-      vsum += vfrac[m];
-    }
-    // Normalize vfrac
+      return vmax;
+    };
+    auto get_dv = [=](const std::size_t m) {
+      const Real vmax = get_vmax(m);
+      const Real vnew = std::min(vmax, vfrac[m]);
+      const Real dv = vfrac[m] - vnew;
+      return dv;
+    };
+
+    // Do an initial sweep of volume fractions to account for missing
+    // initial guesses
+    Real vmax_sum = 0;
     for (std::size_t m = 0; m < nmat; ++m) {
-      vfrac[m] *= robust::ratio(vfrac_total, vsum);
+      const Real vmax = get_vmax(m);
+      if (vfrac[m] <= 0) vfrac[m] = vmax;
+      // Tally this to check if a valid non-tension state is possible
+      vmax_sum += vmax;
     }
+    if (vmax_sum < vfrac_total) {
+      // no way to keep all materials out of tension with a volume
+      // fraction that sums to 1
+      return FAIL;
+    }
+    // start normalized
+    NormalizeVfrac();
+
+    // JMM: Formal maximum number of iterations required is nmat
+    for (std::size_t niter = 0; niter < nmat; ++niter) {
+      Real remaining_vfrac = 0;
+      std::size_t n_uncapped_materials = nmat;
+      for (std::size_t m = 0; m < nmat; ++m) {
+        const Real dv = get_dv(m);
+        vfrac[m] -= dv;
+        remaining_vfrac += dv;
+        n_uncapped_materials -= (dv > 0);
+      }
+      if (std::abs(remaining_vfrac) < 1e-12) {
+        break;
+      }
+      for (std::size_t m = 0; m < nmat; ++m) {
+        const bool uncapped = ((get_vmax(m) - vfrac[m]) > 1e-12);
+        if (uncapped) {
+          vfrac[m] += robust::ratio(remaining_vfrac, n_uncapped_materials);
+        }
+      }
+    }
+
+    // One more normalization, to be safe
+    NormalizeVfrac();
+
+    return SUCCESS;
   }
 
   PORTABLE_FORCEINLINE_FUNCTION
@@ -311,15 +382,21 @@ class PTESolverBase {
       for (std::size_t m = 0; m < nmat; ++m) {
         Tguess = std::max(eos[m].MinimumTemperature(), Tguess);
       }
-      SetVfracFromT(Tguess);
+      rho_fail = SetVfracFromT(Tguess);
+      if (rho_fail) {
+        Tguess *= Tfactor;
+        continue;
+      }
+      for (std::size_t m = 0; m < nmat; ++m) {
+        rho[m] = robust::ratio(rhobar[m], vfrac[m]);
+      }
       // check to make sure the normalization didn't put us below rho_at_pmin
       rho_fail = false;
       for (std::size_t m = 0; m < nmat; ++m) {
         const Real rho_min = eos[m].RhoPmin(Tguess);
         const Real rho_max = eos[m].MaximumDensity();
         PORTABLE_REQUIRE(rho_min < rho_max, "Valid density range must exist!");
-        rho[m] = robust::ratio(rhobar[m], vfrac[m]);
-        PORTABLE_REQUIRE(rho[m] < rho_max, "Density must be less than rho_min");
+        PORTABLE_REQUIRE(rho[m] < rho_max, "Density must be less than rho_max");
         if (rho[m] < rho_min) {
           rho_fail = true;
           Tguess *= Tfactor;
@@ -333,6 +410,7 @@ class PTESolverBase {
       PORTABLE_ALWAYS_WARN(
           "rho < rho_min in PTE initialization!  Solver may not converge.\n");
     }
+
     return Tguess;
   }
 
@@ -364,8 +442,8 @@ class PTESolverBase {
     // intialize rhobar array and final density
     InitRhoBarandRho();
     const Real utotal = rho_total * sie_total;
-    uscale = std::abs(utotal);
-    // TODO(): Consider edge case when utotal \simeq 0
+    // TODO(): Consider more carefully edge case when utotal \simeq 0
+    uscale = std::max(std::abs(utotal), 1.0e-14);
     utotal_scale = robust::ratio(utotal, uscale);
 
     // guess some non-zero temperature to start
@@ -711,6 +789,7 @@ class PTESolverRhoT
                         uscale);
       dpdv[m] = robust::ratio((p_pert - press[m]), dv);
       dedv[m] = robust::ratio(rhobar[m] * robust::ratio(e_pert, uscale) - u[m], dv);
+
       //////////////////////////////
       // perturb temperature
       //////////////////////////////

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -223,7 +223,7 @@ inline bool RunPTE2Mat(EOS eos1, EOS eos2, Real rhobar1, Real rhobar2, Real alph
             success = false;
           }
           if (!isClose(press[0], Ptrue)) {
-            printf("Pressures do not match! %.14e %.1re\n", press[0], Ptrue);
+            printf("Pressures do not match! %.14e %.14e\n", press[0], Ptrue);
             success = false;
           }
         }
@@ -432,8 +432,8 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
       constexpr Real Ttrue = 3.02477729062119e+02;
       constexpr Real Ptrue = 9.98701227398616e+05;
 
-      int nsuccess =
-          RunPTE2Mat(al_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
+      bool success =
+          RunPTE2Mat(He_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
                      sietot, Tguess, alpha1_true, alpha2_true, Ttrue, Ptrue);
 
       THEN("The solver converges") { REQUIRE(success); }

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -348,16 +348,16 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
         const bool pte_converged = run_PTE_from_state<PTESolverRhoT>(
             num_pte, v_EOS, spvol_bulk, sie_bulk, PTESolverRhoTRequiredScratch, mass_frac,
             u_bulk_out);
+        CHECK(pte_converged);
         const MixParams params;
-        // CHECK(pte_converged);
-        // AND_THEN("The solution satisfies the bulk internal energy constraint") {
-        //   // NOTE(@pdmullen): The following fails prior to PR401
-        //   const Real u_bulk = ratio(sie_bulk, spvol_bulk);
-        //   const Real u_scale = std::abs(u_bulk);
-        //   const Real u_bulk_scale = ratio(u_bulk, u_scale);
-        //   const Real residual = std::abs(u_bulk_scale - ratio(u_bulk_out, u_scale));
-        //   CHECK(residual < params.pte_rel_tolerance_e);
-        // }
+        AND_THEN("The solution satisfies the bulk internal energy constraint") {
+          // NOTE(@pdmullen): The following fails prior to PR401
+          const Real u_bulk = ratio(sie_bulk, spvol_bulk);
+          const Real u_scale = std::abs(u_bulk);
+          const Real u_bulk_scale = ratio(u_bulk, u_scale);
+          const Real residual = std::abs(u_bulk_scale - ratio(u_bulk_out, u_scale));
+          CHECK(residual < params.pte_rel_tolerance_e);
+        }
         // Free EOS copies on device
         PORTABLE_FREE(v_EOS);
       }

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -73,6 +73,7 @@ using MyLambdaIndexer = LambdaIndexer<NEOS, singularity::IndexableTypes::LogDens
                                       singularity::IndexableTypes::RootStatus,
                                       singularity::IndexableTypes::TableStatus>;
 
+// TODO(JMM): Clean this up to account for these two differetn APIs
 template <template <typename... Types> class PTESolver_t, typename Scratch_t,
           typename ArrT>
 bool run_PTE_from_state(const int num_pte, EOS *v_EOS, const Real spvol_bulk,
@@ -160,10 +161,11 @@ bool run_PTE_from_state(const int num_pte, EOS *v_EOS, const Real spvol_bulk,
   return pte_converged;
 }
 
-constexpr int NT = 1;
-inline int RunPTE2Mat(EOS eos1, EOS eos2, Real rhobar1, Real rhobar2, Real alpha_guess1,
-                      Real alpha_guess2, Real sietot, Real Tguess, Real alpha1_true,
-                      Real alpha2_true, Rela Ttrue, Real Ptrue) {
+// TODO(JMM): Clean this up to account for these two differetn APIs
+inline bool RunPTE2Mat(EOS eos1, EOS eos2, Real rhobar1, Real rhobar2, Real alpha_guess1,
+                       Real alpha_guess2, Real sietot, Real Tguess, Real alpha1_true,
+                       Real alpha2_true, Rela Ttrue, Real Ptrue) {
+  constexpr int NT = 1;
   constexpr int NEOS = 2;
 
   EOS *eos = (EOS *)PORTABLE_MALLOC(NEOS * sizeof(EOS));
@@ -237,7 +239,7 @@ inline int RunPTE2Mat(EOS eos1, EOS eos2, Real rhobar1, Real rhobar2, Real alpha
   PORTABLE_FREE(press);
   PORTABLE_FREE(plambda);
 
-  return nsuccess;
+  return (nsuccess == NT);
 }
 
 SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
@@ -393,11 +395,11 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
       constexpr Real Ttrue = 2.10866067749579e+04;
       constexpr Real Ptrue = 1.44504093939007e+10;
 
-      int nsuccess =
+      bool success =
           RunPTE2Mat(al_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
                      sietot, Tguess, alpha1_ture, alpha2_true, Ttrue, Ptrue);
 
-      THEN("The solver converges") { REQUIRE(nsuccess == NT); }
+      THEN("The solver converges") { REQUIRE(success); }
     }
 
     al_eos_h.Finalize();
@@ -433,7 +435,7 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
           RunPTE2Mat(al_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
                      sietot, Tguess, alpha1_ture, alpha2_true, Ttrue, Ptrue);
 
-      THEN("The solver converges") { REQUIRE(nsuccess == NT); }
+      THEN("The solver converges") { REQUIRE(success); }
     }
 
     He_eos_h.Finalize();

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -164,7 +164,7 @@ bool run_PTE_from_state(const int num_pte, EOS *v_EOS, const Real spvol_bulk,
 // TODO(JMM): Clean this up to account for these two differetn APIs
 inline bool RunPTE2Mat(EOS eos1, EOS eos2, Real rhobar1, Real rhobar2, Real alpha_guess1,
                        Real alpha_guess2, Real sietot, Real Tguess, Real alpha1_true,
-                       Real alpha2_true, Rela Ttrue, Real Ptrue) {
+                       Real alpha2_true, Real Ttrue, Real Ptrue) {
   constexpr int NT = 1;
   constexpr int NEOS = 2;
 
@@ -397,7 +397,7 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
 
       bool success =
           RunPTE2Mat(al_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
-                     sietot, Tguess, alpha1_ture, alpha2_true, Ttrue, Ptrue);
+                     sietot, Tguess, alpha1_true, alpha2_true, Ttrue, Ptrue);
 
       THEN("The solver converges") { REQUIRE(success); }
     }
@@ -409,6 +409,7 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
   }
 
   GIVEN("A cell containing a difficult mixture with a tabulated and ideal gas EOS") {
+    const std::string eos_file = "../materials.sp5";
     constexpr Real gm1 = 0.666666666666667;
     constexpr Real Cv = 3.1e7;
     EOS He_eos_h = IdealGas(gm1, Cv);
@@ -433,7 +434,7 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
 
       int nsuccess =
           RunPTE2Mat(al_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
-                     sietot, Tguess, alpha1_ture, alpha2_true, Ttrue, Ptrue);
+                     sietot, Tguess, alpha1_true, alpha2_true, Ttrue, Ptrue);
 
       THEN("The solver converges") { REQUIRE(success); }
     }

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -301,7 +301,6 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
             u_bulk_out);
         CHECK(pte_converged);
         AND_THEN("The solution satisfies the bulk internal energy constraint") {
-          // NOTE(@pdmullen): The following fails prior to PR401
           const Real u_bulk = ratio(sie_bulk, spvol_bulk);
           const Real u_scale = std::abs(u_bulk);
           const Real u_bulk_scale = ratio(u_bulk, u_scale);
@@ -319,7 +318,6 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
             u_bulk_out);
         CHECK(pte_converged);
         AND_THEN("The solution satisfies the bulk internal energy constraint") {
-          // NOTE(@pdmullen): The following fails prior to PR401
           const Real u_bulk = ratio(sie_bulk, spvol_bulk);
           const Real u_scale = std::abs(u_bulk);
           const Real u_bulk_scale = ratio(u_bulk, u_scale);

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -160,6 +160,86 @@ bool run_PTE_from_state(const int num_pte, EOS *v_EOS, const Real spvol_bulk,
   return pte_converged;
 }
 
+constexpr int NT = 1;
+inline int RunPTE2Mat(EOS eos1, EOS eos2, Real rhobar1, Real rhobar2, Real alpha_guess1,
+                      Real alpha_guess2, Real sietot, Real Tguess, Real alpha1_true,
+                      Real alpha2_true, Rela Ttrue, Real Ptrue) {
+  constexpr int NEOS = 2;
+
+  EOS *eos = (EOS *)PORTABLE_MALLOC(NEOS * sizeof(EOS));
+  Real *rho = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
+  Real *alpha = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
+  Real *sie = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
+  Real *temp = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
+  Real *press = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
+  Real *plambda = (Real *)PORTABLE_MALLOC(MyLambdaIndexer<NEOS>::size() * sizeof(Real));
+
+  // PTE solvers require internal scratch space. However, the solver
+  // doesn't manage memory. We must provide it ourselves.
+  const std::size_t pte_scratch_size = singularity::PTESolverRhoTRequiredScratch(NEOS);
+  Real *pscratch = (Real *)PORTABLE_MALLOC(pte_scratch_size * sizeof(Real));
+
+  // The pte_params object contains a number of settings you can
+  // modify for the PTE solver, such as tolerances.
+  singularity::MixParams pte_params;
+  pte_params.pte_rel_tolerance_p = 1e-12;
+  pte_params.pte_rel_tolerance_e = 1e-12;
+  pte_params.pte_abs_tolerance_p = 0;
+
+  int nsuccess = 0;
+  portableReduce(
+      "Run a difficult 2 material state", 0, NT,
+      PORTABLE_LAMBDA(const int i, int &ns) {
+        Real vfrac_sum = alpha_guess1 + alpha_guess2;
+        alpha[0] = alpha_guess1 / vfrac_sum;
+        alpha[1] = alpha_guess2 / vfrac_sum;
+        rho[0] = vfrac_sum * rhobar1 / alpha_guess1;
+        rho[1] = vfrac_sum * rhobar2 / alpha_guess2;
+
+        eos[0] = eos1;
+        eos[1] = eos2;
+        MyLambdaIndexer<NEOS> lambda(plambda);
+
+        singularity::PTESolverRhoT<EOS *, Real *, MyLambdaIndexer<NEOS>> method(
+            NEOS, eos, 1.0, sietot, rho, alpha, sie, temp, press, lambda, pscratch,
+            Tguess, pte_params);
+        // Run the solver
+        auto status = singularity::PTESolver(method);
+
+        bool success = true;
+        if (!status.converged) {
+          printf("Solver did not converge!\n");
+          success = false;
+        } else {
+          if (!(isClose(alpha[0], alpha1_true) && isClose(alpha[1], alpha2_true))) {
+            printf("Volume fractions dop not match! [%.14e %.14e], [%.14e %.14e]\n",
+                   alpha[0], alpha[1], alpha1_true, alpha2_true);
+            success = false;
+          }
+          if (!isClose(temp[0], Ttrue)) {
+            printf("Temperatures do not match! %.14e %.14e\n", temp[0], Ttrue);
+            success = false;
+          }
+          if (!isClose(press[0], Ptrue)) {
+            printf("Pressures do not match! %.14e %.1re\n", press[0], Ptrue);
+            success = false;
+          }
+        }
+        ns += success;
+      },
+      nsuccess);
+
+  PORTABLE_FREE(eos);
+  PORTABLE_FREE(rho);
+  PORTABLE_FREE(alpha);
+  PORTABLE_FREE(sie);
+  PORTABLE_FREE(temp);
+  PORTABLE_FREE(press);
+  PORTABLE_FREE(plambda);
+
+  return nsuccess;
+}
+
 SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
 
   GIVEN("Four equations of state") {
@@ -308,90 +388,56 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
     constexpr Real Tguess = 1.49041098541734e+03;
 
     WHEN("We call PTE") {
-      constexpr int NEOS = 2;
-      constexpr int NT = 1;
       constexpr Real alpha1_true = 2.65277486969419e-03;
       constexpr Real alpha2_true = 9.97347225130306e-01;
       constexpr Real Ttrue = 2.10866067749579e+04;
       constexpr Real Ptrue = 1.44504093939007e+10;
 
-      EOS *eos = (EOS *)PORTABLE_MALLOC(NEOS * sizeof(EOS));
-      Real *rho = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
-      Real *alpha = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
-      Real *sie = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
-      Real *temp = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
-      Real *press = (Real *)PORTABLE_MALLOC(NEOS * sizeof(Real *));
-      Real *plambda =
-          (Real *)PORTABLE_MALLOC(MyLambdaIndexer<NEOS>::size() * sizeof(Real));
-
-      // PTE solvers require internal scratch space. However, the solver
-      // doesn't manage memory. We must provide it ourselves.
-      const std::size_t pte_scratch_size =
-          singularity::PTESolverRhoTRequiredScratch(NEOS);
-      Real *pscratch = (Real *)PORTABLE_MALLOC(pte_scratch_size * sizeof(Real));
-
-      // The pte_params object contains a number of settings you can
-      // modify for the PTE solver, such as tolerances.
-      singularity::MixParams pte_params;
-      pte_params.pte_rel_tolerance_p = 1e-12;
-      pte_params.pte_rel_tolerance_e = 1e-12;
-      pte_params.pte_abs_tolerance_p = 0;
-
-      int nsuccess = 0;
-      portableReduce(
-          "Run a difficult 2 material state", 0, NT,
-          PORTABLE_LAMBDA(const int i, int &ns) {
-            Real vfrac_sum = alpha_guess1 + alpha_guess2;
-            alpha[0] = alpha_guess1 / vfrac_sum;
-            alpha[1] = alpha_guess2 / vfrac_sum;
-            rho[0] = vfrac_sum * rhobar1 / alpha_guess1;
-            rho[1] = vfrac_sum * rhobar2 / alpha_guess2;
-
-            eos[0] = al_eos;
-            eos[1] = foam_eos;
-            MyLambdaIndexer<NEOS> lambda(plambda);
-
-            singularity::PTESolverRhoT<EOS *, Real *, MyLambdaIndexer<NEOS>> method(
-                NEOS, eos, 1.0, sietot, rho, alpha, sie, temp, press, lambda, pscratch,
-                Tguess, pte_params);
-            // Run the solver
-            auto status = singularity::PTESolver(method);
-
-            bool success = true;
-            if (!status.converged) {
-              printf("Solver did not converge!\n");
-              success = false;
-            } else {
-              if (!(isClose(alpha[0], alpha1_true) && isClose(alpha[1], alpha2_true))) {
-                printf("Volume fractions dop not match! [%.14e %.14e], [%.14e %.14e]\n",
-                       alpha[0], alpha[1], alpha1_true, alpha2_true);
-                success = false;
-              }
-              if (!isClose(temp[0], Ttrue)) {
-                printf("Temperatures do not match! %.14e %.14e\n", temp[0], Ttrue);
-                success = false;
-              }
-              if (!isClose(press[0], Ptrue)) {
-                printf("Pressures do not match! %.14e %.1re\n", press[0], Ptrue);
-                success = false;
-              }
-            }
-            ns += success;
-          },
-          nsuccess);
+      int nsuccess =
+          RunPTE2Mat(al_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
+                     sietot, Tguess, alpha1_ture, alpha2_true, Ttrue, Ptrue);
 
       THEN("The solver converges") { REQUIRE(nsuccess == NT); }
-
-      PORTABLE_FREE(eos);
-      PORTABLE_FREE(rho);
-      PORTABLE_FREE(alpha);
-      PORTABLE_FREE(sie);
-      PORTABLE_FREE(temp);
-      PORTABLE_FREE(press);
-      PORTABLE_FREE(plambda);
     }
+
     al_eos_h.Finalize();
     al_eos.Finalize();
+    foam_eos_h.Finalize();
+    foam_eos.Finalize();
+  }
+
+  GIVEN("A cell containing a difficult mixture with a tabulated and ideal gas EOS") {
+    constexpr Real gm1 = 0.666666666666667;
+    constexpr Real Cv = 3.1e7;
+    EOS He_eos_h = IdealGas(gm1, Cv);
+    EOS He_eos = He_eos_h.GetOnDevice();
+
+    constexpr int foam_matid = 7592;
+    EOS foam_eos_h = SpinerEOSDependsRhoT(eos_file, foam_matid);
+    EOS foam_eos = foam_eos_h.GetOnDevice();
+
+    constexpr Real rhobar1 = 1.59761356859602e-04;
+    constexpr Real rhobar2 = 7.81928505957464e-09;
+    constexpr Real alpha_guess1 = 9.99999776549350e-01;
+    constexpr Real alpha_guess2 = 2.23450650410351e-07;
+    constexpr Real sietot = 9.37635921815154e+09;
+    constexpr Real Tguess = 293;
+
+    WHEN("We call PTE") {
+      constexpr Real alpha1_true = 9.99999989159325e-01;
+      constexpr Real alpha2_true = 1.08406754944454e-08;
+      constexpr Real Ttrue = 3.02477729062119e+02;
+      constexpr Real Ptrue = 9.98701227398616e+05;
+
+      int nsuccess =
+          RunPTE2Mat(al_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
+                     sietot, Tguess, alpha1_ture, alpha2_true, Ttrue, Ptrue);
+
+      THEN("The solver converges") { REQUIRE(nsuccess == NT); }
+    }
+
+    He_eos_h.Finalize();
+    He_eos.Finalize();
     foam_eos_h.Finalize();
     foam_eos.Finalize();
   }


### PR DESCRIPTION
While debugging riot, I discovered another failure mode for the PTE solvers. In particular, the code has routines to enforce that volume fractions are initialized such that no materials start in a state such that dP/drho < 0. This can happen if you are to the expansion side of the minimum pressure in tension. If you start in this state, a Newton solver can't get you out of it---minimum pressure is a local extremum. 

This routine `SetVfracFromT` *does* set volume fractions to be outside of the spinodal region/vapor dome (where this can happen), but then it re-normalizes them so they sum to 1 (or vfrac_sum if specified != 1), and this can put you back into a bad state.

The proper thing to do is to use a [water filling algorithm](https://en.wikipedia.org/wiki/Water-filling_algorithm) that properly distributes the volume of a mixture across all materials while respecting their bounds. The spinodal requirement can be interpreted as a maximum allowable volume fraction for a given material.

I implement this change, and indeed it improves robustness. Some states that previously failed now succeed. Note that in some sense this was a bug. The solver was correct, but our initial guess machinery was sometimes choosing a pathological initial guess!

I still need to add a unit test enforcing that this mixture passes PTE. An interesting feature of this case is it's a mixture between an ideal gas and a tabulated EOS.

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
