### PR TITLE
properly handle vapor dome for Maxwell-constructed EOS's

### DIFF
--- a/doc/sphinx/src/models.rst
+++ b/doc/sphinx/src/models.rst
@@ -1695,18 +1695,24 @@ The constructor for ``SpinerEOSDependsRhoT`` is given by two overloads:
 
   SpinerEOSDependsRhoT(const std::string &filename, int matid,
                        const singularity::TableSplit = singularity::TableSplit::Total,
-                       bool reproduciblity_mode = false);
+                       bool reproduciblity_mode = false,
+                       bool pmin_vapor_dome = false);
   SpinerEOSDependsRhoT(const std::string &filename, const std::string &materialName,
                        const singularity::TableSplit = singularity::TableSplit::Total,
-                       bool reproducibility_mode = false);
+                       bool reproducibility_mode = false,
+                       bool pmin_vapor_dome = false);
 
 where here ``filename`` is the input file, ``matid`` is the unique
 material ID in the database in the file, ``materialName`` is the name
 of the material in the file, and ``reproducability_mode`` is a boolean
 which slightly changes how initial guesses for root finds are
 computed. The ``TableSplit`` option selects electron, ion, or total
-equation of state tables for partial ionization. The constructor for
-``SpinerEOSDependsRhoSie`` is identical.
+equation of state tables for partial ionization. ``pmin_vapor_dome``
+specifies how to interpret the ``RhoPMin`` function. If it is false
+(the default), it is the usual interpretation. If it is ``true`` and
+the equation of state is Maxwell constructed, then ``RhoPMin`` for
+this EOS will return compression edge of the vapor dome. The
+constructor for ``SpinerEOSDependsRhoSie`` is identical.
 
 .. note::
 

--- a/doc/sphinx/src/using-closures.rst
+++ b/doc/sphinx/src/using-closures.rst
@@ -557,6 +557,10 @@ contains the following member fields, with default values:
     Real temperature_limit = 1.0e15;
     Real default_tguess = 300.;
     Real min_dtde = 1.0e-16;
+    std::size_t pte_small_step_tries = 2;
+    Real pte_small_step_thresh = 1e-16;
+    Real pte_max_dpdv = -1e-8;
+    Real pte_min_drdp = 1e-8;
   };
 
 where here ``verbose`` enables verbose output in the PTE solve is,
@@ -581,6 +585,26 @@ maximum temperature allowed by the solver. ``default_tguess`` is used
 as an initial guess for temperature if a better guess is not passed in
 or cannot be inferred. ``min_dtde`` is the minmum that temperature is
 allowed to change with respect to energy when computing Jacobians.
+
+The parameters ``pte_small_step_tries`` and ``pte_small_step_thresh``
+guard against the PTE solver taking tiny steps forever and not
+converging. ``pte_small_step_thresh`` is the size of step the PTE
+solver considers too small and ``pte_small_step_tries`` is the number
+of very small steps the solver will take before erroring out.
+
+``pte_max_dpdv`` is designed to guard against difficult-to-handle
+regions of a multi-phase equation of state, such as a vapor dome that
+contains Van der Waals loops or a region that has been Maxwell
+constructed to remove such loops. In these regions, the slope of
+pressure with respect to microphysical density can vanish, which can
+cause the Jacobian of a solver to have a non-trivial Kernel, and thus
+make the system impossible to solve. This threshold floors this
+Jacobian so that it can always be inverted. The threshold is the
+gradient of the pressure with respect to **volume fraction** and must
+be negative. If a positive threshold is entered, it will be made
+negative. ``pte_min_drdp`` is the equivalent threshold for the
+PT-space solver, which computes a gradient with respect to pressure of
+density.
 
 .. note::
 

--- a/doc/sphinx/src/using-closures.rst
+++ b/doc/sphinx/src/using-closures.rst
@@ -560,7 +560,6 @@ contains the following member fields, with default values:
     std::size_t pte_small_step_tries = 2;
     Real pte_small_step_thresh = 1e-16;
     Real pte_max_dpdv = -1e-8;
-    Real pte_min_drdp = 1e-8;
   };
 
 where here ``verbose`` enables verbose output in the PTE solve is,
@@ -602,9 +601,7 @@ make the system impossible to solve. This threshold floors this
 Jacobian so that it can always be inverted. The threshold is the
 gradient of the pressure with respect to **volume fraction** and must
 be negative. If a positive threshold is entered, it will be made
-negative. ``pte_min_drdp`` is the equivalent threshold for the
-PT-space solver, which computes a gradient with respect to pressure of
-density.
+negative.
 
 .. note::
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -27,15 +27,15 @@ if (SINGULARITY_USE_SPINER_WITH_HDF5)
   add_executable(pte_2mat pte_2mat.cpp)
   target_link_libraries(pte_2mat PRIVATE
     singularity-eos::singularity-eos)
+  add_executable(get_spiner_bounds
+    get_spiner_bounds.cpp)
+  target_link_libraries(get_spiner_bounds PRIVATE
+    singularity-eos::singularity-eos)
 endif()
 
 if(SINGULARITY_USE_EOSPAC AND SINGULARITY_USE_SPINER_WITH_HDF5)
   add_executable(get_sesame_state
     get_sesame_state.cpp)
   target_link_libraries(get_sesame_state PRIVATE
-    singularity-eos::singularity-eos)
-  add_executable(get_spiner_bounds
-    get_spiner_bounds.cpp)
-  target_link_libraries(get_spiner_bounds PRIVATE
     singularity-eos::singularity-eos)
 endif()

--- a/example/get_spiner_bounds.cpp
+++ b/example/get_spiner_bounds.cpp
@@ -29,15 +29,18 @@ int main(int argc, char *argv[]) {
 #endif
   { // begin kokkos scope
     if (argc < 3) {
-      std::cerr << "Usage: " << argv[0] << " matid sp5_filename" << std::endl;
+      std::cerr << "Usage: " << argv[0] << " matid sp5_filename [avoid vapor dome]"
+                << std::endl;
       std::exit(1);
     }
-
     const int matid = std::atoi(argv[1]);
     const std::string filename = argv[2];
-
-    singularity::SpinerEOSDependsRhoT deprt(filename, matid);
-    singularity::SpinerEOSDependsRhoSie depre(filename, matid);
+    bool pmin_vapor_dome = false;
+    if (argc >= 4) {
+      pmin_vapor_dome = atoi(argv[3]);
+    }
+    singularity::SpinerEOSDependsRhoT deprt(filename, matid, false, pmin_vapor_dome);
+    singularity::SpinerEOSDependsRhoSie depre(filename, matid, false, pmin_vapor_dome);
 
     printf("# rho bounds, depends(r, T): %.14e %.14e\n", deprt.MinimumDensity(),
            deprt.rhoMax());

--- a/example/get_spiner_bounds.cpp
+++ b/example/get_spiner_bounds.cpp
@@ -30,7 +30,6 @@ int main(int argc, char *argv[]) {
   { // begin kokkos scope
     if (argc < 3) {
       std::cerr << "Usage: " << argv[0] << " matid sp5_filename" << std::endl;
-      // std::cerr << "Arguments given: " << argc << std::endl;
       std::exit(1);
     }
 
@@ -40,14 +39,17 @@ int main(int argc, char *argv[]) {
     singularity::SpinerEOSDependsRhoT deprt(filename, matid);
     singularity::SpinerEOSDependsRhoSie depre(filename, matid);
 
-    printf("rho bounds, depends(r, T): %.14e %.14e\n", deprt.MinimumDensity(),
+    printf("# rho bounds, depends(r, T): %.14e %.14e\n", deprt.MinimumDensity(),
            deprt.rhoMax());
-    printf("rho bounds, depends(r, sie): %.14e %.14e\n", depre.MinimumDensity(),
+    printf("# rho bounds, depends(r, sie): %.14e %.14e\n", depre.MinimumDensity(),
            depre.rhoMax());
-    printf("T bounds, depends(r, T): %.14e %.14e\n", deprt.MinimumTemperature(),
+    printf("# T bounds, depends(r, T): %.14e %.14e\n", deprt.MinimumTemperature(),
            deprt.TMax());
-    printf("T bounds, depends(r, sie): %.14e %.14e\n", depre.MinimumTemperature(),
+    printf("# T bounds, depends(r, sie): %.14e %.14e\n", depre.MinimumTemperature(),
            depre.TMax());
+    printf("\n");
+    printf("# [0]: iT, [1]: T, [2] rho(Pmin, T)\n");
+    deprt.PrintRhoPMin();
 
     deprt.Finalize();
     depre.Finalize();

--- a/singularity-eos/base/spiner_table_utils.hpp
+++ b/singularity-eos/base/spiner_table_utils.hpp
@@ -310,7 +310,10 @@ struct SpinerTricks {
   static void Finalize(EOS *peos) {
     if (peos->memoryStatus_ != DataStatus::UnManaged) {
       for (auto *pdb : peos->GetDataBoxPointers_()) {
-        pdb->finalize();
+        // JMM: on host, some databoxes might be slices.
+        if (pdb->ownsAllocatedMemory()) {
+          pdb->finalize();
+        }
       }
     }
     peos->memoryStatus_ = DataStatus::Deallocated;

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -60,10 +60,6 @@ struct MixParams {
   Real min_dtde = 1.0e-16;
   std::size_t pte_small_step_tries = 2;
   Real pte_small_step_thresh = 1e-16;
-  // JMM: Smaller magnitude here means slower convergence for Maxwell
-  // constructed EOS's, but more faithfulness to the table.  This is
-  // assumed to be a negative number, and singularity-eos will make it
-  // negative if you forget.
   Real pte_max_dpdv = -1e-8;
 };
 

--- a/singularity-eos/eos/eos_gruneisen.hpp
+++ b/singularity-eos/eos/eos_gruneisen.hpp
@@ -112,7 +112,7 @@ class Gruneisen : public EosBase<Gruneisen> {
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const;
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real SpecificHeatFromDensityTemperature(
-      const Real rho, const Real temperatummmmmmre,
+      const Real rho, const Real temperature,
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
     return _Cv;
   }

--- a/singularity-eos/eos/eos_spiner_common.hpp
+++ b/singularity-eos/eos/eos_spiner_common.hpp
@@ -54,6 +54,7 @@ PORTABLE_FORCEINLINE_FUNCTION Real from_log(const Real lx, const Real offset) {
 inline herr_t aborting_error_handler(hid_t stack, void *client_data) {
   H5Eprint2(stack, stderr);
   PORTABLE_ALWAYS_THROW_OR_ABORT("HDF5 error detected! Erroring out!");
+  return -1;
 }
 
 } // namespace spiner_common

--- a/singularity-eos/eos/eos_spiner_common.hpp
+++ b/singularity-eos/eos/eos_spiner_common.hpp
@@ -91,13 +91,6 @@ PORTABLE_INLINE_FUNCTION Real SetRhoPMin(DataBox &P, DataBox &rho_at_pmin,
     PMin = std::min(PMin_at_T, PMin);
   }
 
-  // enforce monotonicity of rho_at_pmin vs T
-  for (int i = NT - 2; i >= 0; i--) {
-    if (rho_at_pmin(i) < rho_at_pmin(i + 1)) {
-      rho_at_pmin(i) = rho_at_pmin(i + 1);
-    }
-  }
-
   return PMin;
 }
 

--- a/singularity-eos/eos/eos_spiner_rho_sie.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_sie.hpp
@@ -426,8 +426,8 @@ herr_t SpinerEOSDependsRhoSie::loadDataboxes_(const std::string &matid_str, hid_
   dPdRhoMax_ = dependsRhoT_.dPdRho.slice(numRho_ - 1);
 
   // fill in minimum pressure as a function of temperature
-  SetRhoPMin(dependsRhoT_.P, rho_at_pmin_, pmin_vapor_dome_, VAPOR_DPDR_THRESH,
-             lRhoOffset_);
+  PMin_ = SetRhoPMin(dependsRhoT_.P, rho_at_pmin_, pmin_vapor_dome_, VAPOR_DPDR_THRESH,
+                     lRhoOffset_);
 
   // reference state
   Real lRhoNormal = to_log(rhoNormal_, lRhoOffset_);

--- a/singularity-eos/eos/eos_spiner_rho_temp.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_temp.hpp
@@ -1,4 +1,3 @@
-
 //------------------------------------------------------------------------------
 // © 2021-2025. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
@@ -84,18 +83,23 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   SG_ADD_DEFAULT_MEAN_ATOMIC_FUNCTIONS(AZbar_)
   SG_ADD_BASE_CLASS_USINGS(SpinerEOSDependsRhoT);
   inline SpinerEOSDependsRhoT(const std::string &filename, int matid, TableSplit split,
-                              bool reproducibility_mode = false);
+                              bool reproducibility_mode = false,
+                              bool pmin_vapor_dome = false);
   inline SpinerEOSDependsRhoT(const std::string &filename, int matid,
-                              bool reproducibility_mode = false)
-      : SpinerEOSDependsRhoT(filename, matid, TableSplit::Total, reproducibility_mode) {}
+                              bool reproducibility_mode = false,
+                              bool pmin_vapor_dome = false)
+      : SpinerEOSDependsRhoT(filename, matid, TableSplit::Total, reproducibility_mode,
+                             pmin_vapor_dome) {}
   inline SpinerEOSDependsRhoT(const std::string &filename,
                               const std::string &materialName, TableSplit split,
-                              bool reproducibility_mode = false);
+                              bool reproducibility_mode = false,
+                              bool pmin_vapor_dome = false);
   inline SpinerEOSDependsRhoT(const std::string &filename,
                               const std::string &materialName,
-                              bool reproducibility_mode = false)
+                              bool reproducibility_mode = false,
+                              bool pmin_vapor_dome = false)
       : SpinerEOSDependsRhoT(filename, materialName, TableSplit::Total,
-                             reproducibility_mode) {}
+                             reproducibility_mode, pmin_vapor_dome) {}
   PORTABLE_INLINE_FUNCTION
   SpinerEOSDependsRhoT()
       : memoryStatus_(DataStatus::Deallocated), split_(TableSplit::Total) {}
@@ -208,6 +212,9 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
     printf("%s\n\t%s\n\t%s\n\t%s%i\n\t%s\n", s1, s2, s3, s4, matid_, s5);
     return;
   }
+  PORTABLE_FORCEINLINE_FUNCTION void PrintRhoPMin() const {
+    return spiner_common::PrintRhoPMin(rho_at_pmin_, lTOffset_);
+  }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumDensity() const { return rhoMin(); }
   PORTABLE_FORCEINLINE_FUNCTION Real MinimumTemperature() const { return T_(lTMin_); }
   PORTABLE_FORCEINLINE_FUNCTION Real MaximumDensity() const { return rhoMax(); }
@@ -314,9 +321,12 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
   MeanAtomicProperties AZbar_;
   int matid_;
   TableSplit split_;
-  bool reproducible_;
+  bool reproducible_ = false;
+  bool pmin_vapor_dome_ = false;
   static constexpr const Real ROOT_THRESH = 1e-14; // TODO: experiment
   static constexpr const Real SOFT_THRESH = 1e-8;
+  // only used to exclude vapor dome
+  static constexpr const Real VAPOR_DPDR_THRESH = 1e-8;
   DataStatus memoryStatus_ = DataStatus::Deallocated;
   static constexpr const int _n_lambda = 2;
   static constexpr const char *_lambda_names[2] = {"log(rho)", "log(T)"};
@@ -324,9 +334,10 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
 
 inline SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string &filename, int matid,
                                                   TableSplit split,
-                                                  bool reproducibility_mode)
+                                                  bool reproducibility_mode,
+                                                  bool pmin_vapor_dome)
     : matid_(matid), split_(split), reproducible_(reproducibility_mode),
-      memoryStatus_(DataStatus::OnHost) {
+      pmin_vapor_dome_(pmin_vapor_dome), memoryStatus_(DataStatus::OnHost) {
 
   std::string matid_str = std::to_string(matid);
   hid_t file, matGroup, lTGroup, coldGroup;
@@ -371,9 +382,10 @@ inline SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string &filename, i
 inline SpinerEOSDependsRhoT::SpinerEOSDependsRhoT(const std::string &filename,
                                                   const std::string &materialName,
                                                   TableSplit split,
-                                                  bool reproducibility_mode)
+                                                  bool reproducibility_mode,
+                                                  bool pmin_vapor_dome)
     : split_(split), reproducible_(reproducibility_mode),
-      memoryStatus_(DataStatus::OnHost) {
+      pmin_vapor_dome_(pmin_vapor_dome), memoryStatus_(DataStatus::OnHost) {
 
   std::string matid_str;
   hid_t file, matGroup, lTGroup, coldGroup;
@@ -495,20 +507,7 @@ inline herr_t SpinerEOSDependsRhoT::loadDataboxes_(const std::string &matid_str,
   setlTColdCrit_();
 
   // fill in minimum pressure as a function of temperature
-  rho_at_pmin_.resize(numT_);
-  rho_at_pmin_.setRange(0, P_.range(0));
-  for (int i = 0; i < numT_; i++) {
-    PMin_ = std::numeric_limits<Real>::max();
-    int jmax = -1;
-    for (int j = 0; j < numRho_; j++) {
-      if (P_(j, i) < PMin_) {
-        PMin_ = P_(j, i);
-        jmax = j;
-      }
-    }
-    if (jmax < 0) printf("Failed to find minimum pressure.\n");
-    rho_at_pmin_(i) = rho_(P_.range(1).x(jmax));
-  }
+  SetRhoPMin(P_, rho_at_pmin_, pmin_vapor_dome_, VAPOR_DPDR_THRESH, lRhoOffset_);
 
   // fill in Gruneisen parameter and bulk modulus on cold curves
   // unfortunately, EOSPAC's output for these parameters appears

--- a/singularity-eos/eos/eos_spiner_rho_temp.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_temp.hpp
@@ -507,7 +507,7 @@ inline herr_t SpinerEOSDependsRhoT::loadDataboxes_(const std::string &matid_str,
   setlTColdCrit_();
 
   // fill in minimum pressure as a function of temperature
-  SetRhoPMin(P_, rho_at_pmin_, pmin_vapor_dome_, VAPOR_DPDR_THRESH, lRhoOffset_);
+  PMin_ = SetRhoPMin(P_, rho_at_pmin_, pmin_vapor_dome_, VAPOR_DPDR_THRESH, lRhoOffset_);
 
   // fill in Gruneisen parameter and bulk modulus on cold curves
   // unfortunately, EOSPAC's output for these parameters appears

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -442,6 +442,20 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
                      sietot, Tguess, alpha1_true, alpha2_true, Ttrue, Ptrue);
 
       THEN("The solver converges") { REQUIRE(success); }
+
+      AND_WHEN("We call PTE but with a wildly incorrect temperature guess, deep in the "
+               "Maxwell constructed region") {
+        constexpr Real alpha1_true = 9.99999989159325e-01;
+        constexpr Real alpha2_true = 1.08406754944454e-08;
+        constexpr Real Ttrue = 3.02477729062119e+02;
+        constexpr Real Ptrue = 9.98701227398616e+05;
+
+        bool success =
+            RunPTE2Mat(He_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
+                       sietot, 5, alpha1_true, alpha2_true, Ttrue, Ptrue);
+
+        THEN("The solver converges") { REQUIRE(success); }
+      }
     }
 
     He_eos_h.Finalize();

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -417,6 +417,15 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
     EOS foam_eos_h = SpinerEOSDependsRhoT(eos_file, foam_matid);
     EOS foam_eos = foam_eos_h.GetOnDevice();
 
+    WHEN("We request density at minimum pressure") {
+      Real rhopmin_100 = foam_eos_h.RhoPmin(100);
+      Real rhopmin_300 = foam_eos_h.RhoPmin(300);
+      THEN("It's zero, as appropriate for a Maxwell constructed EOS") {
+        REQUIRE(rhopmin_100 == 0);
+        REQUIRE(rhopmin_300 == 0);
+      }
+    }
+
     constexpr Real rhobar1 = 1.59761356859602e-04;
     constexpr Real rhobar2 = 7.81928505957464e-09;
     constexpr Real alpha_guess1 = 9.99999776549350e-01;

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -445,15 +445,9 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
 
       AND_WHEN("We call PTE but with a wildly incorrect temperature guess, deep in the "
                "Maxwell constructed region") {
-        constexpr Real alpha1_true = 9.99999989159325e-01;
-        constexpr Real alpha2_true = 1.08406754944454e-08;
-        constexpr Real Ttrue = 3.02477729062119e+02;
-        constexpr Real Ptrue = 9.98701227398616e+05;
-
         bool success =
             RunPTE2Mat(He_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
                        sietot, 5, alpha1_true, alpha2_true, Ttrue, Ptrue);
-
         THEN("The solver converges") { REQUIRE(success); }
       }
     }

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -419,10 +419,8 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
 
     WHEN("We request density at minimum pressure") {
       Real rhopmin_100 = foam_eos_h.RhoPmin(100);
-      Real rhopmin_300 = foam_eos_h.RhoPmin(300);
       THEN("It's zero, as appropriate for a Maxwell constructed EOS") {
         REQUIRE(rhopmin_100 == 0);
-        REQUIRE(rhopmin_300 == 0);
       }
     }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This MR pre-empts #538 . In investigation of the PTE solver for riot, I noticed that table density often determined whether or not a solver converged. It turned out that this was partly due to the `RhoPMin` machinery not handling the vapor dome of a Maxwell constructed EOS correctly. The vapor dome is problematic for a PTE solver because the Maxwell construction flattens out the slope of $\partial P/\partial \rho$ in that region. This means the Jacobian for the Newton solver may have a trivial direction, which can prevent the solver from escaping the region and finding a different solution. On the other hand, the Maxwell constructed region may contain physically meaningful states we wish to access, so we usually don't want to completely exclude it.

There was another problem, which was that `RhoPMin` was reporting seemingly random values for a Maxwell constructed EOS, where it should report 0. I have resolved these issues with several changes:

1. I add a floor to $\partial P/\partial \rho$ so that the Jacobian doesn't trivialize. In practice, this is actually a *ceiling* on $\partial P/\partial\alpha$ for volume fraction $\alpha$ (for most solvers). This ceiling can be set by the user with the `MixParams` struct.
2. I modify the `rho_at_pmin` logic in the spiner tables to correctly detect a Maxwell constructed EOS (or gas EOS) and in those cases report that the density at Pmin is 0.
3. *optionally* rho_at_pmin may instead be interpreted to report the edge of the vapor dome. It only does so if requested when the EOS is constructed. 

Note that there's also an unfortunate interaction between sesame and eospac for Maxwell constructed equations of state, which is that because eospac's rational function interpolation can overshoot at the edge of the vapor dome, a Maxwell constructed EOS may still have a region of negative pressure near the edge of the vapor dome, when interpreted as a continuous function. It's dangerous to still set rho_at_pmin to 0 in this case, because there genuinely is a region of "negative slope" in the continuum representation output by eospac.

I think fixing this would require modification of EOSPAC, or leveraging a priori knowledge of whether or not a table is Maxwell constructed. This might be possible in `sesame2spiner` in some cases, as I discuss in #542 . For now I let it be. The `rho_at_pmin` algorithm will detect that rho_at_pmin = 0 for most temperatures where eospac doesn't overshoot, but may find a finite rho_at_pmin for some temperatures. I just let this happen.

It may also be worth adding an ability to Spiner to extrapolate to exactly zero pressure/density as described in #541 .

One advantage of these changes is that the PTE solver is now more robust (again). IN particular, some dependencies on spiner table density are now relaxed and coarser tables are possible. Also we can now provide wildly incorrect temperature guesses, for example we can guess a temperature very close to 0 K and the solver will still converge for a difficult state.

Thanks to @jhp-lanl and @pdmullen for your feedback as I worked through the right thing to do here.

As an aside, I have a few more robustness tweaks I'm working on for the PTE solver, so keep an eye out for that. Then it's probably time for another release.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
