### PR TITLE
Robustness improvements to the reduced rho-T system and clarity in residual tol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [[PR524]](https://github.com/lanl/singularity-eos/pull/524) Fix future kokkos-kernels compatibility in PTE solver
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR548]](https://github.com/lanl/singularity-eos/pull/548) Change which tolerances are available for the PTE solver and how they are interpreted to hopefully provide more clarity
 - [[PR545]](https://github.com/lanl/singularity-eos/pull/545) Implement reduced system for PTESolverRhoT
 - [[PR543]](https://github.com/lanl/singularity-eos/pull/543) Made PTE solvers more robust for Maxwell constructed tables
 - [[PR502]](https://github.com/lanl/singularity-eos/pull/502) Expose split tables to Fortran interface

--- a/doc/sphinx/src/using-closures.rst
+++ b/doc/sphinx/src/using-closures.rst
@@ -659,29 +659,40 @@ contains the following member fields, with default values:
 
 .. code-block:: cpp
 
-  struct MixParams {
-    bool verbose = false; // verbosity
-    Real derivative_eps = 3.0e-6;
-    Real pte_rel_tolerance_p = 1.e-6;
-    Real pte_rel_tolerance_e = 1.e-6;
-    Real pte_rel_tolerance_t = 1.e-4;
-    Real pte_abs_tolerance_p = 0.0;
-    Real pte_abs_tolerance_e = 1.e-4;
-    Real pte_abs_tolerance_t = 0.0;
-    Real pte_residual_tolerance = 1.e-8;
-    std::size_t pte_max_iter_per_mat = 128;
-    Real line_search_alpha = 1.e-2;
-    std::size_t line_search_max_iter = 6;
-    Real line_search_fac = 0.5;
-    Real vfrac_safety_fac = 0.95;
-    Real temperature_limit = 1.0e15;
-    Real default_tguess = 300.;
-    Real min_dtde = 1.0e-16;
-    std::size_t pte_small_step_tries = 2;
-    Real pte_small_step_thresh = 1e-16;
-    Real pte_max_dpdv = -1e-8;
-    std::int64_t pte_reduced_system_exclude_idx = -1;  // choose index with largest mass fraction
-  };
+struct MixParams {
+  bool verbose = false;
+  bool iterate_t_guess = true;
+  Real derivative_eps = 3.0e-6;
+  Real pte_rel_tolerance_p = 1.0e-6;
+  Real pte_rel_tolerance_t = 1.0e-4;
+  Real pte_rel_tolerance_e = 1.0e-6;
+  Real pte_rel_tolerance_v = 1.0e-6;
+  Real pte_abs_tolerance_p = 1.0e-6;
+  Real pte_abs_tolerance_t = 1.0e-4;
+
+  Real pte_slow_convergence_thresh = 0.99;
+  Real pte_rel_tolerance_p_sufficient = 1.e2 * pte_rel_tolerance_p;
+  Real pte_rel_tolerance_t_sufficient = 10 * pte_rel_tolerance_t;
+  Real pte_rel_tolerance_e_sufficient = 1.e2 * pte_rel_tolerance_e;
+  Real pte_rel_tolerance_v_sufficient = 1.e2 * pte_rel_tolerance_v;
+  Real pte_abs_tolerance_p_sufficient = 1.e2 * pte_abs_tolerance_p;
+  Real pte_abs_tolerance_t_sufficient = 10 * pte_abs_tolerance_t;
+
+  std::size_t pte_max_iter_per_mat = 128;
+  Real line_search_alpha = 1.e-2;
+  std::size_t line_search_max_iter = 6;
+  Real line_search_fac = 0.5;
+  Real vfrac_safety_fac = 0.95;
+  Real temperature_limit = 1.0e15;
+  Real default_tguess = 300.;
+  Real min_dtde = 1.0e-16;
+  std::size_t pte_small_step_tries = 2;
+  Real pte_small_step_thresh = 1e-16;
+  Real pte_max_dpdv = -1e-8;
+
+  // choose index with largest mass fraction
+  std::int64_t pte_reduced_system_exclude_idx = -1;
+};
 
 where here ``verbose`` enables verbose output in the PTE solve is,
 ``derivative_eps`` is the spacing used for finite differences
@@ -690,8 +701,31 @@ evaluations of equations of state when building a jacobian. The
 ``pte_rel_tolerance_t`` variables are relative tolerances for the
 error in the pressure, energy, temperature respectively. The
 ``pte_abs_tolerance_*`` variables are the same but are absolute,
-rather than relative tolerances. ``pte_residual_tolerance`` is the
-absolute tolerance for the residual.
+rather than relative tolerances. There are no absolute tolerances for
+energy and volume fraction, as the solver works on these in a
+normalized space.
+
+Sometimes the PTE solver may find something that looks very much like
+a solution, but not meet the set tolerances, due to the limits of
+floating point arithmetic at that point in the residual space. For
+example, digits may be lost in the Jacobian inversion or the residual
+itself may suffer catastrophic cancellation. In these cases, the user
+may still wish to call this a success. This is the reason for the
+``pte_slow_convergence_thresh`` and ``pte_*_tolerance_*_sufficient``
+variables. If between two iterations the residual does not decrease to
+``pte_slow_convergence_thresh`` times its previous value or smaller,
+**and** the errors in the relevant variables are within the
+``_sufficient`` tolerances, the solver will consider that "good
+enough" and report succesful convergence. In general these should be
+set to an order of magnitude or two less strict than the desired
+tolerance.
+
+.. note::
+
+  The default tolerances are relatively loose. A user may wish to
+  enforce stricter tolerances. Relative/tolerances of :math:`10^{-12}`
+  for the desired and :math:`10^{-10}` may converge more slowly but
+  are expected to converge in most contexts.
 
 The maximum number of iterations the solver is allowed to take before
 giving up is ``pte_max_iter_per_mat`` multiplied by the number of

--- a/doc/sphinx/src/using-closures.rst
+++ b/doc/sphinx/src/using-closures.rst
@@ -690,7 +690,7 @@ struct MixParams {
   Real pte_small_step_thresh = 1e-16;
   Real pte_max_dpdv = -1e-8;
 
-  // choose index with largest mass fraction
+  // choose index with largest volume fraction
   std::int64_t pte_reduced_system_exclude_idx = -1;
 };
 

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -199,11 +199,11 @@ bool solve_Ax_b_wscr(const std::size_t n, Real *a, Real *b, Real *scr) {
 #endif
     // Eigen VERSION
     using Matrix_t = Eigen::Matrix<Real, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
-    Eigen::Map<Matrix_t> A(a, n, n);
+    Eigen::Map<Matrix_t> A(alu, n, n);
 
     Eigen::Map<Eigen::VectorXd> B(b, n);
     Eigen::Map<Eigen::VectorXd> X(scr, n);
-    X = A.lu().solve(B);
+    X = A.colPivHouseholderQr().solve(B);
 
     B = X;
 #endif // SINGULARITY_USE_KOKKOSKERNELS

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -199,7 +199,7 @@ bool solve_Ax_b_wscr(const std::size_t n, Real *a, Real *b, Real *scr) {
 #endif
     // Eigen VERSION
     using Matrix_t = Eigen::Matrix<Real, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
-    Eigen::Map<Matrix_t> A(alu, n, n);
+    Eigen::Map<Matrix_t> A(a, n, n);
 
     Eigen::Map<Eigen::VectorXd> B(b, n);
     Eigen::Map<Eigen::VectorXd> X(scr, n);

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -19,6 +19,7 @@
 #include <ports-of-call/portable_errors.hpp>
 #include <singularity-eos/base/fast-math/logs.hpp>
 #include <singularity-eos/base/robust_utils.hpp>
+#include <singularity-eos/base/variadic_utils.hpp>
 #include <singularity-eos/eos/eos.hpp>
 
 #include <cmath>
@@ -275,7 +276,7 @@ class PTESolverBase {
   // Finalize restores the temperatures, energies, and pressures to unscaled values from
   // the internally scaled quantities used by the solvers
   PORTABLE_INLINE_FUNCTION
-  void Finalize() {
+  virtual void Finalize() {
     for (std::size_t m = 0; m < nmat; m++) {
       temp[m] *= Tnorm;
       u[m] *= uscale;
@@ -1186,9 +1187,15 @@ class PTESolverPT
   PORTABLE_INLINE_FUNCTION
   void Finalize() {
     for (std::size_t m = 0; m < nmat; m++) {
-      press[m] = Pequil * uscale;
-      temp[m] = Tequil * Tnorm;
-      u[m] *= uscale;
+      if (!variadic_utils::is_nullptr(press)) {
+        press[m] = Pequil * uscale;
+      }
+      if (!variadic_utils::is_nullptr(temp)) {
+        temp[m] = Tequil * Tnorm;
+      }
+      if (!variadic_utils::is_nullptr(u)) {
+        u[m] *= uscale;
+      }
     }
   }
 

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -211,9 +211,9 @@ struct IdentityOperator {
   PORTABLE_FORCEINLINE_FUNCTION Real operator()(const Real x) const { return x; }
 };
 template <typename Data_t, typename Operator_t = IdentityOperator>
-PORTABLE_INLINE_FUNCTION Real sum_neumaier(Data_t &&data, std::size_t n,
-                                           std::size_t offset = 0, std::size_t iskip = -1,
-                                           const Operator_t &op = IdentityOperator()) {
+PORTABLE_FORCEINLINE_FUNCTION Real
+sum_neumaier(Data_t &&data, std::size_t n, std::size_t offset = 0, std::size_t iskip = -1,
+             const Operator_t &op = IdentityOperator()) {
   Real sum = 0;
   Real c = 0; // correction
   for (std::size_t i = 0; i < n; ++i) {

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -874,7 +874,7 @@ class PTESolverRhoT
   }
 
   PORTABLE_INLINE_FUNCTION
-  void Fixup() {
+  virtual void Fixup() {
     // Volume fractions normalized by construction in this
     // formulation, so no reason to normalize them here the way
     // PTESolverBase does.
@@ -2072,7 +2072,7 @@ PORTABLE_INLINE_FUNCTION SolverStatus PTESolver(System &s) {
     // Check for convergence
     // TODO(JMM): I wish I could use std::tie or structured binding,
     // but our clang-based toolchain does not like it
-    auto check = s.CheckPTE(); 
+    auto check = s.CheckPTE();
     converged = check.first;
     close_enough = check.second;
     if (converged) break;

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -271,7 +271,7 @@ class PTESolverBase {
   // after each iteration of the Newton solver.  This version just renormalizes the
   // volume fractions, which is useful to deal with roundoff error.
   PORTABLE_INLINE_FUNCTION
-  virtual void Fixup() const { NormalizeVfrac(); }
+  virtual void Fixup() { NormalizeVfrac(); }
   // Finalize restores the temperatures, energies, and pressures to unscaled values from
   // the internally scaled quantities used by the solvers
   PORTABLE_INLINE_FUNCTION
@@ -874,7 +874,7 @@ class PTESolverRhoT
   }
 
   PORTABLE_INLINE_FUNCTION
-  virtual void Fixup() {
+  void Fixup() {
     // Volume fractions normalized by construction in this
     // formulation, so no reason to normalize them here the way
     // PTESolverBase does.

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -866,7 +866,10 @@ class PTESolverRhoT
 
   PORTABLE_INLINE_FUNCTION
   void Fixup() {
-    NormalizeVfrac();
+    // Volume fractions normalized by construction in this
+    // formulation, so no reason to normalize them here the way
+    // PTESolverBase does.
+    //
     // Re-pick the material to exclude based on largest volume
     // fraction, now that perhaps the volume fractions have been
     // updated
@@ -879,10 +882,10 @@ class PTESolverRhoT
           ms = m;
         }
       }
+      // With the excluded material changed, the residual must be
+      // recomputed
+      Residual();
     }
-    // With the excluded material changed, the residual must be
-    // recomputed
-    Residual();
   }
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -2070,7 +2070,11 @@ PORTABLE_INLINE_FUNCTION SolverStatus PTESolver(System &s) {
     status.max_niter = std::max(status.max_niter, niter);
 
     // Check for convergence
-    std::tie(converged, close_enough) = s.CheckPTE();
+    // TODO(JMM): I wish I could use std::tie or structured binding,
+    // but our clang-based toolchain does not like it
+    auto check = s.CheckPTE(); 
+    converged = check.first;
+    close_enough = check.second;
     if (converged) break;
 
     // compute the Jacobian

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -51,11 +51,11 @@ struct MixParams {
 
   Real pte_slow_convergence_thresh = 0.99;
   Real pte_rel_tolerance_p_sufficient = 1.e2 * pte_rel_tolerance_p;
-  Real pte_rel_tolerance_t_sufficient = 1.e2 * pte_rel_tolerance_t;
+  Real pte_rel_tolerance_t_sufficient = 10 * pte_rel_tolerance_t;
   Real pte_rel_tolerance_e_sufficient = 1.e2 * pte_rel_tolerance_e;
   Real pte_rel_tolerance_v_sufficient = 1.e2 * pte_rel_tolerance_v;
   Real pte_abs_tolerance_p_sufficient = 1.e2 * pte_abs_tolerance_p;
-  Real pte_abs_tolerance_t_sufficient = 1.e2 * pte_abs_tolerance_t;
+  Real pte_abs_tolerance_t_sufficient = 10 * pte_abs_tolerance_t;
 
   std::size_t pte_max_iter_per_mat = 128;
   Real line_search_alpha = 1.e-2;

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -443,11 +443,10 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
 
       THEN("The solver converges") { REQUIRE(success); }
 
-      AND_WHEN("We call PTE but with a wildly incorrect temperature guess, deep in the "
+      AND_WHEN("We call PTE but with wildly incorrect initial guesses, deep in the "
                "Maxwell constructed region") {
-        bool success =
-            RunPTE2Mat(He_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
-                       sietot, 5, alpha1_true, alpha2_true, Ttrue, Ptrue);
+        bool success = RunPTE2Mat(He_eos, foam_eos, rhobar1, rhobar2, 1e-9, 1, sietot, 5,
+                                  alpha1_true, alpha2_true, Ttrue, Ptrue);
         THEN("The solver converges") { REQUIRE(success); }
       }
     }

--- a/test/test_closure_pte.cpp
+++ b/test/test_closure_pte.cpp
@@ -161,10 +161,18 @@ bool run_PTE_from_state(const int num_pte, EOS *v_EOS, const Real spvol_bulk,
   return pte_converged;
 }
 
+template <typename T>
+PORTABLE_INLINE_FUNCTION void swap(T &a, T &b) {
+  T tmp = a;
+  a = b;
+  b = tmp;
+}
+
 // TODO(JMM): Clean this up to account for these two differetn APIs
 inline bool RunPTE2Mat(EOS eos1, EOS eos2, Real rhobar1, Real rhobar2, Real alpha_guess1,
                        Real alpha_guess2, Real sietot, Real Tguess, Real alpha1_true,
-                       Real alpha2_true, Real Ttrue, Real Ptrue) {
+                       Real alpha2_true, Real Ttrue, Real Ptrue,
+                       bool permute_state = false) {
   constexpr int NT = 1;
   constexpr int NEOS = 2;
 
@@ -184,8 +192,8 @@ inline bool RunPTE2Mat(EOS eos1, EOS eos2, Real rhobar1, Real rhobar2, Real alph
   // The pte_params object contains a number of settings you can
   // modify for the PTE solver, such as tolerances.
   singularity::MixParams pte_params;
-  pte_params.pte_rel_tolerance_p = 1e-12;
-  pte_params.pte_rel_tolerance_e = 1e-12;
+  pte_params.pte_rel_tolerance_p = 1e-10;
+  pte_params.pte_rel_tolerance_e = 1e-10;
   pte_params.pte_abs_tolerance_p = 0;
 
   int nsuccess = 0;
@@ -200,6 +208,13 @@ inline bool RunPTE2Mat(EOS eos1, EOS eos2, Real rhobar1, Real rhobar2, Real alph
 
         eos[0] = eos1;
         eos[1] = eos2;
+
+        if (permute_state) {
+          swap(alpha[0], alpha[1]);
+          swap(rho[0], rho[1]);
+          swap(eos[0], eos[1]);
+        }
+
         MyLambdaIndexer<NEOS> lambda(plambda);
 
         singularity::PTESolverRhoT<EOS *, Real *, MyLambdaIndexer<NEOS>> method(
@@ -207,6 +222,10 @@ inline bool RunPTE2Mat(EOS eos1, EOS eos2, Real rhobar1, Real rhobar2, Real alph
             Tguess, pte_params);
         // Run the solver
         auto status = singularity::PTESolver(method);
+
+        if (permute_state) {
+          swap(alpha[0], alpha[1]);
+        }
 
         bool success = true;
         if (!status.converged) {
@@ -443,6 +462,13 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
 
       THEN("The solver converges") { REQUIRE(success); }
 
+      AND_WHEN("We call PTE with a permuted state") {
+        bool success =
+            RunPTE2Mat(He_eos, foam_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
+                       sietot, Tguess, alpha1_true, alpha2_true, Ttrue, Ptrue, true);
+        THEN("The solver converges") { REQUIRE(success); }
+      }
+
       AND_WHEN("We call PTE but with wildly incorrect initial guesses, deep in the "
                "Maxwell constructed region") {
         bool success = RunPTE2Mat(He_eos, foam_eos, rhobar1, rhobar2, 1e-9, 1, sietot, 5,
@@ -455,6 +481,44 @@ SCENARIO("Density- and Pressure-Temperature PTE Solvers", "[PTE]") {
     He_eos.Finalize();
     foam_eos_h.Finalize();
     foam_eos.Finalize();
+  }
+
+  GIVEN("A cell containing nearly equal amounts of mass of copper and helium") {
+    const std::string eos_file = "../materials.sp5";
+    constexpr Real gm1 = 0.666666666666667;
+    constexpr Real Cv = 3.1e7;
+    EOS He_eos_h = IdealGas(gm1, Cv);
+    EOS He_eos = He_eos_h.GetOnDevice();
+
+    constexpr int Cu_matid = 3337;
+    EOS copper_eos_h = SpinerEOSDependsRhoT(eos_file, Cu_matid);
+    EOS copper_eos = copper_eos_h.GetOnDevice();
+
+    constexpr Real rhobar1 = 1.5e-4;
+    constexpr Real rhobar2 = 1.6e-4;
+    constexpr Real alpha_guess1 = 1.0e-5; // this is backwards from
+                                          // the true volume fractions
+    constexpr Real alpha_guess2 = 1 - alpha_guess1;
+    constexpr Real sietot = 4.5e9;
+    constexpr Real Tguess = 30;
+
+    WHEN("We call PTE") {
+      constexpr Real alpha1_true = 9.99982100645951e-01;
+      constexpr Real alpha2_true = 1.78993540487246e-05;
+      constexpr Real Ttrue = 2.99769986713113e+02;
+      constexpr Real Ptrue = 9.29303592744676e+05;
+
+      bool success =
+          RunPTE2Mat(He_eos, copper_eos, rhobar1, rhobar2, alpha_guess1, alpha_guess2,
+                     sietot, Tguess, alpha1_true, alpha2_true, Ttrue, Ptrue);
+
+      THEN("The solver converges") { REQUIRE(success); }
+    }
+
+    He_eos_h.Finalize();
+    He_eos.Finalize();
+    copper_eos_h.Finalize();
+    copper_eos.Finalize();
   }
 }
 #endif // SINGULARITY_USE_SPINER_WITH_HDF5

--- a/test/test_pte.cpp
+++ b/test/test_pte.cpp
@@ -149,13 +149,14 @@ auto TestPTE(const std::string name, const std::size_t nscratch_vars,
             << std::endl;
 
   singularity::MixParams params;
-  params.pte_rel_tolerance_e = 1e-22;
-  params.pte_abs_tolerance_e = 1e-22;
-  params.pte_abs_tolerance_v = 1e-22;
-  params.pte_rel_tolerance_v = 1e-22;
-  params.pte_rel_tolerance_p = 1e-22;
-  params.pte_abs_tolerance_p = 1e-22;
-  params.pte_residual_tolerance = 1.e-22;
+  params.pte_rel_tolerance_e = 1e-16;
+  params.pte_rel_tolerance_v = 1e-16;
+  params.pte_rel_tolerance_p = 1e-16;
+  params.pte_abs_tolerance_p = 1e-14;
+  params.pte_rel_tolerance_e_sufficient = 1e-14;
+  params.pte_rel_tolerance_v_sufficient = 1e-14;
+  params.pte_rel_tolerance_p_sufficient = 1e-14;
+  params.pte_abs_tolerance_p_sufficient = 1e-12;
   params.iterate_t_guess = false;
   params.pte_small_step_thresh = 1e-22;
   params.pte_small_step_tries = 100;

--- a/test/test_pte.cpp
+++ b/test/test_pte.cpp
@@ -153,10 +153,10 @@ auto TestPTE(const std::string name, const std::size_t nscratch_vars,
   params.pte_rel_tolerance_v = 1e-16;
   params.pte_rel_tolerance_p = 1e-16;
   params.pte_abs_tolerance_p = 1e-14;
-  params.pte_rel_tolerance_e_sufficient = 1e-14;
-  params.pte_rel_tolerance_v_sufficient = 1e-14;
-  params.pte_rel_tolerance_p_sufficient = 1e-14;
-  params.pte_abs_tolerance_p_sufficient = 1e-12;
+  params.pte_rel_tolerance_e_sufficient = 1e-6;
+  params.pte_rel_tolerance_v_sufficient = 1e-6;
+  params.pte_rel_tolerance_p_sufficient = 1e-6;
+  params.pte_abs_tolerance_p_sufficient = 1e-6;
   params.iterate_t_guess = false;
   params.pte_small_step_thresh = 1e-22;
   params.pte_small_step_tries = 100;

--- a/test/test_pte_ideal.cpp
+++ b/test/test_pte_ideal.cpp
@@ -101,12 +101,13 @@ int ComparePTEs(EOS_Indexer_t eoss, const std::size_t NEOS, const std::size_t NT
 
   singularity::MixParams params;
   params.pte_rel_tolerance_e = 1e-14;
-  params.pte_abs_tolerance_e = 1e-14;
-  params.pte_abs_tolerance_v = 1e-14;
   params.pte_rel_tolerance_v = 1e-14;
   params.pte_rel_tolerance_p = 1e-14;
   params.pte_abs_tolerance_p = 1e-14;
-  params.pte_residual_tolerance = 1.e-14;
+  params.pte_rel_tolerance_e_sufficient = 1e-22;
+  params.pte_rel_tolerance_v_sufficient = 1e-22;
+  params.pte_rel_tolerance_p_sufficient = 1e-22;
+  params.pte_abs_tolerance_p_sufficient = 1e-22;
 
   int nsuccess = 0;
   portableReduce(


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

My previous MR #545 implemented the reduced rho-T system. However, I noticed a robustness issue which is that excluding the material with the largest mass fraction can be led astray when, for example, a heavy material is in a mixed cell with a light one. To improve robustness, the solver now switches which material to exclude every cycle. I add additional tests to add confidence for this, including a mixed Helium/Copper cell.

I also spent a lot of time thinking about what on earth the residual tolerance in the solver means and is doing. My take is the following: it is checking whether or not we consider the solver to be "good enough" after it starts to fail to find a gradient descent direction. This is indeed a common fail-safe/fallback in solvers, including in, e.g., numerical recipes. 

I revamped this system a little bit to make this functionality more clear and more fine-grained. I add tolerances for each component of the residual, now called `*_sufficient`. When `CheckPTE` is called, it checks both for convergence and "good enough" based on this criteria. The "good enough" condition is only utilized, however, if the residual is not decreasing sufficiently between steps. I made this user-settable and a much tighter check by default.

Note that the default tolerance for the `sufficient` thresholds may look looser than `residual_thresh` looked but it's actually tighter. `residual_thresh` is on the *square* of the residual, because that's how it's formulated in the Newton solver literature, where-as the `_sufficient` thresholds are essentially an $L_1$ or $L_2$ norm. 

I also removed the absolute tolerances for energy and volume fraction, as they did nothing, because energy and volume fraction are normalized the absolute and relative tolerances are identical.

Finally I tweaked the `pte_2mat` example a little bit based on my current experiments. It reports more information now, including timing.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
