### PR TITLE
Make SINGULARITY_EOSPAC_USE_MODERN_ERROR_CODES dependent option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,9 @@ option(SINGULARITY_USE_EOSPAC "Enable eospac backend" OFF)
 option(SINGULARITY_EOSPAC_ENABLE_SHMEM
   "Support shared memory with EOSPAC backend. Requires EOSPAC version 6.5.7."
   OFF)
-option(SINGULARITY_EOSPAC_USE_MODERN_ERROR_CODES
+cmake_dependent_option(SINGULARITY_EOSPAC_USE_MODERN_ERROR_CODES
   "Use the current eospac implementation of error codes, which must be compared with a function. Requires EOSPAC version 6.3.0 or greater."
-  ON)
+  OFF "SINGULARITY_USE_EOSPAC" ON)
 
 # TODO This should be dependent option (or fortran option)
 option(SINGULARITY_BUILD_CLOSURE "Mixed Cell Closure" ON)


### PR DESCRIPTION
The SINGULARITY_EOSPAC_USE_MODERN_ERROR_CODES was not dependent on EOSPAC being on. This option shouldn't be exposed unless EOSPAC is on.

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
