### PR TITLE
Create `safeGet` and `safeSet` for indexable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed (Repair bugs, etc)
 - [[PR561]](https://github.com/lanl/singularity-eos/pull/561) Fix logic for kokkos-kernels in spackage so that it is only required for closure models on GPU
+- [[PR564]](https://github.com/lanl/singularity-eos/pull/564) Fix logic for numerical vs type indices by adding safeGet() and safeSet() helpers
 
 ### Changed (changing behavior/API/variables/...)
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -699,6 +699,8 @@ of the ``[]`` operator that takes your type. For example:
 
   class MyLambda_t {
   public:
+    // Enable recognition that this is type-indexable
+    constexpr static bool is_type_indexable = true;
     MyLambda_t() = default;
     PORTABLE_FORCEINLINE_FUNCTION
     Real &operator[](const std::size_t idx) const {
@@ -724,17 +726,53 @@ which might be used as
 where ``MeanIonizationState`` is shorthand for index 2, since you
 defined that overload. Note that the ``operator[]`` must be marked
 ``const``. To more easily enable mixing and matching integer-based
-indexing with type-based indexing, the function
+indexing with type-based indexing, the functions
 
 .. code-block:: cpp
 
-  template<typename Name_t, typename Indexer_t>
+  template <typename T, typename Indexer_t>
   PORTABLE_FORCEINLINE_FUNCTION
-  Real &Get(Indexer_t &&lambda, std::size_t idx = 0);
+  inline bool safeGet(Indexer_t const &lambda, std::size_t const idx, Real &out);
 
-will return a reference to the value at named index ``Name_t()`` if
-that overload is defined in ``Indexer_t`` and otherwise return a
-reference at index ``idx``.
+.. code-block:: cpp
+
+  template <typename T, typename Indexer_t>
+  PORTABLE_FORCEINLINE_FUNCTION
+  inline bool safeGet(Indexer_t const &lambda, Real &out);
+
+will update the value of ``out`` with the value at either the appropriate
+type-based index, ``T``, or the numerical index, ``idx``, if the ``Indexer_t``
+doesn't accept type-based indexing. If the ``Indexer_t`` **does** accept
+type-based indexing but **doesn't** have the requested index, then the
+``out`` value is not updated. The same is true for when ``Indexer_t`` is the
+``nullptr``. The overload that doesn't take a numerical index will *only*
+return the value at a type-based index.
+
+Similarly, the functions
+
+.. code-block:: cpp
+
+  template <typename T, typename Indexer_t>
+  PORTABLE_FORCEINLINE_FUNCTION
+  inline bool safeSet(Indexer_t &lambda, std::size_t const idx, Real const in);
+
+.. code-block:: cpp
+
+  template <typename T, typename Indexer_t>
+  PORTABLE_FORCEINLINE_FUNCTION
+  inline bool safeSet(Indexer_t &lambda, Real const in)
+
+can modify the values in the ``Indexer_t`` and behave the same way. In this way,
+if a type-based index isn't present in the container, then another index won't
+be overwritten.
+
+.. note::
+
+  Previous versions defined a ``Get()`` function that was "unsafe" in the
+  sense that it would fall back on the numerical index even if a type-based
+  indexer was used. This could result in retrieving and overwriting incorrect
+  values in the indexer. We recommend not using this function and instead using
+  the "safe" versions.
 
 As a convenience tool, the struct
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -732,13 +732,25 @@ indexing with type-based indexing, the functions
 
   template <typename T, typename Indexer_t>
   PORTABLE_FORCEINLINE_FUNCTION
-  inline bool safeGet(Indexer_t const &lambda, std::size_t const idx, Real &out);
+  bool SafeGet(Indexer_t const &lambda, std::size_t const idx, Real &out);
 
 .. code-block:: cpp
 
   template <typename T, typename Indexer_t>
   PORTABLE_FORCEINLINE_FUNCTION
-  inline bool safeGet(Indexer_t const &lambda, Real &out);
+  bool SafeGet(Indexer_t const &lambda, Real &out);
+
+.. code-block:: cpp
+
+  template <typename T, typename Indexer_t>
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real SafeMustGet(Indexer_t const &lambda, std::size_t const idx)
+
+.. code-block:: cpp
+
+  template <typename T, typename Indexer_t>
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real SafeMustGet(Indexer_t const &lambda)
 
 will update the value of ``out`` with the value at either the appropriate
 type-based index, ``T``, or the numerical index, ``idx``, if the ``Indexer_t``
@@ -746,7 +758,11 @@ doesn't accept type-based indexing. If the ``Indexer_t`` **does** accept
 type-based indexing but **doesn't** have the requested index, then the
 ``out`` value is not updated. The same is true for when ``Indexer_t`` is the
 ``nullptr``. The overload that doesn't take a numerical index will *only*
-return the value at a type-based index.
+return the value at a type-based index. The ``SafeMustGet()`` version
+is intended to generate errors if a value can't be retrieved. In the case of
+type-based indexing, the error will be at compile time if the type isn't located
+in the indexer. A runtime abort will occur if either the null pointer is passed
+or if integer indexing isn't allowed for some reason.
 
 Similarly, the functions
 
@@ -754,17 +770,31 @@ Similarly, the functions
 
   template <typename T, typename Indexer_t>
   PORTABLE_FORCEINLINE_FUNCTION
-  inline bool safeSet(Indexer_t &lambda, std::size_t const idx, Real const in);
+  inline bool SafeSet(Indexer_t &lambda, std::size_t const idx, Real const in);
 
 .. code-block:: cpp
 
   template <typename T, typename Indexer_t>
   PORTABLE_FORCEINLINE_FUNCTION
-  inline bool safeSet(Indexer_t &lambda, Real const in)
+  inline bool SafeSet(Indexer_t &lambda, Real const in)
+
+.. code-block:: cpp
+
+  template <typename T, typename Indexer_t>
+  PORTABLE_FORCEINLINE_FUNCTION
+  inline bool SafeMustSet(Indexer_t &lambda, std::size_t const idx, Real const in);
+
+.. code-block:: cpp
+
+  template <typename T, typename Indexer_t>
+  PORTABLE_FORCEINLINE_FUNCTION
+  inline bool SafeMustSet(Indexer_t &lambda, Real const in)
 
 can modify the values in the ``Indexer_t`` and behave the same way. In this way,
 if a type-based index isn't present in the container, then another index won't
-be overwritten.
+be overwritten. Again, the ``SafeMustSet()`` version will compile-time fail
+or runtime abort if the lambda value can't be modified for the same reasons as
+``SafeMustGet()``.
 
 .. note::
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -758,11 +758,20 @@ doesn't accept type-based indexing. If the ``Indexer_t`` **does** accept
 type-based indexing but **doesn't** have the requested index, then the
 ``out`` value is not updated. The same is true for when ``Indexer_t`` is the
 ``nullptr``. The overload that doesn't take a numerical index will *only*
-return the value at a type-based index. The ``SafeMustGet()`` version
-is intended to generate errors if a value can't be retrieved. In the case of
-type-based indexing, the error will be at compile time if the type isn't located
-in the indexer. A runtime abort will occur if either the null pointer is passed
-or if integer indexing isn't allowed for some reason.
+return the value at a type-based index.
+
+The ``SafeMustGet()`` version is intended to generate errors if a value can't be
+retrieved with four types of errors that can occur:
+
+1. If a null pointer is passed as the indexer, a runtime abort or exception will
+   occur
+2. If a type-based indexer is passed (i.e. one with the ``constexpr static bool``
+   member ``is_type_indexable = true``), but the type doesn't exist then a **static**
+   assertion will fail
+3. If one of the overloads is used where a ``std::size_t`` index is provided, but
+   the indexer can't accept integer indexing, then a **static** assertion will fail
+4. If the indexer can't use type-based indexing but an ``std::size_t`` index
+   wasn't provided, then a **static** assertion will fail
 
 Similarly, the functions
 
@@ -791,7 +800,7 @@ Similarly, the functions
   inline bool SafeMustSet(Indexer_t &lambda, Real const in)
 
 can modify the values in the ``Indexer_t`` and behave the same way. In this way,
-if a type-based index isn't present in the container, then another index won't
+if a type-based index isn't present in the container, then a different index won't
 be overwritten. Again, the ``SafeMustSet()`` version will compile-time fail
 or runtime abort if the lambda value can't be modified for the same reasons as
 ``SafeMustGet()``.

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -148,12 +148,14 @@ PORTABLE_FORCEINLINE_FUNCTION void SafeMustSet(Indexer_t &lambda, std::size_t co
   if constexpr (is_type_indexer_v<Indexer_t>) {
     static_assert(variadic_utils::is_indexable_v<Indexer_t, T>);
     lambda[T{}] = in;
+    return;
   }
 
   // Fall back to numerical indexing if allowed
   if constexpr (AI == AllowedIndexing::Numeric) {
     if constexpr (variadic_utils::has_int_index<Indexer_t>::value) {
       lambda[idx] = in;
+      return;
     }
   }
 

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -24,8 +24,85 @@
 
 namespace singularity {
 namespace IndexerUtils {
-// Convenience function for accessing an indexer by either type or
-// natural number index depending on what is available
+
+// Identifies an indexer as a type-based indexer
+template<class, class=void>
+struct is_type_indexer : std::false_type {};
+template<class Indexer_t>
+struct is_type_indexer<Indexer_t,
+  std::void_t<decltype(std::decay_t<Indexer_t>::is_type_indexable)>>
+  : std::bool_constant<std::decay_t<Indexer_t>::is_type_indexable> {};
+template<class Indexer_t>
+constexpr bool is_type_indexer_v = is_type_indexer<Indexer_t>::value;
+
+// The "safe" version of Get(). This function will ONLY return a value IF that
+// type-based index is present in the Indexer OR if the Indexer doesn't support
+// type-based indexing.
+template <typename T, typename Indexer_t>
+inline bool safeGet(Indexer_t const& lambda, std::size_t const idx, Real& out) noexcept {
+  // If null then nothing happens
+  if (variadic_utils::is_nullptr(lambda)) {
+    return false;
+  }
+
+  // Return value if type index is available
+  if constexpr (variadic_utils::is_indexable_v<Indexer_t, T>) {
+    out = lambda[T{}];
+    return true;
+  }
+
+  // Do nothing if lambda has type indexing BUT doesn't have this type index
+  if constexpr (is_type_indexer_v<Indexer_t>) {
+    return false;
+  }
+
+  // Fall back to numerical indexing if no type indexing
+  if constexpr (variadic_utils::has_whole_num_index<Indexer_t>::value) {
+    out = lambda[idx];
+    return true;
+  }
+
+  // Something else...
+  return false;
+}
+
+// Break out "Set" functionality from "Get". The original "Get()" did both, but
+// the "safe" version needs to separate that functionality for setting the
+// values in a lambda
+template <typename T, typename Indexer_t>
+inline bool safeSet(Indexer_t& lambda, std::size_t const idx, Real const in) noexcept {
+  // If null then nothing happens
+  if (variadic_utils::is_nullptr(lambda)) {
+    return false;
+  }
+
+  // Return value if type index is available
+  if constexpr (variadic_utils::is_indexable_v<Indexer_t, T>) {
+    lambda[T{}] = in;
+    return true;
+  }
+
+  // Do nothing if lambda has type indexing BUT doesn't have this type index
+  if constexpr (is_type_indexer_v<Indexer_t>) {
+    return false;
+  }
+
+  // Fall back to numerical indexing if no type indexing
+  if constexpr (variadic_utils::has_whole_num_index<Indexer_t>::value) {
+    lambda[idx] = in;
+    return true;
+  }
+
+  // Something else...
+  return false;
+}
+
+// NOTE: this Get is "unsafe" because it can allow you to overwrite a type-based
+// index since it automatically falls back to numeric indexing if the type
+// index isn't present.
+
+// Convenience function for accessing an indexer by either type or natural
+// number index depending on what is available.
 template <typename T, typename Indexer_t>
 PORTABLE_FORCEINLINE_FUNCTION auto &Get(Indexer_t &&lambda, std::size_t idx = 0) {
   if constexpr (variadic_utils::is_indexable_v<Indexer_t, T>) {
@@ -40,25 +117,44 @@ PORTABLE_FORCEINLINE_FUNCTION auto &Get(Indexer_t &&lambda, std::size_t idx = 0)
 template <typename Data_t, typename... Ts>
 class VariadicIndexerBase {
  public:
+  // Any class that wants to be recognized as indexable (so that we don't
+  // accidentally fall back to integer indexing when we don't want to) needs to
+  // include this.
+  constexpr static bool is_type_indexable = true;
+
+  // JHP: another option for the `is_type_indexable` flag is to take the ADL
+  // route. Essentially this would involve defining a friend function that
+  // could be defined in an appropriate namesapce so that theoretically a host
+  // code could use a TPL container with type-based indexing and allow that
+  // container to be flagged in our code as acceptable. This seems like a bit
+  // of a heavy hammer for what we need here though. We can easily change this
+  // if a TPL provides a type that is being used for this purpose.
+
   VariadicIndexerBase() = default;
+
   PORTABLE_FORCEINLINE_FUNCTION
   VariadicIndexerBase(const Data_t &data) : data_(data) {}
+
   template <typename T,
             typename = std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
   PORTABLE_FORCEINLINE_FUNCTION Real &operator[](const T &t) {
     constexpr std::size_t idx = variadic_utils::GetIndexInTL<T, Ts...>();
     return data_[idx];
   }
+
   PORTABLE_FORCEINLINE_FUNCTION
   Real &operator[](const std::size_t idx) { return data_[idx]; }
+
   template <typename T,
             typename = std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
   PORTABLE_FORCEINLINE_FUNCTION const Real &operator[](const T &t) const {
     constexpr std::size_t idx = variadic_utils::GetIndexInTL<T, Ts...>();
     return data_[idx];
   }
+
   PORTABLE_FORCEINLINE_FUNCTION
   const Real &operator[](const std::size_t idx) const { return data_[idx]; }
+
   static inline constexpr std::size_t size() { return sizeof...(Ts); }
 
  private:
@@ -70,6 +166,7 @@ using VariadicIndexer = VariadicIndexerBase<std::array<Real, sizeof...(Ts)>, Ts.
 // uses a Real*
 template <typename... Ts>
 using VariadicPointerIndexer = VariadicIndexerBase<Real *, Ts...>;
+
 } // namespace IndexerUtils
 
 namespace IndexableTypes {

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -40,8 +40,7 @@ constexpr bool is_type_indexer_v = is_type_indexer<Indexer_t>::value;
 // type-based index is present in the Indexer OR if the Indexer doesn't support
 // type-based indexing.
 template <typename T, typename Indexer_t>
-PORTABLE_FORCEINLINE_FUNCTION
-bool SafeGet(Indexer_t const &lambda, Real &out) {
+PORTABLE_FORCEINLINE_FUNCTION bool SafeGet(Indexer_t const &lambda, Real &out) {
   // If null then nothing happens
   if (variadic_utils::is_nullptr(lambda)) {
     return false;
@@ -64,8 +63,8 @@ bool SafeGet(Indexer_t const &lambda, Real &out) {
 
 // Overload when numerical index is provided
 template <typename T, typename Indexer_t>
-PORTABLE_FORCEINLINE_FUNCTION
-bool SafeGet(Indexer_t const &lambda, std::size_t const idx, Real &out) {
+PORTABLE_FORCEINLINE_FUNCTION bool SafeGet(Indexer_t const &lambda, std::size_t const idx,
+                                           Real &out) {
   const auto modified = SafeGet<T>(lambda, out);
 
   // Fall back to numerical indexing if no type indexing
@@ -83,8 +82,8 @@ bool SafeGet(Indexer_t const &lambda, std::size_t const idx, Real &out) {
 // Same as above but causes an error condition (static or dynamic) if the value
 // can't be obtained
 template <typename T, typename Indexer_t>
-PORTABLE_FORCEINLINE_FUNCTION
-Real SafeMustGet(Indexer_t const &lambda, std::size_t const idx) {
+PORTABLE_FORCEINLINE_FUNCTION Real SafeMustGet(Indexer_t const &lambda,
+                                               std::size_t const idx) {
   // Error on null pointer
   PORTABLE_ALWAYS_REQUIRE(!variadic_utils::is_nullptr(lambda),
                           "Indexer can't be nullptr");
@@ -108,8 +107,7 @@ Real SafeMustGet(Indexer_t const &lambda, std::size_t const idx) {
 // the "safe" version needs to separate that functionality for setting the
 // values in a lambda
 template <typename T, typename Indexer_t>
-PORTABLE_FORCEINLINE_FUNCTION
-bool SafeSet(Indexer_t &lambda, Real const in) {
+PORTABLE_FORCEINLINE_FUNCTION bool SafeSet(Indexer_t &lambda, Real const in) {
   // If null then nothing happens
   if (variadic_utils::is_nullptr(lambda)) {
     return false;
@@ -132,8 +130,8 @@ bool SafeSet(Indexer_t &lambda, Real const in) {
 
 // Overload when numerical index is provided
 template <typename T, typename Indexer_t>
-PORTABLE_FORCEINLINE_FUNCTION
-bool SafeSet(Indexer_t &lambda, std::size_t const idx, Real const in) {
+PORTABLE_FORCEINLINE_FUNCTION bool SafeSet(Indexer_t &lambda, std::size_t const idx,
+                                           Real const in) {
   const auto modified = SafeSet<T>(lambda, in);
 
   // Fall back to numerical indexing if no type indexing
@@ -151,8 +149,8 @@ bool SafeSet(Indexer_t &lambda, std::size_t const idx, Real const in) {
 // Same as above but causes an error condition (static or dynamic) if the value
 // can't be obtained
 template <typename T, typename Indexer_t>
-PORTABLE_FORCEINLINE_FUNCTION
-void SafeMustSet(Indexer_t &lambda, std::size_t const idx, Real const in) {
+PORTABLE_FORCEINLINE_FUNCTION void SafeMustSet(Indexer_t &lambda, std::size_t const idx,
+                                               Real const in) {
   // Error on null pointer
   PORTABLE_ALWAYS_REQUIRE(!variadic_utils::is_nullptr(lambda),
                           "Indexer can't be nullptr");

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -184,12 +184,6 @@ PORTABLE_FORCEINLINE_FUNCTION Real SafeMustGet(Indexer_t const &lambda,
 // Overload when numerical index isn't provided
 template <typename T, typename Indexer_t>
 PORTABLE_FORCEINLINE_FUNCTION Real SafeMustGet(Indexer_t const &lambda) {
-  if constexpr (!is_type_indexer_v<Indexer_t>) {
-    // Ill-formed since no index provided
-    PORTABLE_ALWAYS_THROW_OR_ABORT(
-        "SafeMustGet: Type-based indexing is required, but lambda does does not contain "
-        "is_type_indexable boolean data member");
-  }
   std::size_t idx = 0;
   return impl::SafeMustGetSet<impl::AllowedIndexing::TypeOnly, T>(lambda, idx);
 }
@@ -204,12 +198,6 @@ PORTABLE_FORCEINLINE_FUNCTION void SafeMustSet(Indexer_t &lambda, std::size_t co
 // Overload when numerical index isn't provided
 template <typename T, typename Indexer_t>
 PORTABLE_FORCEINLINE_FUNCTION void SafeMustSet(Indexer_t &lambda, Real const in) {
-  if constexpr (!is_type_indexer_v<Indexer_t>) {
-    // Ill-formed since no index provided
-    PORTABLE_ALWAYS_THROW_OR_ABORT(
-        "SafeMustSet: Type-based indexing is required, but lambda does does not contain "
-        "is_type_indexable boolean data member");
-  }
   std::size_t idx = 0;
   impl::SafeMustGetSet<impl::AllowedIndexing::TypeOnly, T>(lambda, idx) = in;
 }

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -26,20 +26,20 @@ namespace singularity {
 namespace IndexerUtils {
 
 // Identifies an indexer as a type-based indexer
-template<class, class=void>
+template <class, class = void>
 struct is_type_indexer : std::false_type {};
-template<class Indexer_t>
+template <class Indexer_t>
 struct is_type_indexer<Indexer_t,
-  std::void_t<decltype(std::decay_t<Indexer_t>::is_type_indexable)>>
-  : std::bool_constant<std::decay_t<Indexer_t>::is_type_indexable> {};
-template<class Indexer_t>
+                       std::void_t<decltype(std::decay_t<Indexer_t>::is_type_indexable)>>
+    : std::bool_constant<std::decay_t<Indexer_t>::is_type_indexable> {};
+template <class Indexer_t>
 constexpr bool is_type_indexer_v = is_type_indexer<Indexer_t>::value;
 
 // The "safe" version of Get(). This function will ONLY return a value IF that
 // type-based index is present in the Indexer OR if the Indexer doesn't support
 // type-based indexing.
 template <typename T, typename Indexer_t>
-inline bool safeGet(Indexer_t const& lambda, std::size_t const idx, Real& out) {
+inline bool safeGet(Indexer_t const &lambda, std::size_t const idx, Real &out) {
   // If null then nothing happens
   if (variadic_utils::is_nullptr(lambda)) {
     return false;
@@ -68,7 +68,7 @@ inline bool safeGet(Indexer_t const& lambda, std::size_t const idx, Real& out) {
 
 // Overload when no index is provided
 template <typename T, typename Indexer_t>
-inline bool safeGet(Indexer_t const& lambda, Real& out) {
+inline bool safeGet(Indexer_t const &lambda, Real &out) {
   // If null then nothing happens
   if (variadic_utils::is_nullptr(lambda)) {
     return false;
@@ -93,7 +93,7 @@ inline bool safeGet(Indexer_t const& lambda, Real& out) {
 // the "safe" version needs to separate that functionality for setting the
 // values in a lambda
 template <typename T, typename Indexer_t>
-inline bool safeSet(Indexer_t& lambda, std::size_t const idx, Real const in) {
+inline bool safeSet(Indexer_t &lambda, std::size_t const idx, Real const in) {
   // If null then nothing happens
   if (variadic_utils::is_nullptr(lambda)) {
     return false;
@@ -122,7 +122,7 @@ inline bool safeSet(Indexer_t& lambda, std::size_t const idx, Real const in) {
 
 // Overload without numeric index
 template <typename T, typename Indexer_t>
-inline bool safeSet(Indexer_t& lambda, Real const in) {
+inline bool safeSet(Indexer_t &lambda, Real const in) {
   // If null then nothing happens
   if (variadic_utils::is_nullptr(lambda)) {
     return false;

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -195,7 +195,8 @@ PORTABLE_FORCEINLINE_FUNCTION bool SafeSet(Indexer_t &lambda, Real const in) {
 
 // Overload when numerical index is provided
 template <typename T, typename Indexer_t>
-PORTABLE_FORCEINLINE_FUNCTION Real SafeMustGet(Indexer_t const &lambda, std::size_t const idx) {
+PORTABLE_FORCEINLINE_FUNCTION Real SafeMustGet(Indexer_t const &lambda,
+                                               std::size_t const idx) {
   return impl::SafeMustGet<impl::AllowedIndexing::Numeric, T>(lambda, idx);
 }
 
@@ -209,7 +210,7 @@ PORTABLE_FORCEINLINE_FUNCTION Real SafeMustGet(Indexer_t const &lambda) {
 // Overload when numerical index is provided
 template <typename T, typename Indexer_t>
 PORTABLE_FORCEINLINE_FUNCTION void SafeMustSet(Indexer_t &lambda, std::size_t const idx,
-                                           Real const in) {
+                                               Real const in) {
   return impl::SafeMustSet<impl::AllowedIndexing::Numeric, T>(lambda, idx, in);
 }
 

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -142,6 +142,11 @@ PORTABLE_FORCEINLINE_FUNCTION decltype(auto) SafeMustGetSet(Indexer_t &&lambda,
 
   // Something else...
   PORTABLE_ALWAYS_THROW_OR_ABORT("Cannot obtain value from unknown indexer");
+
+  // This code is unreachable, but we need a concrete return type so that
+  // everything downstream is happy
+  Real ret = 0;
+  return ret;
 }
 
 } // namespace impl

--- a/singularity-eos/base/variadic_utils.hpp
+++ b/singularity-eos/base/variadic_utils.hpp
@@ -121,6 +121,16 @@ struct has_whole_num_index<
 template <typename T>
 constexpr bool has_whole_num_index_v = has_whole_num_index<T>::value;
 
+// Check if a type can accept an int index
+template <class T, class = void>
+struct has_int_index : std::false_type {};
+template <class T>
+struct has_int_index<
+    T, std::void_t<decltype(std::declval<T>()[std::declval<int>()])>>
+    : std::true_type {};
+template <typename T>
+constexpr bool has_int_index_v = has_int_index<T>::value;
+
 // this flattens a typelist of typelists to a single typelist
 
 // first parameter - accumulator

--- a/singularity-eos/base/variadic_utils.hpp
+++ b/singularity-eos/base/variadic_utils.hpp
@@ -112,11 +112,11 @@ template <typename T, typename Index>
 constexpr bool is_indexable_v = is_indexable<T, Index>::value;
 
 // Check if a type can accept a size_t index
-template<class T, class=void>
+template <class T, class = void>
 struct has_whole_num_index : std::false_type {};
-template<class T>
-struct has_whole_num_index<T,
-                         std::void_t<decltype(std::declval<T>()[std::declval<std::size_t>()])>>
+template <class T>
+struct has_whole_num_index<
+    T, std::void_t<decltype(std::declval<T>()[std::declval<std::size_t>()])>>
     : std::true_type {};
 template <typename T>
 constexpr bool has_whole_num_index_v = has_whole_num_index<T>::value;

--- a/singularity-eos/base/variadic_utils.hpp
+++ b/singularity-eos/base/variadic_utils.hpp
@@ -125,8 +125,7 @@ constexpr bool has_whole_num_index_v = has_whole_num_index<T>::value;
 template <class T, class = void>
 struct has_int_index : std::false_type {};
 template <class T>
-struct has_int_index<
-    T, std::void_t<decltype(std::declval<T>()[std::declval<int>()])>>
+struct has_int_index<T, std::void_t<decltype(std::declval<T>()[std::declval<int>()])>>
     : std::true_type {};
 template <typename T>
 constexpr bool has_int_index_v = has_int_index<T>::value;

--- a/singularity-eos/base/variadic_utils.hpp
+++ b/singularity-eos/base/variadic_utils.hpp
@@ -24,6 +24,16 @@ namespace variadic_utils {
 // Some generic variatic utilities
 // ======================================================================
 
+// Template parameter dependent boolean suitable for causing static_assert
+// errors within `if constexpr` branches. Essentially the issue is that if the
+// static_assert _always_ evaluates to false, then it will _always_ cause a
+// compile time error even if that branch of the code will never be reached.
+// Making the evaluation (superficially) dependent on the template deduction
+// causes it to be evaluated after the `if constexpr` branching has already been
+// determined. See https://en.cppreference.com/w/cpp/language/if.html#Constexpr_if
+template <class>
+inline constexpr bool dependent_false_v = false;
+
 // Useful for generating nullptr of a specific pointer type
 template <typename T>
 inline constexpr T *np() {

--- a/singularity-eos/base/variadic_utils.hpp
+++ b/singularity-eos/base/variadic_utils.hpp
@@ -111,16 +111,6 @@ struct is_indexable<T, Index,
 template <typename T, typename Index>
 constexpr bool is_indexable_v = is_indexable<T, Index>::value;
 
-// Check if a type can accept a size_t index
-template <class T, class = void>
-struct has_whole_num_index : std::false_type {};
-template <class T>
-struct has_whole_num_index<
-    T, std::void_t<decltype(std::declval<T>()[std::declval<std::size_t>()])>>
-    : std::true_type {};
-template <typename T>
-constexpr bool has_whole_num_index_v = has_whole_num_index<T>::value;
-
 // Check if a type can accept an int index
 template <class T, class = void>
 struct has_int_index : std::false_type {};

--- a/singularity-eos/base/variadic_utils.hpp
+++ b/singularity-eos/base/variadic_utils.hpp
@@ -111,6 +111,16 @@ struct is_indexable<T, Index,
 template <typename T, typename Index>
 constexpr bool is_indexable_v = is_indexable<T, Index>::value;
 
+//
+template<class T, class=void>
+struct has_whole_num_index : std::false_type {};
+template<class T>
+struct has_whole_num_index<T,
+                         std::void_t<decltype(std::declval<T>()[std::declval<std::size_t>()])>>
+    : std::true_type {};
+template <typename T>
+constexpr bool has_whole_num_index_v = has_whole_num_index<T>::value;
+
 // this flattens a typelist of typelists to a single typelist
 
 // first parameter - accumulator

--- a/singularity-eos/base/variadic_utils.hpp
+++ b/singularity-eos/base/variadic_utils.hpp
@@ -111,7 +111,7 @@ struct is_indexable<T, Index,
 template <typename T, typename Index>
 constexpr bool is_indexable_v = is_indexable<T, Index>::value;
 
-//
+// Check if a type can accept a size_t index
 template<class T, class=void>
 struct has_whole_num_index : std::false_type {};
 template<class T>

--- a/singularity-eos/eos/eos_electrons.hpp
+++ b/singularity-eos/eos/eos_electrons.hpp
@@ -209,8 +209,8 @@ class IdealElectrons : public EosBase<IdealElectrons> {
  private:
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real _Cv(Indexer_t &&lambda) const {
-    Real Z = IndexerUtils::SafeMustGet<IndexableTypes::MeanIonizationState>(
-      lambda, Lambda::Zi);
+    Real Z = IndexerUtils::SafeMustGet<IndexableTypes::MeanIonizationState>(lambda,
+                                                                            Lambda::Zi);
     return _Cvbase * std::max(Z, static_cast<Real>(0.0));
   }
 

--- a/singularity-eos/eos/eos_electrons.hpp
+++ b/singularity-eos/eos/eos_electrons.hpp
@@ -209,8 +209,8 @@ class IdealElectrons : public EosBase<IdealElectrons> {
  private:
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real _Cv(Indexer_t &&lambda) const {
-    const Real Z =
-        IndexerUtils::Get<IndexableTypes::MeanIonizationState>(lambda, Lambda::Zi);
+    Real Z = IndexerUtils::SafeMustGet<IndexableTypes::MeanIonizationState>(
+      lambda, Lambda::Zi);
     return _Cvbase * std::max(Z, static_cast<Real>(0.0));
   }
 

--- a/singularity-eos/eos/eos_helmholtz.hpp
+++ b/singularity-eos/eos/eos_helmholtz.hpp
@@ -838,7 +838,7 @@ Helmholtz::FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, R
     temp = math_utils::pow10(lT);
   } else {
     lT = std::log10(temp);
-    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
+    IndexerUtils::SafeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
   }
   Real p[NDERIV], e[NDERIV], s[NDERIV], etaele[NDERIV], nep[NDERIV];
   GetFromDensityLogTemperature_(rho, temp, abar, zbar, ye, ytot, ywot, De, lDe, p, e, s,

--- a/singularity-eos/eos/eos_helmholtz.hpp
+++ b/singularity-eos/eos/eos_helmholtz.hpp
@@ -630,8 +630,10 @@ class Helmholtz : public EosBase<Helmholtz> {
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
     using namespace HelmUtils;
     Real p[NDERIV], e[NDERIV], s[NDERIV], etaele[NDERIV], nep[NDERIV];
-    Real abar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
-    Real zbar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
+    Real abar =
+        IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+    Real zbar =
+        IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
     Real ytot, ye, ywot, De, lDe;
     GetElectronDensities_(rho, abar, zbar, ytot, ye, ywot, De, lDe);
     Real lT = lTFromRhoSie_(rho, sie, abar, zbar, ye, ytot, ywot, De, lDe, lambda);
@@ -657,14 +659,16 @@ class Helmholtz : public EosBase<Helmholtz> {
       const Real rho, const Real T,
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
     using namespace HelmUtils;
-    return IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+    return IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda,
+                                                                     Lambda::Abar);
   }
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real MeanAtomicNumberFromDensityTemperature(
       const Real rho, const Real T,
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
     using namespace HelmUtils;
-    return IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
+    return IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda,
+                                                                       Lambda::Zbar);
   }
 
   template <typename Indexer_t = Real *>
@@ -758,8 +762,10 @@ class Helmholtz : public EosBase<Helmholtz> {
   GetFromDensityTemperature_(const Real rho, const Real temperature, Indexer_t &&lambda,
                              Real p[NDERIV], Real e[NDERIV], Real s[NDERIV],
                              Real etaele[NDERIV], Real nep[NDERIV]) const {
-    Real abar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
-    Real zbar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
+    Real abar =
+        IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+    Real zbar =
+        IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
     Real lT = std::log10(temperature);
     IndexerUtils::SafeGet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
     Real ytot, ye, ywot, De, lDe;
@@ -773,8 +779,10 @@ class Helmholtz : public EosBase<Helmholtz> {
   GetFromDensityInternalEnergy_(const Real rho, const Real sie, Indexer_t &&lambda,
                                 Real p[NDERIV], Real e[NDERIV], Real s[NDERIV],
                                 Real etaele[NDERIV], Real nep[NDERIV]) const {
-    Real abar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
-    Real zbar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
+    Real abar =
+        IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+    Real zbar =
+        IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
     Real ytot, ye, ywot, De, lDe;
     GetElectronDensities_(rho, abar, zbar, ytot, ye, ywot, De, lDe);
     Real lT = lTFromRhoSie_(rho, sie, abar, zbar, ye, ytot, ywot, De, lDe, lambda);
@@ -819,8 +827,10 @@ Helmholtz::FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, R
   PORTABLE_ALWAYS_REQUIRE(
       !(need_temp && need_sie),
       "Either specific internal energy or temperature must be provided.");
-  Real abar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
-  Real zbar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
+  Real abar =
+      IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+  Real zbar =
+      IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
   Real ytot, ye, ywot, De, lDe, lT;
   GetElectronDensities_(rho, abar, zbar, ytot, ye, ywot, De, lDe);
   if (need_temp) {

--- a/singularity-eos/eos/eos_helmholtz.hpp
+++ b/singularity-eos/eos/eos_helmholtz.hpp
@@ -630,8 +630,8 @@ class Helmholtz : public EosBase<Helmholtz> {
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
     using namespace HelmUtils;
     Real p[NDERIV], e[NDERIV], s[NDERIV], etaele[NDERIV], nep[NDERIV];
-    Real abar = IndexerUtils::Get<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
-    Real zbar = IndexerUtils::Get<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
+    Real abar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+    Real zbar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
     Real ytot, ye, ywot, De, lDe;
     GetElectronDensities_(rho, abar, zbar, ytot, ye, ywot, De, lDe);
     Real lT = lTFromRhoSie_(rho, sie, abar, zbar, ye, ytot, ywot, De, lDe, lambda);
@@ -657,14 +657,14 @@ class Helmholtz : public EosBase<Helmholtz> {
       const Real rho, const Real T,
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
     using namespace HelmUtils;
-    return IndexerUtils::Get<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+    return IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
   }
   template <typename Indexer_t = Real *>
   PORTABLE_INLINE_FUNCTION Real MeanAtomicNumberFromDensityTemperature(
       const Real rho, const Real T,
       Indexer_t &&lambda = static_cast<Real *>(nullptr)) const {
     using namespace HelmUtils;
-    return IndexerUtils::Get<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
+    return IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
   }
 
   template <typename Indexer_t = Real *>
@@ -758,10 +758,10 @@ class Helmholtz : public EosBase<Helmholtz> {
   GetFromDensityTemperature_(const Real rho, const Real temperature, Indexer_t &&lambda,
                              Real p[NDERIV], Real e[NDERIV], Real s[NDERIV],
                              Real etaele[NDERIV], Real nep[NDERIV]) const {
-    Real abar = IndexerUtils::Get<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
-    Real zbar = IndexerUtils::Get<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
+    Real abar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+    Real zbar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
     Real lT = std::log10(temperature);
-    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
+    IndexerUtils::SafeGet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
     Real ytot, ye, ywot, De, lDe;
     GetElectronDensities_(rho, abar, zbar, ytot, ye, ywot, De, lDe);
     GetFromDensityLogTemperature_(rho, temperature, abar, zbar, ye, ytot, ywot, De, lDe,
@@ -773,8 +773,8 @@ class Helmholtz : public EosBase<Helmholtz> {
   GetFromDensityInternalEnergy_(const Real rho, const Real sie, Indexer_t &&lambda,
                                 Real p[NDERIV], Real e[NDERIV], Real s[NDERIV],
                                 Real etaele[NDERIV], Real nep[NDERIV]) const {
-    Real abar = IndexerUtils::Get<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
-    Real zbar = IndexerUtils::Get<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
+    Real abar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+    Real zbar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
     Real ytot, ye, ywot, De, lDe;
     GetElectronDensities_(rho, abar, zbar, ytot, ye, ywot, De, lDe);
     Real lT = lTFromRhoSie_(rho, sie, abar, zbar, ye, ytot, ywot, De, lDe, lambda);
@@ -819,8 +819,8 @@ Helmholtz::FillEos(Real &rho, Real &temp, Real &energy, Real &press, Real &cv, R
   PORTABLE_ALWAYS_REQUIRE(
       !(need_temp && need_sie),
       "Either specific internal energy or temperature must be provided.");
-  Real abar = IndexerUtils::Get<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
-  Real zbar = IndexerUtils::Get<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
+  Real abar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicMass>(lambda, Lambda::Abar);
+  Real zbar = IndexerUtils::SafeMustGet<IndexableTypes::MeanAtomicNumber>(lambda, Lambda::Zbar);
   Real ytot, ye, ywot, De, lDe, lT;
   GetElectronDensities_(rho, abar, zbar, ytot, ye, ywot, De, lDe);
   if (need_temp) {
@@ -870,7 +870,8 @@ PORTABLE_INLINE_FUNCTION Real Helmholtz::lTFromRhoSie_(const Real rho, const Rea
 
   if (options_.ENABLE_RAD || options_.GAS_DEGENERATE ||
       options_.ENABLE_COULOMB_CORRECTIONS) {
-    Real lTguess = IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT);
+    Real lTguess;
+    IndexerUtils::SafeGet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lTguess);
     if (!((electrons_.lTMin() <= lTguess) && (lTguess <= electrons_.lTMax()))) {
       lTguess = lTAnalytic_(rho, e, ni, ne);
       if (!((electrons_.lTMin() <= lTguess) && (lTguess <= electrons_.lTMax()))) {
@@ -944,7 +945,7 @@ PORTABLE_INLINE_FUNCTION Real Helmholtz::lTFromRhoSie_(const Real rho, const Rea
     }
     lT = electrons_.lTMax();
   }
-  IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
+  IndexerUtils::SafeGet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
   return lT;
 }
 

--- a/singularity-eos/eos/eos_spiner_rho_sie.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_sie.hpp
@@ -687,7 +687,7 @@ PORTABLE_INLINE_FUNCTION void SpinerEOSDependsRhoSieTransformable<TransformerT>:
     }
   } else {
     lRho = to_log(rho, lRhoOffset_);
-    IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+    IndexerUtils::SafeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
   }
   if (output & thermalqs::temperature) {
 
@@ -745,7 +745,7 @@ SpinerEOSDependsRhoSieTransformable<TransformerT>::interpRhoT_(const Real rho,
                                                                Indexer_t &&lambda) const {
   const Real lRho = spiner_common::to_log(rho, lRhoOffset_);
   const Real lT = spiner_common::to_log(T, lTOffset_);
-  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::SafeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
   return db.interpToReal(lRho, lT);
 }
 
@@ -757,7 +757,7 @@ SpinerEOSDependsRhoSieTransformable<TransformerT>::interpRhoSie_(
   const Real lRho = spiner_common::to_log(rho, lRhoOffset_);
   const Real sie_transformed = transformer_.transform(sie, rho);
   const Real lE = spiner_common::to_log(sie_transformed, lEOffset_);
-  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::SafeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
   return db.interpToReal(lRho, lE);
 }
 
@@ -781,7 +781,7 @@ SpinerEOSDependsRhoSieTransformable<TransformerT>::lRhoFromPlT_(
   } else {
     Real lRhoGuess = reproducible_ ? lRhoMin_ : 0.5 * (lRhoMin_ + lRhoMax_);
     Real lRho_cache;
-    IndexerUtils::safeGet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho_cache);
+    IndexerUtils::SafeGet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho_cache);
     if ((lRhoMin_ <= lRho_cache) && (lRho_cache <= lRhoMax_)) {
       lRhoGuess = lRho_cache;
     }
@@ -801,8 +801,8 @@ SpinerEOSDependsRhoSieTransformable<TransformerT>::lRhoFromPlT_(
       lRho = reproducible_ ? lRhoMin_ : lRhoGuess;
     }
   }
-  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
-  IndexerUtils::safeSet<IndexableTypes::RootStatus>(lambda, static_cast<Real>(status));
+  IndexerUtils::SafeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::SafeSet<IndexableTypes::RootStatus>(lambda, static_cast<Real>(status));
   return lRho;
 }
 

--- a/singularity-eos/eos/eos_spiner_rho_temp.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_temp.hpp
@@ -880,8 +880,8 @@ SpinerEOSDependsRhoT::FillEos(Real &rho, Real &temp, Real &energy, Real &press, 
   if (output & thermalqs::bulk_modulus) {
     bmod = bModFromRholRhoTlT_(rho, lRho, temp, lT, whereAmI);
   }
-  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
-  IndexerUtils::safeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
+  IndexerUtils::SafeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::SafeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
 }
 
 template <typename Indexer_t>
@@ -912,8 +912,8 @@ SpinerEOSDependsRhoT::getLogsRhoT_(const Real rho, const Real temperature, Real 
                                    Real &lT, Indexer_t &&lambda) const {
   lRho = lRho_(rho);
   lT = lT_(temperature);
-  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
-  IndexerUtils::safeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
+  IndexerUtils::SafeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::SafeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
 }
 
 template <typename Indexer_t>
@@ -928,7 +928,7 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lRhoFromPlT_(
       (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
 
   Real lRho_cache;
-  IndexerUtils::safeGet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho_cache);
+  IndexerUtils::SafeGet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho_cache);
   if ((lRhoMin_ <= lRho_cache) && (lRho_cache <= lRhoMax_)) {
     lRhoGuess = lRho_cache;
   }
@@ -967,11 +967,11 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lRhoFromPlT_(
 #endif // SPINER_EOS_VERBOSE
     lRho = reproducible_ ? lRhoMax_ : lRhoGuess;
   }
-  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
-  IndexerUtils::safeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
+  IndexerUtils::SafeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::SafeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
   // No numerical index: only set if type-based indexing is used
-  IndexerUtils::safeSet<IndexableTypes::RootStatus>(lambda, static_cast<Real>(status));
-  IndexerUtils::safeSet<IndexableTypes::TableStatus>(lambda, static_cast<Real>(whereAmI));
+  IndexerUtils::SafeSet<IndexableTypes::RootStatus>(lambda, static_cast<Real>(status));
+  IndexerUtils::SafeSet<IndexableTypes::TableStatus>(lambda, static_cast<Real>(whereAmI));
   return lRho;
 }
 
@@ -1003,7 +1003,7 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoSie_(
   } else {
     Real lTGuess = reproducible_ ? lTMin_ : 0.5 * (lTMin_ + lTMax_);
     Real lT_cache;
-    IndexerUtils::safeGet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT_cache);
+    IndexerUtils::SafeGet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT_cache);
     if ((lTMin_ <= lT_cache) && (lT_cache <= lTMax_)) {
       lTGuess = lT_cache;
     }
@@ -1027,11 +1027,11 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoSie_(
       lT = reproducible_ ? lTMin_ : lTGuess;
     }
   }
-  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
-  IndexerUtils::safeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
+  IndexerUtils::SafeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::SafeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
   // No numerical index: only set if type-based indexing is used
-  IndexerUtils::safeSet<IndexableTypes::RootStatus>(lambda, static_cast<Real>(status));
-  IndexerUtils::safeSet<IndexableTypes::TableStatus>(lambda, static_cast<Real>(whereAmI));
+  IndexerUtils::SafeSet<IndexableTypes::RootStatus>(lambda, static_cast<Real>(status));
+  IndexerUtils::SafeSet<IndexableTypes::TableStatus>(lambda, static_cast<Real>(whereAmI));
   return lT;
 }
 
@@ -1062,7 +1062,7 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoP_(
     whereAmI = TableStatus::OnTable;
     lTGuess = 0.5 * (lTMin_ + lTMax_);
     Real lT_cache;
-    IndexerUtils::safeGet<IndexableTypes::LogTemperature>(lambda, lT, lT_cache);
+    IndexerUtils::SafeGet<IndexableTypes::LogTemperature>(lambda, lT, lT_cache);
     if ((lTMin_ <= lT_cache) && (lT_cache <= lTMax_)) {
       lTGuess = lT_cache;
     }
@@ -1082,11 +1082,11 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoP_(
       lT = reproducible_ ? lTMin_ : lTGuess;
     }
   }
-  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
-  IndexerUtils::safeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
+  IndexerUtils::SafeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::SafeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
   // No numerical index: only set if type-based indexing is used
-  IndexerUtils::safeSet<IndexableTypes::RootStatus>(lambda, static_cast<Real>(status));
-  IndexerUtils::safeSet<IndexableTypes::TableStatus>(lambda, static_cast<Real>(whereAmI));
+  IndexerUtils::SafeSet<IndexableTypes::RootStatus>(lambda, static_cast<Real>(status));
+  IndexerUtils::SafeSet<IndexableTypes::TableStatus>(lambda, static_cast<Real>(whereAmI));
   return lT;
 }
 

--- a/singularity-eos/eos/eos_spiner_rho_temp.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_temp.hpp
@@ -880,10 +880,8 @@ SpinerEOSDependsRhoT::FillEos(Real &rho, Real &temp, Real &energy, Real &press, 
   if (output & thermalqs::bulk_modulus) {
     bmod = bModFromRholRhoTlT_(rho, lRho, temp, lT, whereAmI);
   }
-  if (!variadic_utils::is_nullptr(lambda)) {
-    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
-    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
-  }
+  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::safeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
 }
 
 template <typename Indexer_t>
@@ -914,10 +912,8 @@ SpinerEOSDependsRhoT::getLogsRhoT_(const Real rho, const Real temperature, Real 
                                    Real &lT, Indexer_t &&lambda) const {
   lRho = lRho_(rho);
   lT = lT_(temperature);
-  if (!variadic_utils::is_nullptr(lambda)) {
-    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
-    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
-  }
+  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::safeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
 }
 
 template <typename Indexer_t>
@@ -931,11 +927,10 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lRhoFromPlT_(
   const RootFinding1D::RootCounts *pcounts =
       (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
 
-  if (!variadic_utils::is_nullptr(lambda)) {
-    Real lRho_cache = IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho);
-    if ((lRhoMin_ <= lRho_cache) && (lRho_cache <= lRhoMax_)) {
-      lRhoGuess = lRho_cache;
-    }
+  Real lRho_cache;
+  IndexerUtils::safeGet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho_cache);
+  if ((lRhoMin_ <= lRho_cache) && (lRho_cache <= lRhoMax_)) {
+    lRhoGuess = lRho_cache;
   }
 
   if (lT <= lTMin_) { // cold curve
@@ -972,17 +967,11 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lRhoFromPlT_(
 #endif // SPINER_EOS_VERBOSE
     lRho = reproducible_ ? lRhoMax_ : lRhoGuess;
   }
-  if (!variadic_utils::is_nullptr(lambda)) {
-    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
-    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
-    if constexpr (variadic_utils::is_indexable_v<Indexer_t, IndexableTypes::RootStatus>) {
-      lambda[IndexableTypes::RootStatus()] = static_cast<Real>(status);
-    }
-    if constexpr (variadic_utils::is_indexable_v<Indexer_t,
-                                                 IndexableTypes::TableStatus>) {
-      lambda[IndexableTypes::TableStatus()] = static_cast<Real>(whereAmI);
-    }
-  }
+  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::safeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
+  // No numerical index: only set if type-based indexing is used
+  IndexerUtils::safeSet<IndexableTypes::RootStatus>(lambda, static_cast<Real>(status));
+  IndexerUtils::safeSet<IndexableTypes::TableStatus>(lambda, static_cast<Real>(whereAmI));
   return lRho;
 }
 
@@ -1013,12 +1002,10 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoSie_(
     }
   } else {
     Real lTGuess = reproducible_ ? lTMin_ : 0.5 * (lTMin_ + lTMax_);
-    if (!variadic_utils::is_nullptr(lambda)) {
-      Real lT_cache =
-          IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT);
-      if ((lTMin_ <= lT_cache) && (lT_cache <= lTMax_)) {
-        lTGuess = lT_cache;
-      }
+    Real lT_cache;
+    IndexerUtils::safeGet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT_cache);
+    if ((lTMin_ <= lT_cache) && (lT_cache <= lTMax_)) {
+      lTGuess = lT_cache;
     }
     const callable_interp::r_interp sieFunc(sie_, lRho);
     status = SP_ROOT_FINDER(sieFunc, sie, lTGuess, lTMin_, lTMax_, ROOT_THRESH,
@@ -1040,17 +1027,11 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoSie_(
       lT = reproducible_ ? lTMin_ : lTGuess;
     }
   }
-  if (!variadic_utils::is_nullptr(lambda)) {
-    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
-    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
-    if constexpr (variadic_utils::is_indexable_v<Indexer_t, IndexableTypes::RootStatus>) {
-      lambda[IndexableTypes::RootStatus()] = static_cast<Real>(status);
-    }
-    if constexpr (variadic_utils::is_indexable_v<Indexer_t,
-                                                 IndexableTypes::TableStatus>) {
-      lambda[IndexableTypes::TableStatus()] = static_cast<Real>(whereAmI);
-    }
-  }
+  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::safeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
+  // No numerical index: only set if type-based indexing is used
+  IndexerUtils::safeSet<IndexableTypes::RootStatus>(lambda, static_cast<Real>(status));
+  IndexerUtils::safeSet<IndexableTypes::TableStatus>(lambda, static_cast<Real>(whereAmI));
   return lT;
 }
 
@@ -1080,11 +1061,10 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoP_(
   } else {
     whereAmI = TableStatus::OnTable;
     lTGuess = 0.5 * (lTMin_ + lTMax_);
-    if (!variadic_utils::is_nullptr(lambda)) {
-      Real lT_cache = IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, lT);
-      if ((lTMin_ <= lT_cache) && (lT_cache <= lTMax_)) {
-        lTGuess = lT_cache;
-      }
+    Real lT_cache;
+    IndexerUtils::safeGet<IndexableTypes::LogTemperature>(lambda, lT, lT_cache);
+    if ((lTMin_ <= lT_cache) && (lT_cache <= lTMax_)) {
+      lTGuess = lT_cache;
     }
     const callable_interp::r_interp PFunc(P_, lRho);
     status = SP_ROOT_FINDER(PFunc, press, lTGuess, lTMin_, lTMax_, ROOT_THRESH,
@@ -1102,17 +1082,11 @@ PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lTFromlRhoP_(
       lT = reproducible_ ? lTMin_ : lTGuess;
     }
   }
-  if (!variadic_utils::is_nullptr(lambda)) {
-    IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, Lambda::lRho) = lRho;
-    IndexerUtils::Get<IndexableTypes::LogTemperature>(lambda, Lambda::lT) = lT;
-    if constexpr (variadic_utils::is_indexable_v<Indexer_t, IndexableTypes::RootStatus>) {
-      lambda[IndexableTypes::RootStatus()] = static_cast<Real>(status);
-    }
-    if constexpr (variadic_utils::is_indexable_v<Indexer_t,
-                                                 IndexableTypes::TableStatus>) {
-      lambda[IndexableTypes::TableStatus()] = static_cast<Real>(whereAmI);
-    }
-  }
+  IndexerUtils::safeSet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho);
+  IndexerUtils::safeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
+  // No numerical index: only set if type-based indexing is used
+  IndexerUtils::safeSet<IndexableTypes::RootStatus>(lambda, static_cast<Real>(status));
+  IndexerUtils::safeSet<IndexableTypes::TableStatus>(lambda, static_cast<Real>(whereAmI));
   return lT;
 }
 

--- a/singularity-eos/eos/eos_stellar_collapse.hpp
+++ b/singularity-eos/eos/eos_stellar_collapse.hpp
@@ -668,7 +668,8 @@ PORTABLE_INLINE_FUNCTION void StellarCollapse::DensityEnergyFromPressureTemperat
   Real lrguess = lRho_(rho);
   Real lT = lT_(temp);
   Real lP = P2lP_(press);
-  Real Ye = IndexerUtils::SafeMustGet<IndexableTypes::ElectronFraction>(lambda, Lambda::Ye);
+  Real Ye =
+      IndexerUtils::SafeMustGet<IndexableTypes::ElectronFraction>(lambda, Lambda::Ye);
 
   if ((lrguess < lRhoMin_) || (lrguess > lRhoMax_)) {
     lrguess = lRho_(rhoNormal_);
@@ -763,7 +764,8 @@ StellarCollapse::ValuesAtReferenceState(Real &rho, Real &temp, Real &sie, Real &
   dpde = dPdENormal_;
   dvdt = dVdTNormal_;
   Real lT = lT_(temp);
-  IndexerUtils::SafeMustSet<IndexableTypes::ElectronFraction>(lambda, Lambda::Ye, YeNormal_);
+  IndexerUtils::SafeMustSet<IndexableTypes::ElectronFraction>(lambda, Lambda::Ye,
+                                                              YeNormal_);
   IndexerUtils::SafeSet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lT);
 }
 
@@ -1178,7 +1180,8 @@ PORTABLE_INLINE_FUNCTION Real StellarCollapse::lTFromlRhoSie_(
   RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
   using RootFinding1D::regula_falsi;
   Real lT;
-  Real Ye = IndexerUtils::SafeMustGet<IndexableTypes::ElectronFraction>(lambda, Lambda::Ye);
+  Real Ye =
+      IndexerUtils::SafeMustGet<IndexableTypes::ElectronFraction>(lambda, Lambda::Ye);
   Real lTGuess;
   IndexerUtils::SafeGet<IndexableTypes::LogTemperature>(lambda, Lambda::lT, lTGuess);
 

--- a/singularity-eos/eos/modifiers/zsplit_eos.hpp
+++ b/singularity-eos/eos/modifiers/zsplit_eos.hpp
@@ -276,8 +276,7 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
   PORTABLE_FORCEINLINE_FUNCTION Real GetIonizationState_(Indexer_t &&lambda) const {
     using namespace variadic_utils;
     return std::max(0.0, IndexerUtils::SafeMustGet<IndexableTypes::MeanIonizationState>(
-      lambda, T::nlambda()
-    ));
+                             lambda, T::nlambda()));
   }
   // TODO(JMM): Runtime?
   template <typename Indexer_t = Real *>

--- a/singularity-eos/eos/modifiers/zsplit_eos.hpp
+++ b/singularity-eos/eos/modifiers/zsplit_eos.hpp
@@ -275,14 +275,9 @@ class ZSplit : public EosBase<ZSplit<ztype, T>> {
   template <typename Indexer_t = Real *>
   PORTABLE_FORCEINLINE_FUNCTION Real GetIonizationState_(Indexer_t &&lambda) const {
     using namespace variadic_utils;
-    if (is_nullptr(lambda)) {
-      PORTABLE_THROW_OR_ABORT("ZSplitEOS: lambda must contain mean ionization state!\n");
-    }
-    if constexpr (is_indexable_v<Indexer_t, IndexableTypes::MeanIonizationState>) {
-      return std::max(0.0, lambda[IndexableTypes::MeanIonizationState()]);
-    } else {
-      return std::max(0.0, lambda[T::nlambda()]);
-    }
+    return std::max(0.0, IndexerUtils::SafeMustGet<IndexableTypes::MeanIonizationState>(
+      lambda, T::nlambda()
+    ));
   }
   // TODO(JMM): Runtime?
   template <typename Indexer_t = Real *>

--- a/test/test_indexable_types.cpp
+++ b/test/test_indexable_types.cpp
@@ -81,18 +81,18 @@ SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer
         REQUIRE(lRho == static_cast<Real>(2));
       }
     }
-    WHEN("We use the safeGet functionality") {
+    WHEN("We use the SafeGet functionality") {
       constexpr Real unmodified = -1.0;
       Real destination = unmodified;
       WHEN("We request a type that exists") {
-        const bool modified = safeGet<MeanIonizationState>(lambda, 2, destination);
+        const bool modified = SafeGet<MeanIonizationState>(lambda, 2, destination);
         THEN("The destination value will be modified") {
           CHECK(modified);
           REQUIRE(destination == lambda[MeanIonizationState{}]);
         }
       }
       WHEN("We request a type that doesn't exist") {
-        const bool modified = safeGet<TableStatus>(lambda, 2, destination);
+        const bool modified = SafeGet<TableStatus>(lambda, 2, destination);
         THEN("The destination value will remain UNmodified") {
           CHECK(!modified);
           REQUIRE(destination == unmodified);
@@ -101,24 +101,24 @@ SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer
       WHEN("A normal array-like lambda is used") {
         std::array<Real, Lambda_t::size()> lambda_arr{1, 2, 3};
         constexpr size_t my_index = 2;
-        const bool modified = safeGet<LogDensity>(lambda_arr, my_index, destination);
+        const bool modified = SafeGet<LogDensity>(lambda_arr, my_index, destination);
         THEN("The destination value will reflect the index from the array") {
           CHECK(modified);
           REQUIRE(destination == lambda_arr[my_index]);
         }
       }
     }
-    WHEN("We use the safeSet functionality") {
+    WHEN("We use the SafeSet functionality") {
       constexpr Real new_value = -1.0;
       WHEN("We want to set a value for a type index that exists") {
-        const bool modified = safeSet<MeanIonizationState>(lambda, 2, new_value);
+        const bool modified = SafeSet<MeanIonizationState>(lambda, 2, new_value);
         THEN("The lambda index was modified") {
           CHECK(modified);
           REQUIRE(lambda[MeanIonizationState{}] == new_value);
         }
       }
       WHEN("We want to set a value for a type index that doesn't exist") {
-        const bool modified = safeSet<TableStatus>(lambda, 2, new_value);
+        const bool modified = SafeSet<TableStatus>(lambda, 2, new_value);
         Lambda_t old_lambda;
         for (std::size_t i = 0; i < Lambda_t::size(); ++i) {
           old_lambda[i] = lambda[i];
@@ -134,7 +134,7 @@ SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer
       WHEN("A normal array-like lambda is used") {
         std::array<Real, Lambda_t::size()> lambda_arr{4, 5, 6};
         constexpr size_t my_index = 1;
-        const bool modified = safeSet<LogDensity>(lambda_arr, my_index, new_value);
+        const bool modified = SafeSet<LogDensity>(lambda_arr, my_index, new_value);
         THEN("The lambda value at the appropriate index has been modified") {
           CHECK(modified);
           REQUIRE(lambda_arr[my_index] == new_value);
@@ -160,12 +160,12 @@ SCENARIO("IndexableTypes and ManualLambda", "[IndexableTypes]") {
         REQUIRE(lRho == static_cast<Real>(2));
       }
     }
-    WHEN("We use the safeGet functionality") {
+    WHEN("We use the SafeGet functionality") {
       constexpr Real unmodified = -1.0;
       Real destination = unmodified;
       WHEN("We request a type that doesn't exist in the manual indexer") {
         constexpr size_t my_index = 1;
-        const bool modified = safeGet<TableStatus>(lambda, my_index, destination);
+        const bool modified = SafeGet<TableStatus>(lambda, my_index, destination);
         THEN("The destination WILL be modified since the manual indexer doesn't have the "
              " `is_type_indexable` data member") {
           CHECK(modified);
@@ -181,7 +181,7 @@ SCENARIO("IndexableTypes and ManualLambda", "[IndexableTypes]") {
         WHEN("We request a type that doesn't exist in the manual indexer") {
           destination = unmodified;
           constexpr size_t my_index = 1;
-          const bool modified = safeGet<TableStatus>(lambda_new, my_index, destination);
+          const bool modified = SafeGet<TableStatus>(lambda_new, my_index, destination);
           THEN("The destination will NOT be modified") {
             CHECK(!modified);
             REQUIRE(destination == unmodified);
@@ -189,11 +189,11 @@ SCENARIO("IndexableTypes and ManualLambda", "[IndexableTypes]") {
         }
       }
     }
-    WHEN("We use the safeSet functionality") {
+    WHEN("We use the SafeSet functionality") {
       constexpr Real new_value = -1.0;
       WHEN("We want to set a value for a type index that doesn't exist") {
         constexpr size_t my_index = 1;
-        const bool modified = safeSet<TableStatus>(lambda, my_index, new_value);
+        const bool modified = SafeSet<TableStatus>(lambda, my_index, new_value);
         THEN("The lambda value WILL be modified since the manual indexer doesn't have "
              "the `is_type_indexable` data member") {
           CHECK(modified);
@@ -208,7 +208,7 @@ SCENARIO("IndexableTypes and ManualLambda", "[IndexableTypes]") {
         }
         WHEN("We request a type that doesn't exist in the manual indexer") {
           constexpr size_t my_index = 1;
-          const bool modified = safeSet<TableStatus>(lambda_new, my_index, new_value);
+          const bool modified = SafeSet<TableStatus>(lambda_new, my_index, new_value);
           THEN("The lambda will NOT be modified") {
             CHECK(!modified);
             for (std::size_t i = 0; i < lambda.length; ++i) {

--- a/test/test_indexable_types.cpp
+++ b/test/test_indexable_types.cpp
@@ -212,16 +212,6 @@ SCENARIO("IndexableTypes and ManualLambda", "[IndexableTypes]") {
     for (std::size_t i = 0; i < lambda.length; ++i) {
       lambda[i] = static_cast<Real>(i);
     }
-    WHEN("We use the Get functionality") {
-      // Request a type that exists, but an incorrect index
-      Real Zbar = Get<MeanIonizationState>(lambda, 2);
-      // Request a type that doesn't exist but an index that does
-      Real lRho = Get<LogTemperature>(lambda, 2);
-      THEN("We get the correct values") {
-        REQUIRE(Zbar == static_cast<Real>(0));
-        REQUIRE(lRho == static_cast<Real>(2));
-      }
-    }
     WHEN("We use the SafeGet functionality") {
       constexpr Real unmodified = -1.0;
       Real destination = unmodified;

--- a/test/test_indexable_types.cpp
+++ b/test/test_indexable_types.cpp
@@ -179,9 +179,6 @@ SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer
           CHECK_THAT(lambda[i], Catch::Matchers::WithinRel(val, 1.0e-14));
         }
       }
-      THEN("If an integer index isn't provided, an exception is thrown") {
-        REQUIRE_MAYBE_THROWS(SafeMustGet<LogTemperature>(lambda));
-      }
     }
     WHEN("We use the SafeMustSet functionality") {
       THEN("The type-based index is ignored and only the integer index is used") {
@@ -191,9 +188,6 @@ SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer
           SafeMustSet<LogDensity>(lambda, i, val);
           CHECK_THAT(lambda[i], Catch::Matchers::WithinRel(val, 1.0e-14));
         }
-      }
-      THEN("If an integer index isn't provided, an exception is thrown") {
-        REQUIRE_MAYBE_THROWS(SafeMustSet<LogTemperature>(lambda, 1.0));
       }
     }
   }

--- a/test/test_indexable_types.cpp
+++ b/test/test_indexable_types.cpp
@@ -86,11 +86,8 @@ SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer
       // This is probably a dumb check since Zbar_1 wasn't a Real* or a Real&
       AND_THEN("We don't modify the lambda values by changing the local values") {
         Zbar_1 = 5.3;
-        REQUIRE_THAT(
-            Zbar,
-            Catch::Matchers::WithinRel(
-                SafeMustGet<MeanIonizationState>(lambda),
-                1.0e-14));
+        REQUIRE_THAT(Zbar, Catch::Matchers::WithinRel(
+                               SafeMustGet<MeanIonizationState>(lambda), 1.0e-14));
       }
     }
     WHEN("We use the SafeMustSet functionality") {
@@ -101,14 +98,10 @@ SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer
       Real lRho = 1.102;
       SafeMustSet<LogDensity>(lambda, 0, lRho);
       THEN("We get the correct values") {
+        REQUIRE_THAT(Zbar, Catch::Matchers::WithinRel(
+                               SafeMustGet<MeanIonizationState>(lambda), 1.0e-14));
         REQUIRE_THAT(
-          Zbar,
-          Catch::Matchers::WithinRel(SafeMustGet<MeanIonizationState>(lambda),
-                                     1.0e-14));
-        REQUIRE_THAT(
-          lRho,
-          Catch::Matchers::WithinRel(SafeMustGet<LogDensity>(lambda),
-                                     1.0e-14));
+            lRho, Catch::Matchers::WithinRel(SafeMustGet<LogDensity>(lambda), 1.0e-14));
       }
     }
     WHEN("We use the SafeGet functionality") {

--- a/test/test_indexable_types.cpp
+++ b/test/test_indexable_types.cpp
@@ -180,7 +180,7 @@ SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer
         }
       }
       THEN("If an integer index isn't provided, an exception is thrown") {
-        REQUIRE_MAYBE_THROWS(SafeMustGet<void>(lambda));
+        REQUIRE_MAYBE_THROWS(SafeMustGet<LogTemperature>(lambda));
       }
     }
     WHEN("We use the SafeMustSet functionality") {
@@ -193,7 +193,7 @@ SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer
         }
       }
       THEN("If an integer index isn't provided, an exception is thrown") {
-        REQUIRE_MAYBE_THROWS(SafeMustSet<void>(lambda, 1.0));
+        REQUIRE_MAYBE_THROWS(SafeMustSet<LogTemperature>(lambda, 1.0));
       }
     }
   }

--- a/test/test_indexable_types.cpp
+++ b/test/test_indexable_types.cpp
@@ -29,14 +29,22 @@ using Lambda_t = VariadicIndexer<MeanIonizationState, ElectronFraction, LogDensi
 
 class ManualLambda_t {
  public:
+  constexpr static size_t length = 3;
   ManualLambda_t() = default;
+  const Real &operator[](const std::size_t idx) const { return data_[idx]; }
   Real &operator[](const std::size_t idx) { return data_[idx]; }
   Real &operator[](const MeanIonizationState &zbar) { return data_[0]; }
   Real &operator[](const ElectronFraction &Ye) { return data_[1]; }
   Real &operator[](const LogDensity &lRho) { return data_[2]; }
 
  private:
-  std::array<Real, 3> data_;
+  std::array<Real, length> data_;
+};
+
+class NewManualLambda_t : public ManualLambda_t {
+ public:
+  // Enable recognition that this is type-indexable
+  constexpr static bool is_type_indexable = true;
 };
 
 SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer]") {
@@ -73,13 +81,73 @@ SCENARIO("IndexableTypes and VariadicIndexer", "[IndexableTypes][VariadicIndexer
         REQUIRE(lRho == static_cast<Real>(2));
       }
     }
+    WHEN("We use the safeGet functionality") {
+      constexpr Real unmodified = -1.0;
+      Real destination = unmodified;
+      WHEN("We request a type that exists") {
+        const bool modified = safeGet<MeanIonizationState>(lambda, 2, destination);
+        THEN("The destination value will be modified") {
+          CHECK(modified);
+          REQUIRE(destination == lambda[MeanIonizationState{}]);
+        }
+      }
+      WHEN("We request a type that doesn't exist") {
+        const bool modified = safeGet<TableStatus>(lambda, 2, destination);
+        THEN("The destination value will remain UNmodified") {
+          CHECK(!modified);
+          REQUIRE(destination == unmodified);
+        }
+      }
+      WHEN("A normal array-like lambda is used") {
+        std::array<Real, Lambda_t::size()> lambda_arr{1, 2, 3};
+        constexpr size_t my_index = 2;
+        const bool modified = safeGet<LogDensity>(lambda_arr, my_index, destination);
+        THEN("The destination value will reflect the index from the array") {
+          CHECK(modified);
+          REQUIRE(destination == lambda_arr[my_index]);
+        }
+      }
+    }
+    WHEN("We use the safeSet functionality") {
+      constexpr Real new_value = -1.0;
+      WHEN("We want to set a value for a type index that exists") {
+        const bool modified = safeSet<MeanIonizationState>(lambda, 2, new_value);
+        THEN("The lambda index was modified") {
+          CHECK(modified);
+          REQUIRE(lambda[MeanIonizationState{}] == new_value);
+        }
+      }
+      WHEN("We want to set a value for a type index that doesn't exist") {
+        const bool modified = safeSet<TableStatus>(lambda, 2, new_value);
+        Lambda_t old_lambda;
+        for (std::size_t i = 0; i < Lambda_t::size(); ++i) {
+          old_lambda[i] = lambda[i];
+        }
+        THEN("None of the lambda values were modified") {
+          CHECK(!modified);
+          for (std::size_t i = 0; i < Lambda_t::size(); ++i) {
+            INFO("i: " << i);
+            CHECK(lambda[i] == old_lambda[i]);
+          }
+        }
+      }
+      WHEN("A normal array-like lambda is used") {
+        std::array<Real, Lambda_t::size()> lambda_arr{4, 5, 6};
+        constexpr size_t my_index = 1;
+        const bool modified = safeSet<LogDensity>(lambda_arr, my_index, new_value);
+        THEN("The lambda value at the appropriate index has been modified") {
+          CHECK(modified);
+          REQUIRE(lambda_arr[my_index] == new_value);
+        }
+      }
+    }
   }
 }
 
 SCENARIO("IndexableTypes and ManualLambda", "[IndexableTypes]") {
   GIVEN("A manually written indexer, filled with indices 0, 1, 2") {
     ManualLambda_t lambda;
-    for (std::size_t i = 0; i < 3; ++i) {
+    for (std::size_t i = 0; i < lambda.length; ++i) {
       lambda[i] = static_cast<Real>(i);
     }
     WHEN("We use the Get functionality") {
@@ -90,6 +158,65 @@ SCENARIO("IndexableTypes and ManualLambda", "[IndexableTypes]") {
       THEN("We get the correct values") {
         REQUIRE(Zbar == static_cast<Real>(0));
         REQUIRE(lRho == static_cast<Real>(2));
+      }
+    }
+    WHEN("We use the safeGet functionality") {
+      constexpr Real unmodified = -1.0;
+      Real destination = unmodified;
+      WHEN("We request a type that doesn't exist in the manual indexer") {
+        constexpr size_t my_index = 1;
+        const bool modified = safeGet<TableStatus>(lambda, my_index, destination);
+        THEN("The destination WILL be modified since the manual indexer doesn't have the "
+             " `is_type_indexable` data member") {
+          CHECK(modified);
+          REQUIRE(destination == lambda[my_index]);
+        }
+      }
+      WHEN("We define a new manual indexer that has the `is_type_indexable` "
+           "data member") {
+        NewManualLambda_t lambda_new;
+        for (std::size_t i = 0; i < lambda.length; ++i) {
+          lambda_new[i] = lambda[i];
+        }
+        WHEN("We request a type that doesn't exist in the manual indexer") {
+          destination = unmodified;
+          constexpr size_t my_index = 1;
+          const bool modified = safeGet<TableStatus>(lambda_new, my_index, destination);
+          THEN("The destination will NOT be modified") {
+            CHECK(!modified);
+            REQUIRE(destination == unmodified);
+          }
+        }
+      }
+    }
+    WHEN("We use the safeSet functionality") {
+      constexpr Real new_value = -1.0;
+      WHEN("We want to set a value for a type index that doesn't exist") {
+        constexpr size_t my_index = 1;
+        const bool modified = safeSet<TableStatus>(lambda, my_index, new_value);
+        THEN("The lambda value WILL be modified since the manual indexer doesn't have "
+             "the `is_type_indexable` data member") {
+          CHECK(modified);
+          REQUIRE(lambda[my_index] == new_value);
+        }
+      }
+      WHEN("We define a new manual indexer that has the `is_type_indexable` data "
+           "member") {
+        NewManualLambda_t lambda_new;
+        for (std::size_t i = 0; i < lambda.length; ++i) {
+          lambda_new[i] = lambda[i];
+        }
+        WHEN("We request a type that doesn't exist in the manual indexer") {
+          constexpr size_t my_index = 1;
+          const bool modified = safeSet<TableStatus>(lambda_new, my_index, new_value);
+          THEN("The lambda will NOT be modified") {
+            CHECK(!modified);
+            for (std::size_t i = 0; i < lambda.length; ++i) {
+              INFO("i: " << i);
+              CHECK(lambda_new[i] == lambda[i]);
+            }
+          }
+        }
       }
     }
   }

--- a/test/test_pte_ideal.cpp
+++ b/test/test_pte_ideal.cpp
@@ -51,8 +51,12 @@ using singularity::IndexableTypes::MeanIonizationState;
 struct LambdaIndexerSingle {
   PORTABLE_FORCEINLINE_FUNCTION
   Real &operator[](const int i) { return z; }
+  PORTABLE_INLINE_FUNCTION
+  const Real &operator[](const int i) const { return z; }
   PORTABLE_FORCEINLINE_FUNCTION
   Real &operator[](const MeanIonizationState &s) { return z; }
+  PORTABLE_INLINE_FUNCTION
+  const Real &operator[](const MeanIonizationState &s) const { return z; }
   Real z = 0.9;
 };
 

--- a/test/test_spiner_transform.cpp
+++ b/test/test_spiner_transform.cpp
@@ -102,9 +102,7 @@ struct TestDataContainer {
     const Real lRho = spiner_common::to_log(rho, lRhoOffset);
     const Real lE = spiner_common::to_log(sie, lEOffset);
     // If we wanted to mock the lambda write-back (optional)
-    if (!variadic_utils::is_nullptr(lambda)) {
-      IndexerUtils::Get<IndexableTypes::LogDensity>(lambda, 0) = lRho;
-    }
+    IndexerUtils::SafeSet<IndexableTypes::LogDensity>(lambda, 0, lRho);
     return db.interpToReal(lRho, lE);
   }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This PR creates new helper functions for indexable types that are safer to use with indexable types.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

The underlying issue is that the original `Get()` helper function would try to use a type from the `IndexableTypes` namespace to get a lamda value and then it would fall back on a numerical index if that type wasn't present. The issue here is that when a types-based indexer is used, it could contain other types and we don't want to get or overwrite the value at another index.

The `safeGet()` and `safeSet()` helpers will _only_ use a numerical index if the indexer doesn't have a data member, `is_type_indexable` that is `true`. They can also detect whether or not they are passed a null pointer and appropriately do nothing.

There are also overloads for the `safe` functions that can avoid numerical indices altogether and also do nothing when a null pointer is passed.

## PR Checklist

TODO
- [x] Spiner classes
- [x] Helmholtz
- [x] Stellar Collapse
- [x] Electrons
- [x] ZSplit EOS

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
