### PR TITLE
Change search region for spiner

### DIFF
--- a/singularity-eos/eos/eos_spiner_rho_sie.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_sie.hpp
@@ -769,7 +769,7 @@ SpinerEOSDependsRhoSieTransformable<TransformerT>::lRhoFromPlT_(
   const RootFinding1D::RootCounts *pcounts =
       (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
   RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
-  const Real rhopmin = rho_at_pmin_.interpToReal(lT);
+  const Real rhopmin = spiner_common::to_log(rho_at_pmin_.interpToReal(lT), lRhoOffset_);
 
   Real lRho;
   Real dPdRhoMax = dPdRhoMax_.interpToReal(lT);

--- a/singularity-eos/eos/eos_spiner_rho_temp.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_temp.hpp
@@ -916,7 +916,7 @@ template <typename Indexer_t>
 PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lRhoFromPlT_(
     const Real P, const Real lT, TableStatus &whereAmI, Indexer_t &&lambda) const {
   RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
-  Real rhopmin = rho_at_pmin_.interpToReal(lT);
+  Real rhopmin = lRho_(rho_at_pmin_.interpToReal(lT));
 
   Real lRho;
   Real lRhoGuess = reproducible_ ? lRhoMax_ : 0.5 * (rhopmin + lRhoMax_);

--- a/singularity-eos/eos/eos_spiner_rho_temp.hpp
+++ b/singularity-eos/eos/eos_spiner_rho_temp.hpp
@@ -312,7 +312,6 @@ class SpinerEOSDependsRhoT : public EosBase<SpinerEOSDependsRhoT> {
 
   int numRho_, numT_;
   Real lRhoMin_, lRhoMax_, rhoMax_;
-  Real lRhoMinSearch_;
   Real lTMin_, lTMax_, TMax_;
   Real PMin_;
   Real rhoNormal_, TNormal_, sieNormal_, PNormal_;
@@ -494,9 +493,6 @@ inline herr_t SpinerEOSDependsRhoT::loadDataboxes_(const std::string &matid_str,
   TMax_ = from_log(lTMax_, lTOffset_);
 
   Real rhoMin = from_log(lRhoMin_, lRhoOffset_);
-  Real rhoMinSearch = std::max(
-      rhoMin, std::max(std::abs(robust::EPS()) * 10, std::abs(robust::EPS() * rhoMin)));
-  lRhoMinSearch_ = to_log(rhoMinSearch, lRhoOffset_);
 
   // bulk modulus can be wrong in the tables. Use FLAG's approach to
   // fix the table.
@@ -920,40 +916,38 @@ template <typename Indexer_t>
 PORTABLE_INLINE_FUNCTION Real SpinerEOSDependsRhoT::lRhoFromPlT_(
     const Real P, const Real lT, TableStatus &whereAmI, Indexer_t &&lambda) const {
   RootFinding1D::Status status = RootFinding1D::Status::SUCCESS;
+  Real rhopmin = rho_at_pmin_.interpToReal(lT);
 
   Real lRho;
-  Real lRhoGuess = reproducible_ ? lRhoMax_ : 0.5 * (lRhoMin_ + lRhoMax_);
+  Real lRhoGuess = reproducible_ ? lRhoMax_ : 0.5 * (rhopmin + lRhoMax_);
   // Real lRhoGuess = lRhoMin_ + 0.9*(lRhoMax_ - lRhoMin_);
   const RootFinding1D::RootCounts *pcounts =
       (memoryStatus_ == DataStatus::OnDevice) ? nullptr : &counts;
 
   Real lRho_cache;
   IndexerUtils::SafeGet<IndexableTypes::LogDensity>(lambda, Lambda::lRho, lRho_cache);
-  if ((lRhoMin_ <= lRho_cache) && (lRho_cache <= lRhoMax_)) {
+  if ((rhopmin <= lRho_cache) && (lRho_cache <= lRhoMax_)) {
     lRhoGuess = lRho_cache;
   }
 
   if (lT <= lTMin_) { // cold curve
     whereAmI = TableStatus::OffBottom;
     const callable_interp::interp PFunc(PCold_);
-    status =
-        SP_ROOT_FINDER(PFunc, P, lRhoGuess,
-                       // lRhoMin_, lRhoMax_,
-                       lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, pcounts);
+    status = SP_ROOT_FINDER(PFunc, P, lRhoGuess,
+                            // lRhoMin_, lRhoMax_,
+                            rhopmin, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, pcounts);
   } else if (lT >= lTMax_) { // ideal gas
     whereAmI = TableStatus::OffTop;
     const callable_interp::prod_interp_1d PFunc(gm1Max_, dEdTMax_, lT);
-    status =
-        SP_ROOT_FINDER(PFunc, P, lRhoGuess,
-                       // lRhoMin_, lRhoMax_,
-                       lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, pcounts);
+    status = SP_ROOT_FINDER(PFunc, P, lRhoGuess,
+                            // lRhoMin_, lRhoMax_,
+                            rhopmin, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, pcounts);
   } else { // on table
     whereAmI = TableStatus::OnTable;
     const callable_interp::l_interp PFunc(P_, lT);
-    status =
-        SP_ROOT_FINDER(PFunc, P, lRhoGuess,
-                       // lRhoMin_, lRhoMax_,
-                       lRhoMinSearch_, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, pcounts);
+    status = SP_ROOT_FINDER(PFunc, P, lRhoGuess,
+                            // lRhoMin_, lRhoMax_,
+                            rhopmin, lRhoMax_, ROOT_THRESH, ROOT_THRESH, lRho, pcounts);
   }
   if (status != RootFinding1D::Status::SUCCESS) {
 #if SPINER_EOS_VERBOSE


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@jonahm-LANL @Yurlungur added a change to how the `SpinerEOS*` classes handle density guesses for a given pressure and temperature.

This fixed a test issue I was encountering in https://github.com/lanl/singularity-eos/pull/526 where the results were not reproducible when doing the lookup from several different places.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
