### PR TITLE
Fix bug in FixedT PTE solver

### DIFF
--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -1455,7 +1455,7 @@ class PTESolverFixedT
     Real error_p = 0;
     for (std::size_t m = 1; m < nmat; ++m) {
       mean_p += vfrac[m] * press[m];
-      error_p += residual[m + 1] * residual[m + 1];
+      error_p += residual[m] * residual[m];
     }
     error_p = std::sqrt(error_p);
     Real error_v = std::abs(residual[0]);


### PR DESCRIPTION
There was a small indexing bug in the FixedT PTE solver with an index going out of bounds. The residual has size `nmat` in this PTE solver so the last iteration was OOB.

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
