### PR TITLE
SetRhoPMin shouldn't be a host device function

### DIFF
--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -222,7 +222,7 @@ struct IdentityOperator {
 };
 template <typename Data_t, typename Operator_t = IdentityOperator>
 PORTABLE_FORCEINLINE_FUNCTION Real
-sum_neumaier(Data_t &&data, std::size_t n, std::size_t offset = 0, std::size_t iskip = -1,
+sum_neumaier(Data_t &&data, std::size_t n, std::size_t offset = 0, int iskip = -1,
              const Operator_t &op = IdentityOperator()) {
   Real sum = 0;
   Real c = 0; // correction

--- a/singularity-eos/closure/mixed_cell_models.hpp
+++ b/singularity-eos/closure/mixed_cell_models.hpp
@@ -227,7 +227,7 @@ sum_neumaier(Data_t &&data, std::size_t n, std::size_t offset = 0, int iskip = -
   Real sum = 0;
   Real c = 0; // correction
   for (std::size_t i = 0; i < n; ++i) {
-    if (i == iskip) continue;
+    if (iskip >= 0 && i == static_cast<std::size_t>(iskip)) continue;
     Real x = op(data[i + offset]);
     Real t = sum + x;
     if (std::abs(sum) >= std::abs(x)) {

--- a/singularity-eos/eos/eos_spiner_common.hpp
+++ b/singularity-eos/eos/eos_spiner_common.hpp
@@ -53,10 +53,8 @@ PORTABLE_FORCEINLINE_FUNCTION Real from_log(const Real lx, const Real offset) {
   return FastMath::pow10(lx) - offset;
 }
 
-PORTABLE_INLINE_FUNCTION Real SetRhoPMin(DataBox &P, DataBox &rho_at_pmin,
-                                         const bool pmin_vapor_dome,
-                                         const Real VAPOR_DPDR_THRESH,
-                                         const Real lRhoOffset) {
+Real SetRhoPMin(DataBox &P, DataBox &rho_at_pmin, const bool pmin_vapor_dome,
+                const Real VAPOR_DPDR_THRESH, const Real lRhoOffset) {
   Real PMin = std::numeric_limits<Real>::max();
   const auto lTs = P.range(0);
   const auto lRs = P.range(1);

--- a/singularity-eos/eos/eos_spiner_common.hpp
+++ b/singularity-eos/eos/eos_spiner_common.hpp
@@ -53,8 +53,8 @@ PORTABLE_FORCEINLINE_FUNCTION Real from_log(const Real lx, const Real offset) {
   return FastMath::pow10(lx) - offset;
 }
 
-Real SetRhoPMin(DataBox &P, DataBox &rho_at_pmin, const bool pmin_vapor_dome,
-                const Real VAPOR_DPDR_THRESH, const Real lRhoOffset) {
+inline Real SetRhoPMin(DataBox &P, DataBox &rho_at_pmin, const bool pmin_vapor_dome,
+                       const Real VAPOR_DPDR_THRESH, const Real lRhoOffset) {
   Real PMin = std::numeric_limits<Real>::max();
   const auto lTs = P.range(0);
   const auto lRs = P.range(1);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

Eliminates a warning on GPU builds. This function never should have been a host device function.

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
