### PR TITLE
spack: remove redundant conflicts replaced by requires

### DIFF
--- a/spack-repo/v1/packages/singularity-eos/package.py
+++ b/spack-repo/v1/packages/singularity-eos/package.py
@@ -188,9 +188,6 @@ class SingularityEos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("amdgpu_target=none", when="+rocm", msg="ROCm architecture is required")
 
     # these are mirrored in the cmake configuration
-    conflicts("+cuda", when="~kokkos")
-    conflicts("+rocm", when="~kokkos")
-    conflicts("+kokkos-kernels", when="~kokkos")
     conflicts("+hdf5", when="~spiner")
 
     conflicts("+fortran", when="~closure")

--- a/spack-repo/v2/spack_repo/singularity_eos/packages/singularity_eos/package.py
+++ b/spack-repo/v2/spack_repo/singularity_eos/packages/singularity_eos/package.py
@@ -191,9 +191,6 @@ class SingularityEos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("amdgpu_target=none", when="+rocm", msg="ROCm architecture is required")
 
     # these are mirrored in the cmake configuration
-    conflicts("+cuda", when="~kokkos")
-    conflicts("+rocm", when="~kokkos")
-    conflicts("+kokkos-kernels", when="~kokkos")
     conflicts("+hdf5", when="~spiner")
 
     conflicts("+fortran", when="~closure")


### PR DESCRIPTION
## PR Summary

Since https://github.com/lanl/singularity-eos/pull/561 added `requires` rules, these conflicts are redundant.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
