### PR TITLE
cmake: installed target should only be IMPORTED

### DIFF
--- a/config/singularity-eosConfig.cmake.in
+++ b/config/singularity-eosConfig.cmake.in
@@ -109,7 +109,7 @@ endforeach()
 # singularity-eos convenience target
 # ------------------------------------------------------------------------------#
 if(NOT TARGET singularity-eos AND NOT singularity-eos_BINARY_DIR)
-  add_library(singularity-eos INTERFACE)
+  add_library(singularity-eos INTERFACE IMPORTED)
   add_library(singularity-eos::singularity-eos ALIAS singularity-eos)
 
   if("Interface" IN_LIST ${CMAKE_FIND_PACKAGE_NAME}_comps)


### PR DESCRIPTION
## PR Summary

Without this, any client that links to the library and tries to export its own targets will get a CMake error complaining about singularity-eos not being in any export set. IMPORTED will remove the target from being considered for export.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Ensure that any `when='@main'` dependencies are updated to the release version in the package.py
