### PR TITLE
Thread execution spaces through vector API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added (new features/APIs/variables/...)
 - [[PR623]](https://github.com/lanl/singularity-eos/pull/623) Expanded the sesame2spiner syntax to support multiple material definitions in one input file.
 - [[PR618]](https://github.com/lanl/singularity-eos/pull/618) Add PTDerivativesFromPreferred for computing derivatives of a mixture  in a cell
+- [[PR630]](https://github.com/lanl/singularity-eos/pull/630) Thread execution spaces through vector API.
 
 ### Fixed (Repair bugs, etc)
 

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -525,8 +525,9 @@ available member function.
 
 .. warning::
 
-  EOSPAC does **not** support non-host execution spaces. Calling them
-  will result in undefined behavior.
+  EOSPAC does **not** support selection of execution spaces. You will
+  get whatever execution space (likely host) that the EOSPAC backend
+  has been configured for.
 
 The Evaluate Methods
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx/src/using-eos.rst
+++ b/doc/sphinx/src/using-eos.rst
@@ -475,6 +475,23 @@ The vector API is templated to accept accessors. We do note, however,
 that vectorization may suffer if your underlying data structure is not
 contiguous in memory.
 
+Execution spaces for the vector API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``singularity-eos`` borrows from the `Kokkos`_ notion of an *execution
+space*. Each vector API call accepts an execution space as an optional
+first argument, telling ``singularity-eos`` where to launch work,
+either on CPU or GPU (for example). These are implemented via
+`ports-of-call`_. By default, the two execution spaces available are
+``PortsOfCall::Exec::Host`` and ``PortsOfCall::Exec::Device``. If you
+build with the serial backend, these are equivalent. If you build with
+``Kokkos`` enabled, you may also pass in any valid ``Kokkos``
+execution space.
+
+.. _Kokkos: https://kokkos.org/kokkos-core-wiki/
+
+.. _ports-of-call: https://lanl.github.io/ports-of-call/main/index.html
+
 .. _eospac_vector:
 
 EOSPAC Vector Functions
@@ -505,6 +522,11 @@ available member function.
    // call EOSPAC eos vector function with scratch buffer
    eos.TemperatureFromDensityInternalEnergy(density.data(), energy.data(), temperature.data(),
                                             scratch.data(), density.size());
+
+.. warning::
+
+  EOSPAC does **not** support non-host execution spaces. Calling them
+  will result in undefined behavior.
 
 The Evaluate Methods
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/plan_histories/MR630-2026-04-09-modifier-vector-macro-proposal.md
+++ b/plan_histories/MR630-2026-04-09-modifier-vector-macro-proposal.md
@@ -1,0 +1,186 @@
+# MR630 Modifier Vector Macro Proposal
+
+## Goal
+
+Reduce the line count in `singularity-eos/eos/modifiers/*.hpp` for the raw-pointer
+vector API, especially the overloads that only forward to
+`PortsOfCall::Exec::Device()`.
+
+## Current Situation
+
+The modified vector API in the modifier headers now has two overload families for each
+raw-pointer vector method:
+
+1. A `Space` overload:
+
+```cpp
+template <typename Space, typename LambdaIndexer,
+          typename EnableIfSpace =
+              std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+inline void NAME(const Space &s, ...);
+```
+
+2. A default-device wrapper:
+
+```cpp
+template <typename LambdaIndexer>
+inline void NAME(...) const {
+  NAME(PortsOfCall::Exec::Device(), ...);
+}
+```
+
+This repeats across:
+
+- `scaled_eos.hpp`
+- `shifted_eos.hpp`
+- `eos_unitsystem.hpp`
+- `ramps_eos.hpp`
+- `floored_energy.hpp`
+
+## Important Constraint
+
+The default-device wrappers cannot simply be deleted while preserving the current API.
+The inherited wrappers in `eos/eos_base.hpp` do not automatically route into the
+modifier-specific raw-pointer `Space` overloads. If we want to keep the existing
+call surface, the realistic near-term win is to generate these wrappers, not remove the
+behavior.
+
+## Recommended Macro Scheme
+
+Introduce a small modifier-only macro header, for example:
+
+- `singularity-eos/eos/modifiers/modifier_vector_macros.hpp`
+
+That header would define the default-device wrappers once.
+
+### 2-in / 1-out wrapper
+
+```cpp
+#define SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(NAME)                                           \
+  template <typename LambdaIndexer>                                                      \
+  inline void NAME(const Real *in1, const Real *in2, Real *out, Real *scratch,           \
+                   const int num, LambdaIndexer &&lambdas,                               \
+                   Transform &&transform = Transform()) const {                          \
+    NAME(PortsOfCall::Exec::Device(), in1, in2, out, scratch, num,                       \
+         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));      \
+  }
+```
+
+### 1-in / 1-out wrapper
+
+```cpp
+#define SG_MODIFIER_DEVICE_WRAP_1IN_1OUT(NAME)                                           \
+  template <typename LambdaIndexer>                                                      \
+  inline void NAME(const Real *in1, Real *out, Real *scratch, const int num,             \
+                   LambdaIndexer &&lambdas,                                              \
+                   Transform &&transform = Transform()) const {                          \
+    NAME(PortsOfCall::Exec::Device(), in1, out, scratch, num,                            \
+         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));      \
+  }
+```
+
+### Aggregate wrapper list
+
+```cpp
+#define SG_MODIFIER_DEVICE_WRAP_ALL()                                                    \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(TemperatureFromDensityInternalEnergy)                  \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(PressureFromDensityTemperature)                        \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(PressureFromDensityInternalEnergy)                     \
+  SG_MODIFIER_DEVICE_WRAP_1IN_1OUT(MinInternalEnergyFromDensity)                          \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(SpecificHeatFromDensityTemperature)                    \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(SpecificHeatFromDensityInternalEnergy)                 \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(BulkModulusFromDensityTemperature)                     \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(BulkModulusFromDensityInternalEnergy)                  \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(GruneisenParamFromDensityTemperature)                  \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(GruneisenParamFromDensityInternalEnergy)               \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(InternalEnergyFromDensityTemperature)                  \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(EntropyFromDensityTemperature)                         \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(EntropyFromDensityInternalEnergy)
+```
+
+## How This Would Be Used
+
+Each modifier would keep only its `Space` overload implementations. At the end of the
+vector API block, it would add:
+
+```cpp
+SG_MODIFIER_DEVICE_WRAP_ALL()
+```
+
+That removes most of the duplicate default-device wrapper code while preserving the
+current behavior.
+
+## Second Stage for Simple Forwarders
+
+For `scaled_eos.hpp` and `eos_unitsystem.hpp`, the `Space` overload bodies are also
+highly repetitive:
+
+- update `transform`
+- call `t_.NAME(s, ...)`
+
+Those two files could use a second macro family such as:
+
+```cpp
+#define SG_MODIFIER_FORWARD_2IN_1OUT(NAME, PREPARE)                                      \
+  template <typename Space, typename LambdaIndexer,                                      \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
+  inline void NAME(const Space &s, const Real *in1, const Real *in2, Real *out,          \
+                   Real *scratch, const int num, LambdaIndexer &&lambdas,                \
+                   Transform &&transform = Transform()) const {                          \
+    PREPARE                                                                              \
+    t_.NAME(s, in1, in2, out, scratch, num,                                              \
+            std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));   \
+  }                                                                                      \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(NAME)
+```
+
+Example usage:
+
+```cpp
+SG_MODIFIER_FORWARD_2IN_1OUT(
+    TemperatureFromDensityInternalEnergy,
+    transform.x.apply(scale_);
+    transform.y.apply(inv_scale_);)
+```
+
+## Where Not to Overuse Macros
+
+I would not force the body macros into:
+
+- `shifted_eos.hpp`
+- `floored_energy.hpp`
+- `ramps_eos.hpp`
+
+Those files contain real per-method logic:
+
+- scratch-buffer preprocessing and postprocessing
+- local `portableFor` loops
+- ramp-pressure overrides
+
+For those files, the better tradeoff is:
+
+- keep explicit `Space` overload bodies
+- macro-generate only the default-device wrappers
+
+## Alternative If True Elimination Is Desired
+
+If the actual goal is to eliminate per-file default-device overloads entirely, use a CRTP
+mixin instead of macros. Each modifier would define only the `Space` overloads, and the
+mixin would provide the no-space wrappers once.
+
+That is conceptually cleaner than making the macro scheme more aggressive, but it is a
+larger refactor than the macro-only approach above.
+
+## Recommendation
+
+Preferred implementation order:
+
+1. Add a shared modifier macro header that generates the default-device wrappers.
+2. Convert all five modified modifier headers to use that wrapper macro set.
+3. Optionally add the forwarding-body macros for `ScaledEOS` and `EOSUnitSystem`.
+4. Leave `ShiftedEOS`, `FlooredEnergy`, and `BilinearRampEOS` with explicit `Space`
+   overload bodies.
+
+This gives most of the line-count reduction without hiding the custom vector logic that
+still needs to be readable.

--- a/python/module.hpp
+++ b/python/module.hpp
@@ -22,6 +22,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
+#include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_errors.hpp>
 
 #include <singularity-eos/base/variadic_utils.hpp>
@@ -104,10 +105,11 @@ void func(const T & self, py::array_t<Real> a, py::array_t<Real> b,             
   auto av = a.unchecked<1>();                                                     \
   auto bv = b.unchecked<1>();                                                     \
   auto outv = PyArrayHelper(out.mutable_unchecked<1>());                          \
+  PortsOfCall::Exec::Host host;                                                   \
   if(lambdas_info.shape[1] > 0) {                                                 \
-    self.func(av, bv, outv, a.size(), LambdaHelper(lambdas));                     \
+    self.func(host, av, bv, outv, a.size(), LambdaHelper(lambdas));               \
   } else {                                                                        \
-    self.func(av, bv, outv, a.size(), NoLambdaHelper());                          \
+    self.func(host, av, bv, outv, a.size(), NoLambdaHelper());                    \
   }                                                                               \
 }                                                                                 \
                                                                                   \
@@ -122,15 +124,16 @@ void func##WithScratch(const T & self, py::array_t<Real> a, py::array_t<Real> b,
   auto bv = PyArrayHelper(b.mutable_unchecked<1>());                              \
   auto outv = PyArrayHelper(out.mutable_unchecked<1>());                          \
   auto scrv = PyArrayHelper(scratch.mutable_unchecked<1>());                      \
+  PortsOfCall::Exec::Host host;                                                   \
   PORTABLE_REQUIRE(av.IsContiguous(), "arrays w/ scratch must be contiguous");    \
   PORTABLE_REQUIRE(bv.IsContiguous(), "arrays w/ scratch must be contiguous");    \
   PORTABLE_REQUIRE(outv.IsContiguous(), "arrays w/ scratch must be contiguous");  \
   PORTABLE_REQUIRE(scrv.IsContiguous(), "arrays w/ scratch must be contiguous");  \
   if(lambdas_info.shape[1] > 0) {                                                 \
-    self.func(av.data(), bv.data(), outv.data(), scrv.data(), a.size(),           \
+    self.func(host, av.data(), bv.data(), outv.data(), scrv.data(), a.size(),     \
               LambdaHelper(lambdas));                                             \
   } else {                                                                        \
-    self.func(av.data(), bv.data(), outv.data(), scrv.data(), a.size(),           \
+    self.func(host, av.data(), bv.data(), outv.data(), scrv.data(), a.size(),     \
               NoLambdaHelper());                                                  \
   }                                                                               \
 }                                                                                 \
@@ -141,7 +144,8 @@ void func##NoLambda(const T & self, py::array_t<Real> a, py::array_t<Real> b,   
   auto av = a.unchecked<1>();                                                     \
   auto bv = b.unchecked<1>();                                                     \
   auto outv = PyArrayHelper(out.mutable_unchecked<1>());                          \
-  self.func(av, bv, outv, a.size(), NoLambdaHelper());                            \
+  PortsOfCall::Exec::Host host;                                                   \
+  self.func(host, av, bv, outv, a.size(), NoLambdaHelper());                      \
 }                                                                                 \
                                                                                   \
 template<typename T>                                                              \
@@ -151,11 +155,12 @@ void func##NoLambdaWithScratch(const T & self, py::array_t<Real> a, py::array_t<
   auto bv = PyArrayHelper(b.mutable_unchecked<1>());                              \
   auto outv = PyArrayHelper(out.mutable_unchecked<1>());                          \
   auto scrv = PyArrayHelper(scratch.mutable_unchecked<1>());                      \
+  PortsOfCall::Exec::Host host;                                                   \
   PORTABLE_REQUIRE(av.IsContiguous(), "arrays w/ scratch must be contiguous");    \
   PORTABLE_REQUIRE(bv.IsContiguous(), "arrays w/ scratch must be contiguous");    \
   PORTABLE_REQUIRE(outv.IsContiguous(), "arrays w/ scratch must be contiguous");  \
   PORTABLE_REQUIRE(scrv.IsContiguous(), "arrays w/ scratch must be contiguous");  \
-  self.func(av.data(), bv.data(), outv.data(), scrv.data(), a.size(),             \
+  self.func(host, av.data(), bv.data(), outv.data(), scrv.data(), a.size(),       \
             NoLambdaHelper());                                                    \
 }
 
@@ -260,11 +265,13 @@ struct VectorFunctions {
       auto bmodsv = PyArrayHelper(bmods.mutable_unchecked<1>());
 
       if(lambdas_info.shape[1] > 0) {
-        self.FillEos(rhosv, temperaturesv,
+        self.FillEos(PortsOfCall::Exec::Host(),
+                     rhosv, temperaturesv,
                      siesv, pressuresv, cvsv,
                      bmodsv, rhos.size(), output, LambdaHelper(lambdas));
       } else {
-        self.FillEos(rhosv, temperaturesv,
+        self.FillEos(PortsOfCall::Exec::Host(),
+                     rhosv, temperaturesv,
                      siesv, pressuresv, cvsv,
                      bmodsv, rhos.size(), output, NoLambdaHelper());
       }
@@ -282,7 +289,8 @@ struct VectorFunctions {
       auto pressuresv = PyArrayHelper(pressures.mutable_unchecked<1>());
       auto cvsv = PyArrayHelper(cvs.mutable_unchecked<1>());
       auto bmodsv = PyArrayHelper(bmods.mutable_unchecked<1>());
-      self.FillEos(rhosv, temperaturesv,
+      self.FillEos(PortsOfCall::Exec::Host(),
+                   rhosv, temperaturesv,
                     siesv, pressuresv, cvsv,
                    bmodsv, rhos.size(), output, NoLambdaHelper());
     }, py::arg("rhos"), py::arg("temperatures"), py::arg("sies"), py::arg("pressures"), py::arg("cvs"), py::arg("bmods"), py::arg("output"));
@@ -334,12 +342,14 @@ struct VectorFunctions<T,true> {
       auto scrv = PyArrayHelper(scratch.mutable_unchecked<1>());
 
       if(lambdas_info.shape[1] > 0) {
-        self.FillEos(rhosv.data(), temperaturesv.data(),
+        self.FillEos(PortsOfCall::Exec::Host(),
+                     rhosv.data(), temperaturesv.data(),
                      siesv.data(), pressuresv.data(), cvsv.data(),
                      bmodsv.data(), scrv.data(), rhos.size(), output,
                      LambdaHelper(lambdas));
       } else {
-        self.FillEos(rhosv.data(), temperaturesv.data(),
+        self.FillEos(PortsOfCall::Exec::Host(),
+                     rhosv.data(), temperaturesv.data(),
                      siesv.data(), pressuresv.data(), cvsv.data(),
                      bmodsv.data(), scrv.data(), rhos.size(), output,
                      NoLambdaHelper());
@@ -361,7 +371,8 @@ struct VectorFunctions<T,true> {
       auto bmodsv = PyArrayHelper(bmods.mutable_unchecked<1>());
       auto scrv = PyArrayHelper(scratch.mutable_unchecked<1>());
 
-      self.FillEos(rhosv.data(), temperaturesv.data(),
+      self.FillEos(PortsOfCall::Exec::Host(),
+                   rhosv.data(), temperaturesv.data(),
                    siesv.data(), pressuresv.data(), cvsv.data(),
                    bmodsv.data(), scrv.data(), rhos.size(),
                    output, NoLambdaHelper());

--- a/sesame2spiner/io_eospac.cpp
+++ b/sesame2spiner/io_eospac.cpp
@@ -333,7 +333,6 @@ bool eosMassFraction(int matid, const Bounds &lRhoBounds, const Bounds &lTBounds
                      std::string &phase_names, Verbosity eospacWarn) {
   using namespace EospacWrapper;
 
-  EOS_INTEGER errorCode = EOS_OK;
   constexpr int NT = 2;
   EOS_INTEGER tableHandle[NT];
   EOS_INTEGER tableType[NT] = {EOS_M_DT, EOS_Comment};

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -57,6 +57,7 @@ register_headers(
     eos/eos_helmholtz.hpp
     eos/eos_sap_polynomial.hpp
     eos/eos_type_lists.hpp
+    eos/modifiers/modifier_vector_macros.hpp
     eos/modifiers/relativistic_eos.hpp
     eos/modifiers/scaled_eos.hpp
     eos/modifiers/ramps_eos.hpp

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -302,9 +302,8 @@ class VariadicIndexerBase {
   PORTABLE_FORCEINLINE_FUNCTION
   VariadicIndexerBase(const Data_t &data) : data_(data) {}
 
-  template <typename T,
-            typename EnableIfContained =
-                std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
+  template <typename T, typename EnableIfContained =
+                            std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
   PORTABLE_FORCEINLINE_FUNCTION Real &operator[](const T &t) {
     constexpr std::size_t idx = variadic_utils::GetIndexInTL<T, Ts...>();
     return data_[idx];
@@ -313,9 +312,8 @@ class VariadicIndexerBase {
   PORTABLE_FORCEINLINE_FUNCTION
   Real &operator[](const std::size_t idx) { return data_[idx]; }
 
-  template <typename T,
-            typename EnableIfContained =
-                std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
+  template <typename T, typename EnableIfContained =
+                            std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
   PORTABLE_FORCEINLINE_FUNCTION const Real &operator[](const T &t) const {
     constexpr std::size_t idx = variadic_utils::GetIndexInTL<T, Ts...>();
     return data_[idx];

--- a/singularity-eos/base/indexable_types.hpp
+++ b/singularity-eos/base/indexable_types.hpp
@@ -303,7 +303,8 @@ class VariadicIndexerBase {
   VariadicIndexerBase(const Data_t &data) : data_(data) {}
 
   template <typename T,
-            typename = std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
+            typename EnableIfContained =
+                std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
   PORTABLE_FORCEINLINE_FUNCTION Real &operator[](const T &t) {
     constexpr std::size_t idx = variadic_utils::GetIndexInTL<T, Ts...>();
     return data_[idx];
@@ -313,7 +314,8 @@ class VariadicIndexerBase {
   Real &operator[](const std::size_t idx) { return data_[idx]; }
 
   template <typename T,
-            typename = std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
+            typename EnableIfContained =
+                std::enable_if_t<variadic_utils::contains<T, Ts...>::value>>
   PORTABLE_FORCEINLINE_FUNCTION const Real &operator[](const T &t) const {
     constexpr std::size_t idx = variadic_utils::GetIndexInTL<T, Ts...>();
     return data_[idx];

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -425,10 +425,10 @@ class EosBase {
 
   /// This is sort of what the SG_EOS_VEC would concretize too, though
   /// it has fewer arguments.
-  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
-            typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename RealIndexer, typename ConstRealIndexer,
+      typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, const int num,
                                            LambdaIndexer &&lambdas) const {
@@ -440,12 +440,12 @@ class EosBase {
           sies[i] = copy.MinInternalEnergyFromDensity(rhos[i], lambdas[i]);
         });
   }
-  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
-            typename LambdaIndexer,
-            typename EnableIfNotRaw =
-                std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename RealIndexer, typename ConstRealIndexer,
+      typename LambdaIndexer,
+      typename EnableIfNotRaw =
+          std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, Real * /*scratch*/,
                                            const int num, LambdaIndexer &&lambdas) const {
@@ -453,9 +453,9 @@ class EosBase {
                                  std::forward<RealIndexer>(sies), num,
                                  std::forward<LambdaIndexer>(lambdas));
   }
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, const Real *rhos, Real *sies,
                                            Real * /*scratch*/, const int num,
                                            LambdaIndexer &&lambdas,
@@ -463,22 +463,20 @@ class EosBase {
     MinInternalEnergyFromDensity(s, rhos, sies, num,
                                  std::forward<LambdaIndexer>(lambdas));
   }
-  template <
-      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename EnableIfIndexed =
-          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename EnableIfIndexed =
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
     MinInternalEnergyFromDensity(
         PortsOfCall::Exec::Device(), std::forward<ConstRealIndexer>(rhos),
         std::forward<RealIndexer>(sies), num, std::forward<LambdaIndexer>(lambdas));
   }
-  template <
-      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename EnableIfNotRaw =
-          std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
-      typename EnableIfIndexed =
-          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename EnableIfNotRaw =
+                std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+            typename EnableIfIndexed =
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real * /*scratch*/, const int num,
                                            LambdaIndexer &&lambdas) const {
@@ -502,9 +500,9 @@ class EosBase {
   SG_EOS_VEC_FOR(GruneisenParam)
   SG_EOS_VEC_FOR(GibbsFreeEnergy)
 
-  template <typename Space, typename RealIndexer, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename RealIndexer, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void FillEos(const Space &s, RealIndexer &&rhos, RealIndexer &&temps,
                       RealIndexer &&energies, RealIndexer &&presses, RealIndexer &&cvs,
                       RealIndexer &&bmods, const int num, const unsigned long output,

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -160,30 +160,68 @@ char *StrCat(char *destination, const char *source) {
 // TODO(JMM): I decided to keep the names in the arguments to macro
 // even though it's not strictly necessary, as I think it's more
 // legible and produces more useful output in, e.g., a debugger.
+/* In order, these overloads are the following:
+   1. Base loop that loops over the scalar call
+   2. Same thing, but with a Real* scratch passed in, maybe unused.
+   3. Explicit specialization where the indexers are Real*s.
+   4. - 6. Same thing as 1.-3., but with a default execution space.
+*/
 #define SG_EOS_VEC_2IN_1OUT(NAME, IN1, IN2, OUT)                                         \
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>     \
-  inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
-                   const int num, LambdaIndexer &&lambdas) const {                       \
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
+            typename LambdaIndexer,                                                      \
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+  inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
+                   RealIndexer &&OUT, const int num, LambdaIndexer &&lambdas) const {    \
     static auto const name = SG_MEMBER_FUNC_NAME();                                      \
     static auto const cname = name.c_str();                                              \
     const CRTP &copy = *(static_cast<CRTP const *>(this));                               \
     portableFor(                                                                         \
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {                                    \
+        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {                                 \
           OUT[i] = copy.NAME(IN1[i], IN2[i], lambdas[i]);                                \
         });                                                                              \
   }                                                                                      \
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
+            typename LambdaIndexer,                                                      \
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,      \
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+  inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
+                   RealIndexer &&OUT, Real * /*scratch*/, const int num,                 \
+                   LambdaIndexer &&lambdas) const {                                      \
+    NAME(s, std::forward<ConstRealIndexer>(IN1), std::forward<ConstRealIndexer>(IN2),    \
+         std::forward<RealIndexer>(OUT), num, std::forward<LambdaIndexer>(lambdas));     \
+  }                                                                                      \
+  template <typename Space, typename LambdaIndexer,                                      \
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+  inline void NAME(const Space &s, const Real *IN1, const Real *IN2, Real *OUT,          \
+                   Real * /*scratch*/, const int num, LambdaIndexer &&lambdas,           \
+                   Transform && = Transform()) const {                                   \
+    NAME(s, IN1, IN2, OUT, num, std::forward<LambdaIndexer>(lambdas));                   \
+  }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>      \
+            typename =                                                                   \
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
+  inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
+                   const int num, LambdaIndexer &&lambdas) const {                       \
+    NAME(PortsOfCall::Exec::Device(), std::forward<ConstRealIndexer>(IN1),               \
+         std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT), num,       \
+         std::forward<LambdaIndexer>(lambdas));                                          \
+  }                                                                                      \
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,      \
+            typename =                                                                   \
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    Real * /*scratch*/, const int num, LambdaIndexer &&lambdas) const {   \
-    NAME(std::forward<ConstRealIndexer>(IN1), std::forward<ConstRealIndexer>(IN2),       \
-         std::forward<RealIndexer>(OUT), num, std::forward<LambdaIndexer>(lambdas));     \
+    NAME(PortsOfCall::Exec::Device(), std::forward<ConstRealIndexer>(IN1),               \
+         std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT), num,       \
+         std::forward<LambdaIndexer>(lambdas));                                          \
   }                                                                                      \
   template <typename LambdaIndexer>                                                      \
   inline void NAME(const Real *IN1, const Real *IN2, Real *OUT, Real * /*scratch*/,      \
                    const int num, LambdaIndexer &&lambdas, Transform && = Transform())   \
       const {                                                                            \
-    NAME(IN1, IN2, OUT, num, std::forward<LambdaIndexer>(lambdas));                      \
+    NAME(PortsOfCall::Exec::Device(), IN1, IN2, OUT, num,                                \
+         std::forward<LambdaIndexer>(lambdas));                                          \
   }
 
 class Factor {
@@ -377,32 +415,67 @@ class EosBase {
 
   /// This is sort of what the SG_EOS_VEC would concretize too, though
   /// it has fewer arguments.
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
-  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
-                                           const int num, LambdaIndexer &&lambdas) const {
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
+            typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
+                                           RealIndexer &&sies, const int num,
+                                           LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
     const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
           sies[i] = copy.MinInternalEnergyFromDensity(rhos[i], lambdas[i]);
         });
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
+            typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
+                                           RealIndexer &&sies, Real * /*scratch*/,
+                                           const int num, LambdaIndexer &&lambdas) const {
+    MinInternalEnergyFromDensity(s, std::forward<ConstRealIndexer>(rhos),
+                                 std::forward<RealIndexer>(sies), num,
+                                 std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, const Real *rhos, Real *sies,
+                                           Real * /*scratch*/, const int num,
+                                           LambdaIndexer &&lambdas,
+                                           Transform && = Transform()) const {
+    MinInternalEnergyFromDensity(s, rhos, sies, num,
+                                 std::forward<LambdaIndexer>(lambdas));
+  }
+  template <
+      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
+                                           const int num, LambdaIndexer &&lambdas) const {
+    MinInternalEnergyFromDensity(
+        PortsOfCall::Exec::Device(), std::forward<ConstRealIndexer>(rhos),
+        std::forward<RealIndexer>(sies), num, std::forward<LambdaIndexer>(lambdas));
+  }
+  template <
+      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+      typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real * /*scratch*/, const int num,
                                            LambdaIndexer &&lambdas) const {
-    MinInternalEnergyFromDensity(std::forward<ConstRealIndexer>(rhos),
-                                 std::forward<RealIndexer>(sies), num,
-                                 std::forward<LambdaIndexer>(lambdas));
+    MinInternalEnergyFromDensity(
+        PortsOfCall::Exec::Device(), std::forward<ConstRealIndexer>(rhos),
+        std::forward<RealIndexer>(sies), num, std::forward<LambdaIndexer>(lambdas));
   }
   template <typename LambdaIndexer>
   inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies,
                                            Real * /*scratch*/, const int num,
                                            LambdaIndexer &&lambdas,
                                            Transform && = Transform()) const {
-    MinInternalEnergyFromDensity(rhos, sies, num, std::forward<LambdaIndexer>(lambdas));
+    MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(), rhos, sies, num,
+                                 std::forward<LambdaIndexer>(lambdas));
   }
   ///
 
@@ -417,19 +490,32 @@ class EosBase {
   SG_EOS_VEC_2IN_1OUT(GibbsFreeEnergyFromDensityTemperature, rhos, Ts, Gs)
   SG_EOS_VEC_2IN_1OUT(GibbsFreeEnergyFromDensityInternalEnergy, rhos, sies, Gs)
 
-  template <typename RealIndexer, typename LambdaIndexer>
-  inline void FillEos(RealIndexer &&rhos, RealIndexer &&temps, RealIndexer &&energies,
-                      RealIndexer &&presses, RealIndexer &&cvs, RealIndexer &&bmods,
-                      const int num, const unsigned long output,
+  template <typename Space, typename RealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void FillEos(const Space &s, RealIndexer &&rhos, RealIndexer &&temps,
+                      RealIndexer &&energies, RealIndexer &&presses, RealIndexer &&cvs,
+                      RealIndexer &&bmods, const int num, const unsigned long output,
                       LambdaIndexer &&lambdas) const {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
     const CRTP &copy = *(static_cast<CRTP const *>(this));
     portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
           copy.FillEos(rhos[i], temps[i], energies[i], presses[i], cvs[i], bmods[i],
                        output, lambdas[i]);
         });
+  }
+  template <typename RealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<variadic_utils::has_int_index_v<RealIndexer>>>
+  inline void FillEos(RealIndexer &&rhos, RealIndexer &&temps, RealIndexer &&energies,
+                      RealIndexer &&presses, RealIndexer &&cvs, RealIndexer &&bmods,
+                      const int num, const unsigned long output,
+                      LambdaIndexer &&lambdas) const {
+    FillEos(PortsOfCall::Exec::Device(), std::forward<RealIndexer>(rhos),
+            std::forward<RealIndexer>(temps), std::forward<RealIndexer>(energies),
+            std::forward<RealIndexer>(presses), std::forward<RealIndexer>(cvs),
+            std::forward<RealIndexer>(bmods), num, output,
+            std::forward<LambdaIndexer>(lambdas));
   }
 
   // Report minimum values of density and temperature

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -707,34 +707,7 @@ class EosBase {
     eos.InternalEnergyFromDensityPressure(rho, P, sie, lambda);
     return sie;
   }
-  // Classes like EOSPAC probably wish to overload/shadow this version
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
-  inline void InternalEnergyFromDensityPressure(ConstRealIndexer &&rhos,
-                                                ConstRealIndexer &&Ps, RealIndexer &&sies,
-                                                const int num,
-                                                LambdaIndexer &&lambdas) const {
-    static auto const name = SG_MEMBER_FUNC_NAME();
-    static auto const cname = name.c_str();
-    CRTP copy = *(static_cast<CRTP const *>(this));
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          copy.InternalEnergyFromDensityPressure(rhos[i], Ps[i], sies[i], lambdas[i]);
-        });
-  }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
-  inline void InternalEnergyFromDensityPressure(ConstRealIndexer &&rhos,
-                                                ConstRealIndexer &&Ps, RealIndexer &&sies,
-                                                Real * /*scratch */, const int num,
-                                                LambdaIndexer &&lambdas) const {
-    return InternalEnergyFromDensityPressure(rhos, Ps, sies, num, lambdas);
-  }
-  template <typename LambdaIndexer>
-  inline void InternalEnergyFromDensityPressure(const Real *rhos, const Real *Ps,
-                                                Real *sies, Real * /*scratch */,
-                                                const int num, LambdaIndexer &&lambdas,
-                                                Transform && = Transform()) const {
-    return InternalEnergyFromDensityPressure(rhos, Ps, sies, num, lambdas);
-  }
+  SG_EOS_VEC_2IN_1OUT(InternalEnergyFromDensityPressure, rhos, Ps, sies)
 
   // Serialization
   /*

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -169,7 +169,8 @@ char *StrCat(char *destination, const char *source) {
 #define SG_EOS_VEC_2IN_1OUT(NAME, IN1, IN2, OUT)                                         \
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
             typename LambdaIndexer,                                                      \
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
   inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
                    RealIndexer &&OUT, const int num, LambdaIndexer &&lambdas) const {    \
     static auto const name = SG_MEMBER_FUNC_NAME();                                      \
@@ -182,8 +183,10 @@ char *StrCat(char *destination, const char *source) {
   }                                                                                      \
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
             typename LambdaIndexer,                                                      \
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,      \
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+            typename EnableIfNotRaw =                                                    \
+                std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,             \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
   inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
                    RealIndexer &&OUT, Real * /*scratch*/, const int num,                 \
                    LambdaIndexer &&lambdas) const {                                      \
@@ -191,14 +194,15 @@ char *StrCat(char *destination, const char *source) {
          std::forward<RealIndexer>(OUT), num, std::forward<LambdaIndexer>(lambdas));     \
   }                                                                                      \
   template <typename Space, typename LambdaIndexer,                                      \
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
   inline void NAME(const Space &s, const Real *IN1, const Real *IN2, Real *OUT,          \
                    Real * /*scratch*/, const int num, LambdaIndexer &&lambdas,           \
                    Transform && = Transform()) const {                                   \
     NAME(s, IN1, IN2, OUT, num, std::forward<LambdaIndexer>(lambdas));                   \
   }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
-            typename =                                                                   \
+            typename EnableIfIndexed =                                                   \
                 std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    const int num, LambdaIndexer &&lambdas) const {                       \
@@ -207,8 +211,9 @@ char *StrCat(char *destination, const char *source) {
          std::forward<LambdaIndexer>(lambdas));                                          \
   }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,      \
-            typename =                                                                   \
+            typename EnableIfNotRaw =                                                    \
+                std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,             \
+            typename EnableIfIndexed =                                                   \
                 std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    Real * /*scratch*/, const int num, LambdaIndexer &&lambdas) const {   \
@@ -422,7 +427,8 @@ class EosBase {
   /// it has fewer arguments.
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,
             typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, const int num,
                                            LambdaIndexer &&lambdas) const {
@@ -436,8 +442,10 @@ class EosBase {
   }
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,
             typename LambdaIndexer,
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfNotRaw =
+                std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, Real * /*scratch*/,
                                            const int num, LambdaIndexer &&lambdas) const {
@@ -446,7 +454,8 @@ class EosBase {
                                  std::forward<LambdaIndexer>(lambdas));
   }
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, const Real *rhos, Real *sies,
                                            Real * /*scratch*/, const int num,
                                            LambdaIndexer &&lambdas,
@@ -456,7 +465,8 @@ class EosBase {
   }
   template <
       typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+      typename EnableIfIndexed =
+          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
     MinInternalEnergyFromDensity(
@@ -465,8 +475,10 @@ class EosBase {
   }
   template <
       typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
-      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+      typename EnableIfNotRaw =
+          std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+      typename EnableIfIndexed =
+          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real * /*scratch*/, const int num,
                                            LambdaIndexer &&lambdas) const {
@@ -491,7 +503,8 @@ class EosBase {
   SG_EOS_VEC_FOR(GibbsFreeEnergy)
 
   template <typename Space, typename RealIndexer, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void FillEos(const Space &s, RealIndexer &&rhos, RealIndexer &&temps,
                       RealIndexer &&energies, RealIndexer &&presses, RealIndexer &&cvs,
                       RealIndexer &&bmods, const int num, const unsigned long output,
@@ -506,7 +519,8 @@ class EosBase {
         });
   }
   template <typename RealIndexer, typename LambdaIndexer,
-            typename = std::enable_if_t<variadic_utils::has_int_index_v<RealIndexer>>>
+            typename EnableIfIndexed =
+                std::enable_if_t<variadic_utils::has_int_index_v<RealIndexer>>>
   inline void FillEos(RealIndexer &&rhos, RealIndexer &&temps, RealIndexer &&energies,
                       RealIndexer &&presses, RealIndexer &&cvs, RealIndexer &&bmods,
                       const int num, const unsigned long output,

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -135,9 +135,16 @@ inline void SetUpOutputScalingOption(EOS_INTEGER options[], EOS_REAL values[],
 // override. MinInternalEnergyFromDensity shows approximately what
 // these concretize to, although MinInternalEnergyDensity requires one
 // fewer array than the macros.
+//
 // TODO(JMM): Execution spaces are not properly passed through EOSPAC
 // and I'm not sure how to make that work. For now, we just have a
 // disclaimer in the docs. Execution space is ignored.
+//
+// TODO(JMM): The first two overloads are the warnings for not using
+// the Real* or scratch specializations. They take an execution
+// space. The second two declarations are general and trigger for the
+// relevant functions below to reduce the number of overloads.
+//
 #define SG_EOSPAC_VEC_2IN_1OUT(NAME, IN1, IN2, OUT)                                      \
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
             typename LambdaIndexer,                                                      \
@@ -170,8 +177,7 @@ inline void SetUpOutputScalingOption(EOS_INTEGER options[], EOS_REAL values[],
          std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT), num,       \
          std::forward<LambdaIndexer>(lambdas));                                          \
   }                                                                                      \
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>      \
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    Real * /*scratch*/, const int num, LambdaIndexer &&lambdas) const {   \
     NAME(PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(IN1),                 \
@@ -318,6 +324,7 @@ class EOSPAC : public EosBase<EOSPAC> {
   inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &s,
                                            ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
+    PORTABLE_WARN("Not providing scratch memory will trigger scalar EOSPAC lookups");
     EosBase<EOSPAC>::MinInternalEnergyFromDensity(s, rhos, sies, num, lambdas);
   }
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,
@@ -331,20 +338,16 @@ class EOSPAC : public EosBase<EOSPAC> {
     PORTABLE_WARN("EOSPAC type mismatch will cause significant performance degradation");
     EosBase<EOSPAC>::MinInternalEnergyFromDensity(s, rhos, sies, num, lambdas);
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
     MinInternalEnergyFromDensity(
         PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(rhos),
         std::forward<RealIndexer>(sies), num, std::forward<LambdaIndexer>(lambdas));
   }
-  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
-            typename LambdaIndexer,
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &s,
-                                           ConstRealIndexer &&rhos, RealIndexer &&sies,
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
+  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real * /*scratch*/, const int num,
                                            LambdaIndexer &&lambdas) const {
     MinInternalEnergyFromDensity(
@@ -403,6 +406,7 @@ class EOSPAC : public EosBase<EOSPAC> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
+  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void PressureFromDensityTemperature(const Space &space, const Real *rhos,
@@ -432,22 +436,13 @@ class EOSPAC : public EosBase<EOSPAC> {
     eosSafeInterpolate(&table, num, R, T, P, dPdr, dPdT, "PofRT", Verbosity::Quiet,
                        options, values, nopts);
   }
-  template <typename LambdaIndexer>
-  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                             Real *pressures, Real *scratch,
-                                             const int num, LambdaIndexer &&lambdas,
-                                             Transform &&transform = Transform()) const {
-    PressureFromDensityTemperature(
-        PortsOfCall::Exec::Host(), rhos, temperatures, pressures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
 
+  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void EntropyFromDensityTemperature([[maybe_unused]] const Space &space,
-                                            const Real *rhos,
-                                            const Real *temperatures, Real *entropies,
-                                            Real *scratch, const int num,
+                                            const Real *rhos, const Real *temperatures,
+                                            Real *entropies, Real *scratch, const int num,
                                             LambdaIndexer /*lambdas*/,
                                             Transform &&transform = Transform()) const {
     using namespace EospacWrapper;
@@ -471,15 +466,6 @@ class EOSPAC : public EosBase<EOSPAC> {
 
     eosSafeInterpolate(&table, num, R, T, S, dSdr, dSdT, "SofRT", Verbosity::Quiet,
                        options, values, nopts);
-  }
-  template <typename LambdaIndexer>
-  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                            Real *entropies, Real *scratch, const int num,
-                                            LambdaIndexer &&lambdas,
-                                            Transform &&transform = Transform()) const {
-    EntropyFromDensityTemperature(
-        PortsOfCall::Exec::Host(), rhos, temperatures, entropies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <typename Space, typename LambdaIndexer,
@@ -600,14 +586,13 @@ class EOSPAC : public EosBase<EOSPAC> {
             scratch, num, output, std::forward<LambdaIndexer>(lambdas));
   }
 
+  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void
-  InternalEnergyFromDensityTemperature([[maybe_unused]] const Space &space,
-                                       const Real *rhos, const Real *temperatures,
-                                       Real *sies, Real *scratch, const int num,
-                                       LambdaIndexer /*lambdas*/,
-                                       Transform &&transform = Transform()) const {
+  inline void InternalEnergyFromDensityTemperature(
+      [[maybe_unused]] const Space &space, const Real *rhos, const Real *temperatures,
+      Real *sies, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
+      Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -633,23 +618,15 @@ class EOSPAC : public EosBase<EOSPAC> {
     eosSafeInterpolate(&table, num, R, T, E, DEDR, DEDT, "EofRT", Verbosity::Quiet,
                        options, values, nopts);
   }
-  template <typename LambdaIndexer>
-  inline void
-  InternalEnergyFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                       Real *sies, Real *scratch, const int num,
-                                       LambdaIndexer &&lambdas,
-                                       Transform &&transform = Transform()) const {
-    InternalEnergyFromDensityTemperature(
-        PortsOfCall::Exec::Host(), rhos, temperatures, sies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
 
+  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void PressureFromDensityInternalEnergy(
-      [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies,
-      Real *pressures, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
-      Transform &&transform = Transform()) const {
+  inline void
+  PressureFromDensityInternalEnergy([[maybe_unused]] const Space &space, const Real *rhos,
+                                    const Real *sies, Real *pressures, Real *scratch,
+                                    const int num, LambdaIndexer /*lambdas*/,
+                                    Transform &&transform = Transform()) const {
     using namespace EospacWrapper;
     EOS_REAL *R = const_cast<EOS_REAL *>(&rhos[0]);
     EOS_REAL *E = const_cast<EOS_REAL *>(&sies[0]);
@@ -671,14 +648,6 @@ class EOSPAC : public EosBase<EOSPAC> {
 
     eosSafeInterpolate(&table, num, R, E, P, dPdr, dPde, "PofRE", Verbosity::Quiet,
                        options, values, nopts);
-  }
-  template <typename LambdaIndexer>
-  inline void PressureFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *pressures, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    PressureFromDensityInternalEnergy(
-        PortsOfCall::Exec::Host(), rhos, sies, pressures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <typename Space, typename LambdaIndexer,
@@ -711,11 +680,12 @@ class EOSPAC : public EosBase<EOSPAC> {
   inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
                                            const int num, LambdaIndexer &&lambdas,
                                            Transform &&transform = Transform()) const {
-    MinInternalEnergyFromDensity(
-        PortsOfCall::Exec::Host(), rhos, sies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+    MinInternalEnergyFromDensity(PortsOfCall::Exec::Host(), rhos, sies, scratch, num,
+                                 std::forward<LambdaIndexer>(lambdas),
+                                 std::forward<Transform>(transform));
   }
 
+  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void SpecificHeatFromDensityTemperature(
@@ -754,20 +724,13 @@ class EOSPAC : public EosBase<EOSPAC> {
               cvFromSesame(std::max(DEDT[i], 0.0)); // Here we do something to the data!
         });
   }
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityTemperature(
-        PortsOfCall::Exec::Host(), rhos, temperatures, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
 
+  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void SpecificHeatFromDensityInternalEnergy(
-      [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies,
-      Real *cvs, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
+      [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies, Real *cvs,
+      Real *scratch, const int num, LambdaIndexer /*lambdas*/,
       Transform &&transform = Transform()) const {
 
     static auto const name =
@@ -826,22 +789,14 @@ class EOSPAC : public EosBase<EOSPAC> {
                            std::max(DEDT[i], 0.0)); // Here we do something to the data!
         });
   }
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityInternalEnergy(
-        PortsOfCall::Exec::Host(), rhos, sies, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
 
+  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void
-  BulkModulusFromDensityTemperature([[maybe_unused]] const Space &space,
-                                    const Real *rhos, const Real *temperatures,
-                                    Real *bmods, Real *scratch, const int num,
-                                    LambdaIndexer /*lambdas*/,
+  BulkModulusFromDensityTemperature([[maybe_unused]] const Space &space, const Real *rhos,
+                                    const Real *temperatures, Real *bmods, Real *scratch,
+                                    const int num, LambdaIndexer /*lambdas*/,
                                     Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
@@ -906,17 +861,8 @@ class EOSPAC : public EosBase<EOSPAC> {
           bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
         });
   }
-  template <typename LambdaIndexer>
-  inline void
-  BulkModulusFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                    Real *bmods, Real *scratch, const int num,
-                                    LambdaIndexer &&lambdas,
-                                    Transform &&transform = Transform()) const {
-    BulkModulusFromDensityTemperature(
-        PortsOfCall::Exec::Host(), rhos, temperatures, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
 
+  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void BulkModulusFromDensityInternalEnergy(
@@ -1004,23 +950,14 @@ class EOSPAC : public EosBase<EOSPAC> {
           bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
         });
   }
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    BulkModulusFromDensityInternalEnergy(
-        PortsOfCall::Exec::Host(), rhos, sies, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
 
+  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void
-  GruneisenParamFromDensityTemperature([[maybe_unused]] const Space &space,
-                                       const Real *rhos, const Real *temperatures,
-                                       Real *gm1s, Real *scratch, const int num,
-                                       LambdaIndexer /*lambdas*/,
-                                       Transform &&transform = Transform()) const {
+  inline void GruneisenParamFromDensityTemperature(
+      [[maybe_unused]] const Space &space, const Real *rhos, const Real *temperatures,
+      Real *gm1s, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
+      Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -1060,22 +997,13 @@ class EOSPAC : public EosBase<EOSPAC> {
           gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
         });
   }
-  template <typename LambdaIndexer>
-  inline void
-  GruneisenParamFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                       Real *gm1s, Real *scratch, const int num,
-                                       LambdaIndexer &&lambdas,
-                                       Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityTemperature(
-        PortsOfCall::Exec::Host(), rhos, temperatures, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
 
+  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void GruneisenParamFromDensityInternalEnergy(
-      [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies,
-      Real *gm1s, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
+      [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies, Real *gm1s,
+      Real *scratch, const int num, LambdaIndexer /*lambdas*/,
       Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
@@ -1134,14 +1062,6 @@ class EOSPAC : public EosBase<EOSPAC> {
           const Real DPDE = DPDT[i] / DEDT[i];
           gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
         });
-  }
-  template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityInternalEnergy(
-        PortsOfCall::Exec::Host(), rhos, sies, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   static inline unsigned long scratch_size(std::string method, unsigned int nelements) {

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -142,7 +142,8 @@ inline void SetUpOutputScalingOption(EOS_INTEGER options[], EOS_REAL values[],
 #define SG_EOSPAC_VEC_2IN_1OUT(NAME, IN1, IN2, OUT)                                      \
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
             typename LambdaIndexer,                                                      \
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
   inline void NAME([[maybe_unused]] const Space &s, ConstRealIndexer &&IN1,              \
                    ConstRealIndexer &&IN2, RealIndexer &&OUT, const int num,             \
                    LambdaIndexer &&lambdas) const {                                      \
@@ -153,8 +154,10 @@ inline void SetUpOutputScalingOption(EOS_INTEGER options[], EOS_REAL values[],
   }                                                                                      \
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
             typename LambdaIndexer,                                                      \
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,      \
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+            typename EnableIfNotRaw =                                                    \
+                std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,             \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
   inline void NAME([[maybe_unused]] const Space &s, ConstRealIndexer &&IN1,              \
                    ConstRealIndexer &&IN2, RealIndexer &&OUT, Real * /*scratch*/,        \
                    const int num, LambdaIndexer &&lambdas) const {                       \
@@ -165,7 +168,7 @@ inline void SetUpOutputScalingOption(EOS_INTEGER options[], EOS_REAL values[],
         std::forward<RealIndexer>(OUT), num, std::forward<LambdaIndexer>(lambdas));      \
   }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
-            typename =                                                                   \
+            typename EnableIfIndexed =                                                   \
                 std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    const int num, LambdaIndexer &&lambdas) const {                       \
@@ -176,9 +179,10 @@ inline void SetUpOutputScalingOption(EOS_INTEGER options[], EOS_REAL values[],
         std::forward<LambdaIndexer>(lambdas));                                           \
   }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
-            typename =                                                                   \
+            typename EnableIfIndexed =                                                   \
                 std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>,     \
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>      \
+            typename EnableIfNotRaw =                                                    \
+                std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>             \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    Real *scratch, const int num, LambdaIndexer &&lambdas) const {        \
     PORTABLE_WARN(                                                                       \
@@ -324,7 +328,8 @@ class EOSPAC : public EosBase<EOSPAC> {
 
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,
             typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &s,
                                            ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
@@ -333,8 +338,10 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,
             typename LambdaIndexer,
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfNotRaw =
+                std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &s,
                                            ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real * /*scratch*/, const int num,
@@ -344,7 +351,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
   template <
       typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+      typename EnableIfIndexed =
+          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
     MinInternalEnergyFromDensity(
@@ -353,8 +361,10 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
   template <
       typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
-      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+      typename EnableIfNotRaw =
+          std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+      typename EnableIfIndexed =
+          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real * /*scratch*/, const int num,
                                            LambdaIndexer &&lambdas) const {
@@ -377,7 +387,8 @@ class EOSPAC : public EosBase<EOSPAC> {
 
   // EOSPAC vector implementations
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void TemperatureFromDensityInternalEnergy(
       [[maybe_unused]] const Space &s, const Real *rhos, const Real *sies,
       Real *temperatures, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -415,7 +426,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void PressureFromDensityTemperature(const Space &space, const Real *rhos,
                                              const Real *temperatures, Real *pressures,
                                              Real *scratch, const int num,
@@ -455,7 +467,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void EntropyFromDensityTemperature([[maybe_unused]] const Space &space,
                                             const Real *rhos, const Real *temperatures,
                                             Real *entropies, Real *scratch, const int num,
@@ -494,7 +507,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void FillEos([[maybe_unused]] const Space &space, Real *rhos, Real *temps,
                       Real *energies, Real *presses, Real *cvs, Real *bmods,
                       Real *scratch, const int num, const unsigned long output,
@@ -612,7 +626,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void InternalEnergyFromDensityTemperature(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *temperatures,
       Real *sies, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -654,7 +669,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void
   PressureFromDensityInternalEnergy([[maybe_unused]] const Space &space, const Real *rhos,
                                     const Real *sies, Real *pressures, Real *scratch,
@@ -694,7 +710,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &space,
                                            const Real *rhos, Real *sies, Real *scratch,
                                            const int num, LambdaIndexer /*lambdas*/,
@@ -729,7 +746,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void SpecificHeatFromDensityTemperature(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *temperatures,
       Real *cvs, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -778,7 +796,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void SpecificHeatFromDensityInternalEnergy(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies, Real *cvs,
       Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -852,7 +871,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void
   BulkModulusFromDensityTemperature([[maybe_unused]] const Space &space, const Real *rhos,
                                     const Real *temperatures, Real *bmods, Real *scratch,
@@ -933,7 +953,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void BulkModulusFromDensityInternalEnergy(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies,
       Real *bmods, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -1031,7 +1052,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void GruneisenParamFromDensityTemperature(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *temperatures,
       Real *gm1s, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -1087,7 +1109,8 @@ class EOSPAC : public EosBase<EOSPAC> {
   }
 
   template <typename Space, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void GruneisenParamFromDensityInternalEnergy(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies, Real *gm1s,
       Real *scratch, const int num, LambdaIndexer /*lambdas*/,

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -179,10 +179,10 @@ inline void SetUpOutputScalingOption(EOS_INTEGER options[], EOS_REAL values[],
   }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
-                   Real * /*scratch*/, const int num, LambdaIndexer &&lambdas) const {   \
+                   Real *scratch, const int num, LambdaIndexer &&lambdas) const {        \
     NAME(PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(IN1),                 \
-         std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT), num,       \
-         std::forward<LambdaIndexer>(lambdas));                                          \
+         std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT), scratch,   \
+         num, std::forward<LambdaIndexer>(lambdas));                                     \
   }
 // Does fromdensitytemperature and fromdensityinternalenergy at once
 #define SG_EOSPAC_VEC_FOR(OUTNAME)                                                       \

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -392,7 +392,7 @@ class EOSPAC : public EosBase<EOSPAC> {
     eosSafeInterpolate(&table, num, R, E, T, dTdr, dTde, "TofRE", Verbosity::Quiet,
                        options, values, nopts);
   }
-  template <typename Space, typename LambdaIndexer>
+  template <typename LambdaIndexer>
   inline void
   TemperatureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
                                        Real *temperatures, Real *scratch, const int num,
@@ -442,9 +442,12 @@ class EOSPAC : public EosBase<EOSPAC> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                            Real *entropies, Real *scratch, const int num,
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void EntropyFromDensityTemperature([[maybe_unused]] const Space &space,
+                                            const Real *rhos,
+                                            const Real *temperatures, Real *entropies,
+                                            Real *scratch, const int num,
                                             LambdaIndexer /*lambdas*/,
                                             Transform &&transform = Transform()) const {
     using namespace EospacWrapper;
@@ -469,11 +472,22 @@ class EOSPAC : public EosBase<EOSPAC> {
     eosSafeInterpolate(&table, num, R, T, S, dSdr, dSdT, "SofRT", Verbosity::Quiet,
                        options, values, nopts);
   }
-
   template <typename LambdaIndexer>
-  inline void FillEos(Real *rhos, Real *temps, Real *energies, Real *presses, Real *cvs,
-                      Real *bmods, Real *scratch, const int num,
-                      const unsigned long output, LambdaIndexer /*lambdas*/) const {
+  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                            Real *entropies, Real *scratch, const int num,
+                                            LambdaIndexer &&lambdas,
+                                            Transform &&transform = Transform()) const {
+    EntropyFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, entropies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void FillEos([[maybe_unused]] const Space &space, Real *rhos, Real *temps,
+                      Real *energies, Real *presses, Real *cvs, Real *bmods,
+                      Real *scratch, const int num, const unsigned long output,
+                      LambdaIndexer /*lambdas*/) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -578,10 +592,19 @@ class EOSPAC : public EosBase<EOSPAC> {
           });
     }
   }
-
   template <typename LambdaIndexer>
+  inline void FillEos(Real *rhos, Real *temps, Real *energies, Real *presses, Real *cvs,
+                      Real *bmods, Real *scratch, const int num,
+                      const unsigned long output, LambdaIndexer &&lambdas) const {
+    FillEos(PortsOfCall::Exec::Host(), rhos, temps, energies, presses, cvs, bmods,
+            scratch, num, output, std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void
-  InternalEnergyFromDensityTemperature(const Real *rhos, const Real *temperatures,
+  InternalEnergyFromDensityTemperature([[maybe_unused]] const Space &space,
+                                       const Real *rhos, const Real *temperatures,
                                        Real *sies, Real *scratch, const int num,
                                        LambdaIndexer /*lambdas*/,
                                        Transform &&transform = Transform()) const {
@@ -610,11 +633,23 @@ class EOSPAC : public EosBase<EOSPAC> {
     eosSafeInterpolate(&table, num, R, T, E, DEDR, DEDT, "EofRT", Verbosity::Quiet,
                        options, values, nopts);
   }
-
   template <typename LambdaIndexer>
+  inline void
+  InternalEnergyFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                       Real *sies, Real *scratch, const int num,
+                                       LambdaIndexer &&lambdas,
+                                       Transform &&transform = Transform()) const {
+    InternalEnergyFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, sies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void PressureFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *pressures, Real *scratch, const int num,
-      LambdaIndexer /*lambdas*/, Transform &&transform = Transform()) const {
+      [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies,
+      Real *pressures, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
+      Transform &&transform = Transform()) const {
     using namespace EospacWrapper;
     EOS_REAL *R = const_cast<EOS_REAL *>(&rhos[0]);
     EOS_REAL *E = const_cast<EOS_REAL *>(&sies[0]);
@@ -637,9 +672,19 @@ class EOSPAC : public EosBase<EOSPAC> {
     eosSafeInterpolate(&table, num, R, E, P, dPdr, dPde, "PofRE", Verbosity::Quiet,
                        options, values, nopts);
   }
-
   template <typename LambdaIndexer>
-  inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
+  inline void PressureFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *pressures, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    PressureFromDensityInternalEnergy(
+        PortsOfCall::Exec::Host(), rhos, sies, pressures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &space,
+                                           const Real *rhos, Real *sies, Real *scratch,
                                            const int num, LambdaIndexer /*lambdas*/,
                                            Transform &&transform = Transform()) const {
     using namespace EospacWrapper;
@@ -662,11 +707,21 @@ class EOSPAC : public EosBase<EOSPAC> {
     eosSafeInterpolate(&table, num, R, R, E, dedr, dedr, "EcofD", Verbosity::Quiet,
                        options, values, nopts);
   }
-
   template <typename LambdaIndexer>
+  inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
+                                           const int num, LambdaIndexer &&lambdas,
+                                           Transform &&transform = Transform()) const {
+    MinInternalEnergyFromDensity(
+        PortsOfCall::Exec::Host(), rhos, sies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void SpecificHeatFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer /*lambdas*/, Transform &&transform = Transform()) const {
+      [[maybe_unused]] const Space &space, const Real *rhos, const Real *temperatures,
+      Real *cvs, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
+      Transform &&transform = Transform()) const {
     using namespace EospacWrapper;
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
@@ -699,11 +754,21 @@ class EOSPAC : public EosBase<EOSPAC> {
               cvFromSesame(std::max(DEDT[i], 0.0)); // Here we do something to the data!
         });
   }
-
   template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    SpecificHeatFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void SpecificHeatFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer /*lambdas*/, Transform &&transform = Transform()) const {
+      [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies,
+      Real *cvs, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
+      Transform &&transform = Transform()) const {
 
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
@@ -761,10 +826,20 @@ class EOSPAC : public EosBase<EOSPAC> {
                            std::max(DEDT[i], 0.0)); // Here we do something to the data!
         });
   }
-
   template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    SpecificHeatFromDensityInternalEnergy(
+        PortsOfCall::Exec::Host(), rhos, sies, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void
-  BulkModulusFromDensityTemperature(const Real *rhos, const Real *temperatures,
+  BulkModulusFromDensityTemperature([[maybe_unused]] const Space &space,
+                                    const Real *rhos, const Real *temperatures,
                                     Real *bmods, Real *scratch, const int num,
                                     LambdaIndexer /*lambdas*/,
                                     Transform &&transform = Transform()) const {
@@ -831,11 +906,23 @@ class EOSPAC : public EosBase<EOSPAC> {
           bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
         });
   }
-
   template <typename LambdaIndexer>
+  inline void
+  BulkModulusFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                    Real *bmods, Real *scratch, const int num,
+                                    LambdaIndexer &&lambdas,
+                                    Transform &&transform = Transform()) const {
+    BulkModulusFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void BulkModulusFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
-      LambdaIndexer /*lambdas*/, Transform &&transform = Transform()) const {
+      [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies,
+      Real *bmods, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
+      Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -917,10 +1004,20 @@ class EOSPAC : public EosBase<EOSPAC> {
           bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
         });
   }
-
   template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    BulkModulusFromDensityInternalEnergy(
+        PortsOfCall::Exec::Host(), rhos, sies, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void
-  GruneisenParamFromDensityTemperature(const Real *rhos, const Real *temperatures,
+  GruneisenParamFromDensityTemperature([[maybe_unused]] const Space &space,
+                                       const Real *rhos, const Real *temperatures,
                                        Real *gm1s, Real *scratch, const int num,
                                        LambdaIndexer /*lambdas*/,
                                        Transform &&transform = Transform()) const {
@@ -963,11 +1060,23 @@ class EOSPAC : public EosBase<EOSPAC> {
           gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
         });
   }
-
   template <typename LambdaIndexer>
+  inline void
+  GruneisenParamFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                       Real *gm1s, Real *scratch, const int num,
+                                       LambdaIndexer &&lambdas,
+                                       Transform &&transform = Transform()) const {
+    GruneisenParamFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void GruneisenParamFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
-      LambdaIndexer /*lambdas*/, Transform &&transform = Transform()) const {
+      [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies,
+      Real *gm1s, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
+      Transform &&transform = Transform()) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(EOSPAC).name(), __func__);
     static auto const cname = name.c_str();
@@ -1025,6 +1134,14 @@ class EOSPAC : public EosBase<EOSPAC> {
           const Real DPDE = DPDT[i] / DEDT[i];
           gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
         });
+  }
+  template <typename LambdaIndexer>
+  inline void GruneisenParamFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
+      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    GruneisenParamFromDensityInternalEnergy(
+        PortsOfCall::Exec::Host(), rhos, sies, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   static inline unsigned long scratch_size(std::string method, unsigned int nelements) {

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -135,24 +135,48 @@ inline void SetUpOutputScalingOption(EOS_INTEGER options[], EOS_REAL values[],
 // override. MinInternalEnergyFromDensity shows approximately what
 // these concretize to, although MinInternalEnergyDensity requires one
 // fewer array than the macros.
+// TODO(JMM): Execution spaces are not properly passed through EOSPAC
+// and I'm not sure how to make that work. For now, we just have a
+// disclaimer in the docs. Execution space is ignored.
 #define SG_EOSPAC_VEC_2IN_1OUT(NAME, IN1, IN2, OUT)                                      \
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
+            typename LambdaIndexer,                                                      \
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+  inline void NAME([[maybe_unused]] const Space &s, ConstRealIndexer &&IN1,              \
+                   ConstRealIndexer &&IN2, RealIndexer &&OUT, const int num,             \
+                   LambdaIndexer &&lambdas) const {                                      \
+    PORTABLE_WARN("Not providing scratch memory will trigger scalar EOSPAC lookups");    \
+    EosBase<EOSPAC>::NAME(                                                               \
+        s, std::forward<ConstRealIndexer>(IN1), std::forward<ConstRealIndexer>(IN2),     \
+        std::forward<RealIndexer>(OUT), num, std::forward<LambdaIndexer>(lambdas));      \
+  }                                                                                      \
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
+            typename LambdaIndexer,                                                      \
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,      \
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+  inline void NAME([[maybe_unused]] const Space &s, ConstRealIndexer &&IN1,              \
+                   ConstRealIndexer &&IN2, RealIndexer &&OUT, Real * /*scratch*/,        \
+                   const int num, LambdaIndexer &&lambdas) const {                       \
+    PORTABLE_WARN(                                                                       \
+        "EOSPAC type mismatch will cause significant performance degradation");          \
+    EosBase<EOSPAC>::NAME(                                                               \
+        s, std::forward<ConstRealIndexer>(IN1), std::forward<ConstRealIndexer>(IN2),     \
+        std::forward<RealIndexer>(OUT), num, std::forward<LambdaIndexer>(lambdas));      \
+  }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    const int num, LambdaIndexer &&lambdas) const {                       \
-    PORTABLE_WARN("Not providing scratch memory will trigger scalar EOSPAC lookups");    \
-    EosBase<EOSPAC>::NAME(                                                               \
-        std::forward<ConstRealIndexer>(IN1), std::forward<ConstRealIndexer>(IN2),        \
-        std::forward<RealIndexer>(OUT), num, std::forward<LambdaIndexer>(lambdas));      \
+    NAME(PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(IN1),                 \
+         std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT), num,       \
+         std::forward<LambdaIndexer>(lambdas));                                          \
   }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
             typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>      \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    Real * /*scratch*/, const int num, LambdaIndexer &&lambdas) const {   \
-    PORTABLE_WARN(                                                                       \
-        "EOSPAC type mismatch will cause significant performance degradation");          \
-    EosBase<EOSPAC>::NAME(                                                               \
-        std::forward<ConstRealIndexer>(IN1), std::forward<ConstRealIndexer>(IN2),        \
-        std::forward<RealIndexer>(OUT), num, std::forward<LambdaIndexer>(lambdas));      \
+    NAME(PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(IN1),                 \
+         std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT), num,       \
+         std::forward<LambdaIndexer>(lambdas));                                          \
   }
 // Does fromdensitytemperature and fromdensityinternalenergy at once
 #define SG_EOSPAC_VEC_FOR(OUTNAME)                                                       \
@@ -288,18 +312,44 @@ class EOSPAC : public EosBase<EOSPAC> {
   SG_EOSPAC_VEC_2IN_1OUT(InternalEnergyFromDensityTemperature, rhos, temperatures, sies)
   SG_EOSPAC_VEC_FOR(Pressure)
 
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
-  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
+            typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &s,
+                                           ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
-    EosBase<EOSPAC>::MinInternalEnergyFromDensity(rhos, sies, num, lambdas);
+    EosBase<EOSPAC>::MinInternalEnergyFromDensity(s, rhos, sies, num, lambdas);
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
-  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
+            typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &s,
+                                           ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real * /*scratch*/, const int num,
                                            LambdaIndexer &&lambdas) const {
     PORTABLE_WARN("EOSPAC type mismatch will cause significant performance degradation");
-    EosBase<EOSPAC>::MinInternalEnergyFromDensity(rhos, sies, num, lambdas);
+    EosBase<EOSPAC>::MinInternalEnergyFromDensity(s, rhos, sies, num, lambdas);
+  }
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
+                                           const int num, LambdaIndexer &&lambdas) const {
+    MinInternalEnergyFromDensity(
+        PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(rhos),
+        std::forward<RealIndexer>(sies), num, std::forward<LambdaIndexer>(lambdas));
+  }
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
+            typename LambdaIndexer,
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &s,
+                                           ConstRealIndexer &&rhos, RealIndexer &&sies,
+                                           Real * /*scratch*/, const int num,
+                                           LambdaIndexer &&lambdas) const {
+    MinInternalEnergyFromDensity(
+        PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(rhos),
+        std::forward<RealIndexer>(sies), num, std::forward<LambdaIndexer>(lambdas));
   }
 
   SG_EOSPAC_VEC_FOR(Entropy)
@@ -315,12 +365,12 @@ class EOSPAC : public EosBase<EOSPAC> {
   SG_ADD_DEFAULT_MEAN_ATOMIC_FUNCTIONS(AZbar_)
 
   // EOSPAC vector implementations
-  template <typename LambdaIndexer>
-  inline void
-  TemperatureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
-                                       Real *temperatures, Real *scratch, const int num,
-                                       LambdaIndexer /*lambdas*/,
-                                       Transform &&transform = Transform()) const {
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void TemperatureFromDensityInternalEnergy(
+      [[maybe_unused]] const Space &s, const Real *rhos, const Real *sies,
+      Real *temperatures, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
+      Transform &&transform = Transform()) const {
     using namespace EospacWrapper;
     EOS_REAL *R = const_cast<EOS_REAL *>(&rhos[0]);
     EOS_REAL *E = const_cast<EOS_REAL *>(&sies[0]);
@@ -342,11 +392,23 @@ class EOSPAC : public EosBase<EOSPAC> {
     eosSafeInterpolate(&table, num, R, E, T, dTdr, dTde, "TofRE", Verbosity::Quiet,
                        options, values, nopts);
   }
+  template <typename Space, typename LambdaIndexer>
+  inline void
+  TemperatureFromDensityInternalEnergy(const Real *rhos, const Real *sies,
+                                       Real *temperatures, Real *scratch, const int num,
+                                       [[maybe_unused]] LambdaIndexer &&lambdas,
+                                       Transform &&transform = Transform()) const {
+    TemperatureFromDensityInternalEnergy(
+        PortsOfCall::Exec::Host(), rhos, sies, temperatures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
 
-  template <typename LambdaIndexer>
-  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                             Real *pressures, Real *scratch,
-                                             const int num, LambdaIndexer /*lambdas*/,
+  template <typename Space, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void PressureFromDensityTemperature(const Space &space, const Real *rhos,
+                                             const Real *temperatures, Real *pressures,
+                                             Real *scratch, const int num,
+                                             LambdaIndexer /*lambdas*/,
                                              Transform &&transform = Transform()) const {
     using namespace EospacWrapper;
     EOS_REAL *R = const_cast<EOS_REAL *>(&rhos[0]);
@@ -369,6 +431,15 @@ class EOSPAC : public EosBase<EOSPAC> {
 
     eosSafeInterpolate(&table, num, R, T, P, dPdr, dPdT, "PofRT", Verbosity::Quiet,
                        options, values, nopts);
+  }
+  template <typename LambdaIndexer>
+  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                             Real *pressures, Real *scratch,
+                                             const int num, LambdaIndexer &&lambdas,
+                                             Transform &&transform = Transform()) const {
+    PressureFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, pressures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -164,19 +164,29 @@ inline void SetUpOutputScalingOption(EOS_INTEGER options[], EOS_REAL values[],
         s, std::forward<ConstRealIndexer>(IN1), std::forward<ConstRealIndexer>(IN2),     \
         std::forward<RealIndexer>(OUT), num, std::forward<LambdaIndexer>(lambdas));      \
   }                                                                                      \
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>     \
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
+            typename =                                                                   \
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    const int num, LambdaIndexer &&lambdas) const {                       \
-    NAME(PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(IN1),                 \
-         std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT), num,       \
-         std::forward<LambdaIndexer>(lambdas));                                          \
+    PORTABLE_WARN("Not providing scratch memory will trigger scalar EOSPAC lookups");    \
+    EosBase<EOSPAC>::NAME(                                                               \
+        PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(IN1),                  \
+        std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT), num,        \
+        std::forward<LambdaIndexer>(lambdas));                                           \
   }                                                                                      \
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>     \
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
+            typename =                                                                   \
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>,     \
+            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>      \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    Real *scratch, const int num, LambdaIndexer &&lambdas) const {        \
-    NAME(PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(IN1),                 \
-         std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT), scratch,   \
-         num, std::forward<LambdaIndexer>(lambdas));                                     \
+    PORTABLE_WARN(                                                                       \
+        "EOSPAC type mismatch will cause significant performance degradation");          \
+    EosBase<EOSPAC>::NAME(                                                               \
+        PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(IN1),                  \
+        std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT), scratch,    \
+        num, std::forward<LambdaIndexer>(lambdas));                                      \
   }
 // Does fromdensitytemperature and fromdensityinternalenergy at once
 #define SG_EOSPAC_VEC_FOR(OUTNAME)                                                       \
@@ -332,15 +342,19 @@ class EOSPAC : public EosBase<EOSPAC> {
     PORTABLE_WARN("EOSPAC type mismatch will cause significant performance degradation");
     EosBase<EOSPAC>::MinInternalEnergyFromDensity(s, rhos, sies, num, lambdas);
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
+  template <
+      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
     MinInternalEnergyFromDensity(
         PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(rhos),
         std::forward<RealIndexer>(sies), num, std::forward<LambdaIndexer>(lambdas));
   }
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-            typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>>
+  template <
+      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+      typename = std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real * /*scratch*/, const int num,
                                            LambdaIndexer &&lambdas) const {
@@ -629,10 +643,11 @@ class EOSPAC : public EosBase<EOSPAC> {
                        options, values, nopts);
   }
   template <typename LambdaIndexer>
-  inline void InternalEnergyFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
-      const int num, [[maybe_unused]] LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
+  inline void
+  InternalEnergyFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                       Real *sies, Real *scratch, const int num,
+                                       [[maybe_unused]] LambdaIndexer &&lambdas,
+                                       Transform &&transform = Transform()) const {
     InternalEnergyFromDensityTemperature(
         PortsOfCall::Exec::Host(), rhos, temperatures, sies, scratch, num,
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
@@ -668,13 +683,14 @@ class EOSPAC : public EosBase<EOSPAC> {
                        options, values, nopts);
   }
   template <typename LambdaIndexer>
-  inline void PressureFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *pressures, Real *scratch,
-      const int num, [[maybe_unused]] LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
-    PressureFromDensityInternalEnergy(
-        PortsOfCall::Exec::Host(), rhos, sies, pressures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  inline void
+  PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
+                                    Real *scratch, const int num,
+                                    [[maybe_unused]] LambdaIndexer &&lambdas,
+                                    Transform &&transform = Transform()) const {
+    PressureFromDensityInternalEnergy(PortsOfCall::Exec::Host(), rhos, sies, pressures,
+                                      scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
   }
 
   template <typename Space, typename LambdaIndexer,
@@ -751,13 +767,14 @@ class EOSPAC : public EosBase<EOSPAC> {
         });
   }
   template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch,
-      const int num, [[maybe_unused]] LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityTemperature(
-        PortsOfCall::Exec::Host(), rhos, temperatures, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  inline void
+  SpecificHeatFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                     Real *cvs, Real *scratch, const int num,
+                                     [[maybe_unused]] LambdaIndexer &&lambdas,
+                                     Transform &&transform = Transform()) const {
+    SpecificHeatFromDensityTemperature(PortsOfCall::Exec::Host(), rhos, temperatures, cvs,
+                                       scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                       std::forward<Transform>(transform));
   }
 
   template <typename Space, typename LambdaIndexer,
@@ -824,10 +841,11 @@ class EOSPAC : public EosBase<EOSPAC> {
         });
   }
   template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
-      [[maybe_unused]] LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
+  inline void
+  SpecificHeatFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *cvs,
+                                        Real *scratch, const int num,
+                                        [[maybe_unused]] LambdaIndexer &&lambdas,
+                                        Transform &&transform = Transform()) const {
     SpecificHeatFromDensityInternalEnergy(
         PortsOfCall::Exec::Host(), rhos, sies, cvs, scratch, num,
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
@@ -904,10 +922,11 @@ class EOSPAC : public EosBase<EOSPAC> {
         });
   }
   template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
-      const int num, [[maybe_unused]] LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
+  inline void
+  BulkModulusFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                    Real *bmods, Real *scratch, const int num,
+                                    [[maybe_unused]] LambdaIndexer &&lambdas,
+                                    Transform &&transform = Transform()) const {
     BulkModulusFromDensityTemperature(
         PortsOfCall::Exec::Host(), rhos, temperatures, bmods, scratch, num,
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
@@ -1001,10 +1020,11 @@ class EOSPAC : public EosBase<EOSPAC> {
         });
   }
   template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
-      [[maybe_unused]] LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
+  inline void
+  BulkModulusFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *bmods,
+                                       Real *scratch, const int num,
+                                       [[maybe_unused]] LambdaIndexer &&lambdas,
+                                       Transform &&transform = Transform()) const {
     BulkModulusFromDensityInternalEnergy(
         PortsOfCall::Exec::Host(), rhos, sies, bmods, scratch, num,
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
@@ -1056,10 +1076,11 @@ class EOSPAC : public EosBase<EOSPAC> {
         });
   }
   template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
-      const int num, [[maybe_unused]] LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
+  inline void
+  GruneisenParamFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                       Real *gm1s, Real *scratch, const int num,
+                                       [[maybe_unused]] LambdaIndexer &&lambdas,
+                                       Transform &&transform = Transform()) const {
     GruneisenParamFromDensityTemperature(
         PortsOfCall::Exec::Host(), rhos, temperatures, gm1s, scratch, num,
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
@@ -1130,10 +1151,11 @@ class EOSPAC : public EosBase<EOSPAC> {
         });
   }
   template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
-      [[maybe_unused]] LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
+  inline void
+  GruneisenParamFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *gm1s,
+                                          Real *scratch, const int num,
+                                          [[maybe_unused]] LambdaIndexer &&lambdas,
+                                          Transform &&transform = Transform()) const {
     GruneisenParamFromDensityInternalEnergy(
         PortsOfCall::Exec::Host(), rhos, sies, gm1s, scratch, num,
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -326,22 +326,22 @@ class EOSPAC : public EosBase<EOSPAC> {
   SG_EOSPAC_VEC_2IN_1OUT(InternalEnergyFromDensityTemperature, rhos, temperatures, sies)
   SG_EOSPAC_VEC_FOR(Pressure)
 
-  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
-            typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename RealIndexer, typename ConstRealIndexer,
+      typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &s,
                                            ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
     PORTABLE_WARN("Not providing scratch memory will trigger scalar EOSPAC lookups");
     EosBase<EOSPAC>::MinInternalEnergyFromDensity(s, rhos, sies, num, lambdas);
   }
-  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
-            typename LambdaIndexer,
-            typename EnableIfNotRaw =
-                std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename RealIndexer, typename ConstRealIndexer,
+      typename LambdaIndexer,
+      typename EnableIfNotRaw =
+          std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &s,
                                            ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real * /*scratch*/, const int num,
@@ -349,22 +349,20 @@ class EOSPAC : public EosBase<EOSPAC> {
     PORTABLE_WARN("EOSPAC type mismatch will cause significant performance degradation");
     EosBase<EOSPAC>::MinInternalEnergyFromDensity(s, rhos, sies, num, lambdas);
   }
-  template <
-      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename EnableIfIndexed =
-          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename EnableIfIndexed =
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
     MinInternalEnergyFromDensity(
         PortsOfCall::Exec::Host(), std::forward<ConstRealIndexer>(rhos),
         std::forward<RealIndexer>(sies), num, std::forward<LambdaIndexer>(lambdas));
   }
-  template <
-      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename EnableIfNotRaw =
-          std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
-      typename EnableIfIndexed =
-          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename EnableIfNotRaw =
+                std::enable_if_t<!is_raw_pointer<RealIndexer, Real>::value>,
+            typename EnableIfIndexed =
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real * /*scratch*/, const int num,
                                            LambdaIndexer &&lambdas) const {
@@ -386,9 +384,9 @@ class EOSPAC : public EosBase<EOSPAC> {
   SG_ADD_DEFAULT_MEAN_ATOMIC_FUNCTIONS(AZbar_)
 
   // EOSPAC vector implementations
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void TemperatureFromDensityInternalEnergy(
       [[maybe_unused]] const Space &s, const Real *rhos, const Real *sies,
       Real *temperatures, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -425,9 +423,9 @@ class EOSPAC : public EosBase<EOSPAC> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void PressureFromDensityTemperature(const Space &space, const Real *rhos,
                                              const Real *temperatures, Real *pressures,
                                              Real *scratch, const int num,
@@ -466,9 +464,9 @@ class EOSPAC : public EosBase<EOSPAC> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void EntropyFromDensityTemperature([[maybe_unused]] const Space &space,
                                             const Real *rhos, const Real *temperatures,
                                             Real *entropies, Real *scratch, const int num,
@@ -506,9 +504,9 @@ class EOSPAC : public EosBase<EOSPAC> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void FillEos([[maybe_unused]] const Space &space, Real *rhos, Real *temps,
                       Real *energies, Real *presses, Real *cvs, Real *bmods,
                       Real *scratch, const int num, const unsigned long output,
@@ -625,9 +623,9 @@ class EOSPAC : public EosBase<EOSPAC> {
             scratch, num, output, std::forward<LambdaIndexer>(lambdas));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void InternalEnergyFromDensityTemperature(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *temperatures,
       Real *sies, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -668,9 +666,9 @@ class EOSPAC : public EosBase<EOSPAC> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void
   PressureFromDensityInternalEnergy([[maybe_unused]] const Space &space, const Real *rhos,
                                     const Real *sies, Real *pressures, Real *scratch,
@@ -709,9 +707,9 @@ class EOSPAC : public EosBase<EOSPAC> {
                                       std::forward<Transform>(transform));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity([[maybe_unused]] const Space &space,
                                            const Real *rhos, Real *sies, Real *scratch,
                                            const int num, LambdaIndexer /*lambdas*/,
@@ -745,9 +743,9 @@ class EOSPAC : public EosBase<EOSPAC> {
                                  std::forward<Transform>(transform));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void SpecificHeatFromDensityTemperature(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *temperatures,
       Real *cvs, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -795,9 +793,9 @@ class EOSPAC : public EosBase<EOSPAC> {
                                        std::forward<Transform>(transform));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void SpecificHeatFromDensityInternalEnergy(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies, Real *cvs,
       Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -870,9 +868,9 @@ class EOSPAC : public EosBase<EOSPAC> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void
   BulkModulusFromDensityTemperature([[maybe_unused]] const Space &space, const Real *rhos,
                                     const Real *temperatures, Real *bmods, Real *scratch,
@@ -952,9 +950,9 @@ class EOSPAC : public EosBase<EOSPAC> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void BulkModulusFromDensityInternalEnergy(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies,
       Real *bmods, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -1051,9 +1049,9 @@ class EOSPAC : public EosBase<EOSPAC> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void GruneisenParamFromDensityTemperature(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *temperatures,
       Real *gm1s, Real *scratch, const int num, LambdaIndexer /*lambdas*/,
@@ -1108,9 +1106,9 @@ class EOSPAC : public EosBase<EOSPAC> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename Space, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void GruneisenParamFromDensityInternalEnergy(
       [[maybe_unused]] const Space &space, const Real *rhos, const Real *sies, Real *gm1s,
       Real *scratch, const int num, LambdaIndexer /*lambdas*/,

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -139,12 +139,6 @@ inline void SetUpOutputScalingOption(EOS_INTEGER options[], EOS_REAL values[],
 // TODO(JMM): Execution spaces are not properly passed through EOSPAC
 // and I'm not sure how to make that work. For now, we just have a
 // disclaimer in the docs. Execution space is ignored.
-//
-// TODO(JMM): The first two overloads are the warnings for not using
-// the Real* or scratch specializations. They take an execution
-// space. The second two declarations are general and trigger for the
-// relevant functions below to reduce the number of overloads.
-//
 #define SG_EOSPAC_VEC_2IN_1OUT(NAME, IN1, IN2, OUT)                                      \
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
             typename LambdaIndexer,                                                      \
@@ -406,7 +400,6 @@ class EOSPAC : public EosBase<EOSPAC> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void PressureFromDensityTemperature(const Space &space, const Real *rhos,
@@ -436,8 +429,17 @@ class EOSPAC : public EosBase<EOSPAC> {
     eosSafeInterpolate(&table, num, R, T, P, dPdr, dPdT, "PofRT", Verbosity::Quiet,
                        options, values, nopts);
   }
+  template <typename LambdaIndexer>
+  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                             Real *pressures, Real *scratch,
+                                             const int num,
+                                             [[maybe_unused]] LambdaIndexer &&lambdas,
+                                             Transform &&transform = Transform()) const {
+    PressureFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, pressures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
 
-  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void EntropyFromDensityTemperature([[maybe_unused]] const Space &space,
@@ -466,6 +468,15 @@ class EOSPAC : public EosBase<EOSPAC> {
 
     eosSafeInterpolate(&table, num, R, T, S, dSdr, dSdT, "SofRT", Verbosity::Quiet,
                        options, values, nopts);
+  }
+  template <typename LambdaIndexer>
+  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                            Real *entropies, Real *scratch, const int num,
+                                            [[maybe_unused]] LambdaIndexer &&lambdas,
+                                            Transform &&transform = Transform()) const {
+    EntropyFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, entropies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <typename Space, typename LambdaIndexer,
@@ -586,7 +597,6 @@ class EOSPAC : public EosBase<EOSPAC> {
             scratch, num, output, std::forward<LambdaIndexer>(lambdas));
   }
 
-  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void InternalEnergyFromDensityTemperature(
@@ -618,8 +628,16 @@ class EOSPAC : public EosBase<EOSPAC> {
     eosSafeInterpolate(&table, num, R, T, E, DEDR, DEDT, "EofRT", Verbosity::Quiet,
                        options, values, nopts);
   }
+  template <typename LambdaIndexer>
+  inline void InternalEnergyFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
+      const int num, [[maybe_unused]] LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    InternalEnergyFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, sies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
 
-  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void
@@ -648,6 +666,15 @@ class EOSPAC : public EosBase<EOSPAC> {
 
     eosSafeInterpolate(&table, num, R, E, P, dPdr, dPde, "PofRE", Verbosity::Quiet,
                        options, values, nopts);
+  }
+  template <typename LambdaIndexer>
+  inline void PressureFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *pressures, Real *scratch,
+      const int num, [[maybe_unused]] LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    PressureFromDensityInternalEnergy(
+        PortsOfCall::Exec::Host(), rhos, sies, pressures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <typename Space, typename LambdaIndexer,
@@ -685,7 +712,6 @@ class EOSPAC : public EosBase<EOSPAC> {
                                  std::forward<Transform>(transform));
   }
 
-  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void SpecificHeatFromDensityTemperature(
@@ -724,8 +750,16 @@ class EOSPAC : public EosBase<EOSPAC> {
               cvFromSesame(std::max(DEDT[i], 0.0)); // Here we do something to the data!
         });
   }
+  template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch,
+      const int num, [[maybe_unused]] LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    SpecificHeatFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
 
-  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void SpecificHeatFromDensityInternalEnergy(
@@ -789,8 +823,16 @@ class EOSPAC : public EosBase<EOSPAC> {
                            std::max(DEDT[i], 0.0)); // Here we do something to the data!
         });
   }
+  template <typename LambdaIndexer>
+  inline void SpecificHeatFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
+      [[maybe_unused]] LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    SpecificHeatFromDensityInternalEnergy(
+        PortsOfCall::Exec::Host(), rhos, sies, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
 
-  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void
@@ -861,8 +903,16 @@ class EOSPAC : public EosBase<EOSPAC> {
           bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
         });
   }
+  template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
+      const int num, [[maybe_unused]] LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    BulkModulusFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
 
-  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void BulkModulusFromDensityInternalEnergy(
@@ -950,8 +1000,16 @@ class EOSPAC : public EosBase<EOSPAC> {
           bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
         });
   }
+  template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
+      [[maybe_unused]] LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    BulkModulusFromDensityInternalEnergy(
+        PortsOfCall::Exec::Host(), rhos, sies, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
 
-  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void GruneisenParamFromDensityTemperature(
@@ -997,8 +1055,16 @@ class EOSPAC : public EosBase<EOSPAC> {
           gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
         });
   }
+  template <typename LambdaIndexer>
+  inline void GruneisenParamFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
+      const int num, [[maybe_unused]] LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    GruneisenParamFromDensityTemperature(
+        PortsOfCall::Exec::Host(), rhos, temperatures, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
 
-  // no-space overload handled by macros
   template <typename Space, typename LambdaIndexer,
             typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void GruneisenParamFromDensityInternalEnergy(
@@ -1062,6 +1128,15 @@ class EOSPAC : public EosBase<EOSPAC> {
           const Real DPDE = DPDT[i] / DEDT[i];
           gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
         });
+  }
+  template <typename LambdaIndexer>
+  inline void GruneisenParamFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
+      [[maybe_unused]] LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    GruneisenParamFromDensityInternalEnergy(
+        PortsOfCall::Exec::Host(), rhos, sies, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   static inline unsigned long scratch_size(std::string method, unsigned int nelements) {

--- a/singularity-eos/eos/eos_gruneisen.hpp
+++ b/singularity-eos/eos/eos_gruneisen.hpp
@@ -292,7 +292,7 @@ PORTABLE_INLINE_FUNCTION Real Gruneisen::ComputeRhoMax(const Real s1, const Real
           maxbound = std::min(min_extremum, maxbound);
         }
       } // s3 > 0 ; else
-    }   // discriminant >= 0
+    } // discriminant >= 0
     if (poly(minbound) * poly(maxbound) < 0.) {
       // Root is appropriately bounded
       using RootFinding1D::regula_falsi;

--- a/singularity-eos/eos/eos_gruneisen.hpp
+++ b/singularity-eos/eos/eos_gruneisen.hpp
@@ -292,7 +292,7 @@ PORTABLE_INLINE_FUNCTION Real Gruneisen::ComputeRhoMax(const Real s1, const Real
           maxbound = std::min(min_extremum, maxbound);
         }
       } // s3 > 0 ; else
-    } // discriminant >= 0
+    }   // discriminant >= 0
     if (poly(minbound) * poly(maxbound) < 0.) {
       // Root is appropriately bounded
       using RootFinding1D::regula_falsi;

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -55,7 +55,8 @@ struct NullIndexer {
 // wrappers below.
 #define SG_VARIANT_VEC_2IN_1OUT(NAME, IN1, IN2, OUT)                                     \
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
   inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
                    RealIndexer &&OUT, const int num) const {                             \
     NullIndexer lambdas{};                                                               \
@@ -65,7 +66,8 @@ struct NullIndexer {
   }                                                                                      \
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
             typename LambdaIndexer,                                                      \
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
   inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
                    RealIndexer &&OUT, const int num, LambdaIndexer &&lambdas) const {    \
     return PortsOfCall::visit(                                                           \
@@ -78,7 +80,8 @@ struct NullIndexer {
         eos_);                                                                           \
   }                                                                                      \
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
   inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
                    RealIndexer &&OUT, Real *scratch, const int num) const {              \
     NullIndexer lambdas{};                                                               \
@@ -88,7 +91,8 @@ struct NullIndexer {
   }                                                                                      \
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
             typename LambdaIndexer,                                                      \
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
   inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
                    RealIndexer &&OUT, Real *scratch, const int num,                      \
                    LambdaIndexer &&lambdas) const {                                      \
@@ -102,7 +106,7 @@ struct NullIndexer {
         eos_);                                                                           \
   }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer,                             \
-            typename =                                                                   \
+            typename EnableIfIndexed =                                                   \
                 std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    const int num) const {                                                \
@@ -111,7 +115,7 @@ struct NullIndexer {
                 num);                                                                    \
   }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
-            typename =                                                                   \
+            typename EnableIfIndexed =                                                   \
                 std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    const int num, LambdaIndexer &&lambdas) const {                       \
@@ -120,7 +124,7 @@ struct NullIndexer {
                 num, std::forward<LambdaIndexer>(lambdas));                              \
   }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer,                             \
-            typename =                                                                   \
+            typename EnableIfIndexed =                                                   \
                 std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    Real *scratch, const int num) const {                                 \
@@ -129,7 +133,7 @@ struct NullIndexer {
                 scratch, num);                                                           \
   }                                                                                      \
   template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
-            typename =                                                                   \
+            typename EnableIfIndexed =                                                   \
                 std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
   inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
                    Real *scratch, const int num, LambdaIndexer &&lambdas) const {        \
@@ -543,7 +547,8 @@ class Variant {
   /// This is sort of what the SG_VARIANT_VEC would concretize too, though
   /// it has fewer arguments.
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
@@ -553,7 +558,8 @@ class Variant {
 
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,
             typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, const int num,
                                            LambdaIndexer &&lambdas) const {
@@ -567,7 +573,8 @@ class Variant {
   }
 
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, Real *scratch,
                                            const int num) const {
@@ -579,7 +586,8 @@ class Variant {
 
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,
             typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, Real *scratch,
                                            const int num, LambdaIndexer &&lambdas) const {
@@ -593,7 +601,8 @@ class Variant {
   }
   template <
       typename RealIndexer, typename ConstRealIndexer,
-      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+      typename EnableIfIndexed =
+          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num) const {
     return MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(),
@@ -603,7 +612,8 @@ class Variant {
 
   template <
       typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+      typename EnableIfIndexed =
+          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
     return MinInternalEnergyFromDensity(
@@ -613,7 +623,8 @@ class Variant {
 
   template <
       typename RealIndexer, typename ConstRealIndexer,
-      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+      typename EnableIfIndexed =
+          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real *scratch, const int num) const {
     return MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(),
@@ -623,7 +634,8 @@ class Variant {
 
   template <
       typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+      typename EnableIfIndexed =
+          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real *scratch, const int num,
                                            LambdaIndexer &&lambdas) const {
@@ -642,7 +654,8 @@ class Variant {
   SG_VARIANT_VEC_2IN_1OUT(InternalEnergyFromDensityPressure, rhos, Ps, sies)
 
   template <typename Space, typename RealIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void FillEos(const Space &s, RealIndexer &&rhos, RealIndexer &&temps,
                       RealIndexer &&energies, RealIndexer &&presses, RealIndexer &&cvs,
                       RealIndexer &&bmods, const int num,
@@ -655,7 +668,8 @@ class Variant {
   }
 
   template <typename Space, typename RealIndexer, typename LambdaIndexer,
-            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+            typename EnableIfSpace =
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void FillEos(const Space &s, RealIndexer &&rhos, RealIndexer &&temps,
                       RealIndexer &&energies, RealIndexer &&presses, RealIndexer &&cvs,
                       RealIndexer &&bmods, const int num, const unsigned long output,
@@ -673,7 +687,8 @@ class Variant {
   }
 
   template <typename RealIndexer,
-            typename = std::enable_if_t<variadic_utils::has_int_index_v<RealIndexer>>>
+            typename EnableIfIndexed =
+                std::enable_if_t<variadic_utils::has_int_index_v<RealIndexer>>>
   inline void FillEos(RealIndexer &&rhos, RealIndexer &&temps, RealIndexer &&energies,
                       RealIndexer &&presses, RealIndexer &&cvs, RealIndexer &&bmods,
                       const int num, const unsigned long output) const {
@@ -684,7 +699,8 @@ class Variant {
   }
 
   template <typename RealIndexer, typename LambdaIndexer,
-            typename = std::enable_if_t<variadic_utils::has_int_index_v<RealIndexer>>>
+            typename EnableIfIndexed =
+                std::enable_if_t<variadic_utils::has_int_index_v<RealIndexer>>>
   inline void FillEos(RealIndexer &&rhos, RealIndexer &&temps, RealIndexer &&energies,
                       RealIndexer &&presses, RealIndexer &&cvs, RealIndexer &&bmods,
                       const int num, const unsigned long output,

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -546,9 +546,9 @@ class Variant {
 
   /// This is sort of what the SG_VARIANT_VEC would concretize too, though
   /// it has fewer arguments.
-  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename RealIndexer, typename ConstRealIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
@@ -556,10 +556,10 @@ class Variant {
                                         std::forward<RealIndexer>(sies), num, lambdas);
   }
 
-  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
-            typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename RealIndexer, typename ConstRealIndexer,
+      typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, const int num,
                                            LambdaIndexer &&lambdas) const {
@@ -572,9 +572,9 @@ class Variant {
         eos_);
   }
 
-  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename RealIndexer, typename ConstRealIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, Real *scratch,
                                            const int num) const {
@@ -584,10 +584,10 @@ class Variant {
                                         lambdas);
   }
 
-  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
-            typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename RealIndexer, typename ConstRealIndexer,
+      typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
                                            RealIndexer &&sies, Real *scratch,
                                            const int num, LambdaIndexer &&lambdas) const {
@@ -599,10 +599,9 @@ class Variant {
         },
         eos_);
   }
-  template <
-      typename RealIndexer, typename ConstRealIndexer,
-      typename EnableIfIndexed =
-          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  template <typename RealIndexer, typename ConstRealIndexer,
+            typename EnableIfIndexed =
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num) const {
     return MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(),
@@ -610,10 +609,9 @@ class Variant {
                                         std::forward<RealIndexer>(sies), num);
   }
 
-  template <
-      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename EnableIfIndexed =
-          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename EnableIfIndexed =
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            const int num, LambdaIndexer &&lambdas) const {
     return MinInternalEnergyFromDensity(
@@ -621,10 +619,9 @@ class Variant {
         std::forward<RealIndexer>(sies), num, std::forward<LambdaIndexer>(lambdas));
   }
 
-  template <
-      typename RealIndexer, typename ConstRealIndexer,
-      typename EnableIfIndexed =
-          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  template <typename RealIndexer, typename ConstRealIndexer,
+            typename EnableIfIndexed =
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real *scratch, const int num) const {
     return MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(),
@@ -632,10 +629,9 @@ class Variant {
                                         std::forward<RealIndexer>(sies), scratch, num);
   }
 
-  template <
-      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
-      typename EnableIfIndexed =
-          std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+            typename EnableIfIndexed =
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
   inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
                                            Real *scratch, const int num,
                                            LambdaIndexer &&lambdas) const {
@@ -653,9 +649,9 @@ class Variant {
   SG_VARIANT_VEC_FOR(GruneisenParam)
   SG_VARIANT_VEC_2IN_1OUT(InternalEnergyFromDensityPressure, rhos, Ps, sies)
 
-  template <typename Space, typename RealIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename RealIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void FillEos(const Space &s, RealIndexer &&rhos, RealIndexer &&temps,
                       RealIndexer &&energies, RealIndexer &&presses, RealIndexer &&cvs,
                       RealIndexer &&bmods, const int num,
@@ -667,9 +663,9 @@ class Variant {
                    std::forward<RealIndexer>(bmods), num, output, lambdas);
   }
 
-  template <typename Space, typename RealIndexer, typename LambdaIndexer,
-            typename EnableIfSpace =
-                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  template <
+      typename Space, typename RealIndexer, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
   inline void FillEos(const Space &s, RealIndexer &&rhos, RealIndexer &&temps,
                       RealIndexer &&energies, RealIndexer &&presses, RealIndexer &&cvs,
                       RealIndexer &&bmods, const int num, const unsigned long output,
@@ -686,9 +682,8 @@ class Variant {
         eos_);
   }
 
-  template <typename RealIndexer,
-            typename EnableIfIndexed =
-                std::enable_if_t<variadic_utils::has_int_index_v<RealIndexer>>>
+  template <typename RealIndexer, typename EnableIfIndexed = std::enable_if_t<
+                                      variadic_utils::has_int_index_v<RealIndexer>>>
   inline void FillEos(RealIndexer &&rhos, RealIndexer &&temps, RealIndexer &&energies,
                       RealIndexer &&presses, RealIndexer &&cvs, RealIndexer &&bmods,
                       const int num, const unsigned long output) const {

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -54,45 +54,88 @@ struct NullIndexer {
 // Helper macros to reduce boilerplate in the Variant vector forwarding
 // wrappers below.
 #define SG_VARIANT_VEC_2IN_1OUT(NAME, IN1, IN2, OUT)                                     \
-  template <typename RealIndexer, typename ConstRealIndexer>                             \
-  inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
-                   const int num) const {                                                \
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+  inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
+                   RealIndexer &&OUT, const int num) const {                             \
     NullIndexer lambdas{};                                                               \
-    return NAME(std::forward<ConstRealIndexer>(IN1),                                     \
+    return NAME(s, std::forward<ConstRealIndexer>(IN1),                                  \
                 std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT),     \
                 num, lambdas);                                                           \
   }                                                                                      \
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>     \
-  inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
-                   const int num, LambdaIndexer &&lambdas) const {                       \
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
+            typename LambdaIndexer,                                                      \
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+  inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
+                   RealIndexer &&OUT, const int num, LambdaIndexer &&lambdas) const {    \
     return PortsOfCall::visit(                                                           \
-        [&IN1, &IN2, &OUT, &num, &lambdas](const auto &eos) {                            \
-          return eos.NAME(std::forward<ConstRealIndexer>(IN1),                           \
+        [&s, &IN1, &IN2, &OUT, &num, &lambdas](const auto &eos) {                        \
+          return eos.NAME(s, std::forward<ConstRealIndexer>(IN1),                        \
                           std::forward<ConstRealIndexer>(IN2),                           \
                           std::forward<RealIndexer>(OUT), num,                           \
                           std::forward<LambdaIndexer>(lambdas));                         \
         },                                                                               \
         eos_);                                                                           \
   }                                                                                      \
-  template <typename RealIndexer, typename ConstRealIndexer>                             \
-  inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
-                   Real *scratch, const int num) const {                                 \
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+  inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
+                   RealIndexer &&OUT, Real *scratch, const int num) const {              \
     NullIndexer lambdas{};                                                               \
-    return NAME(std::forward<ConstRealIndexer>(IN1),                                     \
+    return NAME(s, std::forward<ConstRealIndexer>(IN1),                                  \
                 std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT),     \
                 scratch, num, lambdas);                                                  \
   }                                                                                      \
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>     \
-  inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
-                   Real *scratch, const int num, LambdaIndexer &&lambdas) const {        \
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
+            typename LambdaIndexer,                                                      \
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>        \
+  inline void NAME(const Space &s, ConstRealIndexer &&IN1, ConstRealIndexer &&IN2,       \
+                   RealIndexer &&OUT, Real *scratch, const int num,                      \
+                   LambdaIndexer &&lambdas) const {                                      \
     return PortsOfCall::visit(                                                           \
-        [&IN1, &IN2, &OUT, &scratch, &num, &lambdas](const auto &eos) {                  \
-          return eos.NAME(std::forward<ConstRealIndexer>(IN1),                           \
+        [&s, &IN1, &IN2, &OUT, &scratch, &num, &lambdas](const auto &eos) {              \
+          return eos.NAME(s, std::forward<ConstRealIndexer>(IN1),                        \
                           std::forward<ConstRealIndexer>(IN2),                           \
                           std::forward<RealIndexer>(OUT), scratch, num,                  \
                           std::forward<LambdaIndexer>(lambdas));                         \
         },                                                                               \
         eos_);                                                                           \
+  }                                                                                      \
+  template <typename RealIndexer, typename ConstRealIndexer,                             \
+            typename =                                                                   \
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
+  inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
+                   const int num) const {                                                \
+    return NAME(PortsOfCall::Exec::Device(), std::forward<ConstRealIndexer>(IN1),        \
+                std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT),     \
+                num);                                                                    \
+  }                                                                                      \
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
+            typename =                                                                   \
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
+  inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
+                   const int num, LambdaIndexer &&lambdas) const {                       \
+    return NAME(PortsOfCall::Exec::Device(), std::forward<ConstRealIndexer>(IN1),        \
+                std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT),     \
+                num, std::forward<LambdaIndexer>(lambdas));                              \
+  }                                                                                      \
+  template <typename RealIndexer, typename ConstRealIndexer,                             \
+            typename =                                                                   \
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
+  inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
+                   Real *scratch, const int num) const {                                 \
+    return NAME(PortsOfCall::Exec::Device(), std::forward<ConstRealIndexer>(IN1),        \
+                std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT),     \
+                scratch, num);                                                           \
+  }                                                                                      \
+  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,     \
+            typename =                                                                   \
+                std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>     \
+  inline void NAME(ConstRealIndexer &&IN1, ConstRealIndexer &&IN2, RealIndexer &&OUT,    \
+                   Real *scratch, const int num, LambdaIndexer &&lambdas) const {        \
+    return NAME(PortsOfCall::Exec::Device(), std::forward<ConstRealIndexer>(IN1),        \
+                std::forward<ConstRealIndexer>(IN2), std::forward<RealIndexer>(OUT),     \
+                scratch, num, std::forward<LambdaIndexer>(lambdas));                     \
   }
 
 template <typename... EOSs>
@@ -494,46 +537,95 @@ class Variant {
 
   /// This is sort of what the SG_VARIANT_VEC would concretize too, though
   /// it has fewer arguments.
-  template <typename RealIndexer, typename ConstRealIndexer>
-  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
-                                           const int num) const {
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
+                                           RealIndexer &&sies, const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return MinInternalEnergyFromDensity(std::forward<ConstRealIndexer>(rhos),
+    return MinInternalEnergyFromDensity(s, std::forward<ConstRealIndexer>(rhos),
                                         std::forward<RealIndexer>(sies), num, lambdas);
   }
 
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
-  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
-                                           const int num, LambdaIndexer &&lambdas) const {
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
+            typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
+                                           RealIndexer &&sies, const int num,
+                                           LambdaIndexer &&lambdas) const {
     return PortsOfCall::visit(
-        [&rhos, &sies, &num, &lambdas](const auto &eos) {
-          return eos.MinInternalEnergyFromDensity(std::forward<ConstRealIndexer>(rhos),
+        [&s, &rhos, &sies, &num, &lambdas](const auto &eos) {
+          return eos.MinInternalEnergyFromDensity(s, std::forward<ConstRealIndexer>(rhos),
                                                   std::forward<RealIndexer>(sies), num,
                                                   std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
   }
 
-  template <typename RealIndexer, typename ConstRealIndexer>
-  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
-                                           Real *scratch, const int num) const {
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
+                                           RealIndexer &&sies, Real *scratch,
+                                           const int num) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return MinInternalEnergyFromDensity(std::forward<ConstRealIndexer>(rhos),
+    return MinInternalEnergyFromDensity(s, std::forward<ConstRealIndexer>(rhos),
                                         std::forward<RealIndexer>(sies), scratch, num,
                                         lambdas);
   }
 
-  template <typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer>
-  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
-                                           Real *scratch, const int num,
-                                           LambdaIndexer &&lambdas) const {
+  template <typename Space, typename RealIndexer, typename ConstRealIndexer,
+            typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, ConstRealIndexer &&rhos,
+                                           RealIndexer &&sies, Real *scratch,
+                                           const int num, LambdaIndexer &&lambdas) const {
     return PortsOfCall::visit(
-        [&rhos, &sies, &scratch, &num, &lambdas](const auto &eos) {
+        [&s, &rhos, &sies, &scratch, &num, &lambdas](const auto &eos) {
           return eos.MinInternalEnergyFromDensity(
-              std::forward<ConstRealIndexer>(rhos), std::forward<RealIndexer>(sies),
+              s, std::forward<ConstRealIndexer>(rhos), std::forward<RealIndexer>(sies),
               scratch, num, std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
+  }
+  template <
+      typename RealIndexer, typename ConstRealIndexer,
+      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
+                                           const int num) const {
+    return MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(),
+                                        std::forward<ConstRealIndexer>(rhos),
+                                        std::forward<RealIndexer>(sies), num);
+  }
+
+  template <
+      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
+                                           const int num, LambdaIndexer &&lambdas) const {
+    return MinInternalEnergyFromDensity(
+        PortsOfCall::Exec::Device(), std::forward<ConstRealIndexer>(rhos),
+        std::forward<RealIndexer>(sies), num, std::forward<LambdaIndexer>(lambdas));
+  }
+
+  template <
+      typename RealIndexer, typename ConstRealIndexer,
+      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
+                                           Real *scratch, const int num) const {
+    return MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(),
+                                        std::forward<ConstRealIndexer>(rhos),
+                                        std::forward<RealIndexer>(sies), scratch, num);
+  }
+
+  template <
+      typename RealIndexer, typename ConstRealIndexer, typename LambdaIndexer,
+      typename = std::enable_if_t<variadic_utils::has_int_index_v<ConstRealIndexer>>>
+  inline void MinInternalEnergyFromDensity(ConstRealIndexer &&rhos, RealIndexer &&sies,
+                                           Real *scratch, const int num,
+                                           LambdaIndexer &&lambdas) const {
+    return MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(),
+                                        std::forward<ConstRealIndexer>(rhos),
+                                        std::forward<RealIndexer>(sies), scratch, num,
+                                        std::forward<LambdaIndexer>(lambdas));
   }
   ///
 

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -549,32 +549,59 @@ class Variant {
   SG_VARIANT_VEC_2IN_1OUT(GruneisenParamFromDensityInternalEnergy, rhos, sies, gm1s)
   SG_VARIANT_VEC_2IN_1OUT(InternalEnergyFromDensityPressure, rhos, Ps, sies)
 
-  template <typename RealIndexer>
-  inline void FillEos(RealIndexer &&rhos, RealIndexer &&temps, RealIndexer &&energies,
-                      RealIndexer &&presses, RealIndexer &&cvs, RealIndexer &&bmods,
-                      const int num, const unsigned long output) const {
+  template <typename Space, typename RealIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void FillEos(const Space &s, RealIndexer &&rhos, RealIndexer &&temps,
+                      RealIndexer &&energies, RealIndexer &&presses, RealIndexer &&cvs,
+                      RealIndexer &&bmods, const int num,
+                      const unsigned long output) const {
     NullIndexer lambdas{}; // Returns null pointer for every index
-    return FillEos(std::forward<RealIndexer>(rhos), std::forward<RealIndexer>(temps),
+    return FillEos(s, std::forward<RealIndexer>(rhos), std::forward<RealIndexer>(temps),
                    std::forward<RealIndexer>(energies),
                    std::forward<RealIndexer>(presses), std::forward<RealIndexer>(cvs),
                    std::forward<RealIndexer>(bmods), num, output, lambdas);
   }
 
-  template <typename RealIndexer, typename LambdaIndexer>
-  inline void FillEos(RealIndexer &&rhos, RealIndexer &&temps, RealIndexer &&energies,
-                      RealIndexer &&presses, RealIndexer &&cvs, RealIndexer &&bmods,
-                      const int num, const unsigned long output,
+  template <typename Space, typename RealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void FillEos(const Space &s, RealIndexer &&rhos, RealIndexer &&temps,
+                      RealIndexer &&energies, RealIndexer &&presses, RealIndexer &&cvs,
+                      RealIndexer &&bmods, const int num, const unsigned long output,
                       LambdaIndexer &&lambdas) const {
     return PortsOfCall::visit(
-        [&rhos, &temps, &energies, &presses, &cvs, &bmods, &num, &output,
+        [&s, &rhos, &temps, &energies, &presses, &cvs, &bmods, &num, &output,
          &lambdas](const auto &eos) {
           return eos.FillEos(
-              std::forward<RealIndexer>(rhos), std::forward<RealIndexer>(temps),
+              s, std::forward<RealIndexer>(rhos), std::forward<RealIndexer>(temps),
               std::forward<RealIndexer>(energies), std::forward<RealIndexer>(presses),
               std::forward<RealIndexer>(cvs), std::forward<RealIndexer>(bmods), num,
               output, std::forward<LambdaIndexer>(lambdas));
         },
         eos_);
+  }
+
+  template <typename RealIndexer,
+            typename = std::enable_if_t<variadic_utils::has_int_index_v<RealIndexer>>>
+  inline void FillEos(RealIndexer &&rhos, RealIndexer &&temps, RealIndexer &&energies,
+                      RealIndexer &&presses, RealIndexer &&cvs, RealIndexer &&bmods,
+                      const int num, const unsigned long output) const {
+    return FillEos(PortsOfCall::Exec::Device(), std::forward<RealIndexer>(rhos),
+                   std::forward<RealIndexer>(temps), std::forward<RealIndexer>(energies),
+                   std::forward<RealIndexer>(presses), std::forward<RealIndexer>(cvs),
+                   std::forward<RealIndexer>(bmods), num, output);
+  }
+
+  template <typename RealIndexer, typename LambdaIndexer,
+            typename = std::enable_if_t<variadic_utils::has_int_index_v<RealIndexer>>>
+  inline void FillEos(RealIndexer &&rhos, RealIndexer &&temps, RealIndexer &&energies,
+                      RealIndexer &&presses, RealIndexer &&cvs, RealIndexer &&bmods,
+                      const int num, const unsigned long output,
+                      LambdaIndexer &&lambdas) const {
+    return FillEos(PortsOfCall::Exec::Device(), std::forward<RealIndexer>(rhos),
+                   std::forward<RealIndexer>(temps), std::forward<RealIndexer>(energies),
+                   std::forward<RealIndexer>(presses), std::forward<RealIndexer>(cvs),
+                   std::forward<RealIndexer>(bmods), num, output,
+                   std::forward<LambdaIndexer>(lambdas));
   }
 
   // Serialization

--- a/singularity-eos/eos/modifiers/eos_unitsystem.hpp
+++ b/singularity-eos/eos/modifiers/eos_unitsystem.hpp
@@ -30,6 +30,7 @@
 #include <singularity-eos/base/constants.hpp>
 #include <singularity-eos/base/eos_error.hpp>
 #include <singularity-eos/eos/eos_base.hpp>
+#include <singularity-eos/eos/modifiers/modifier_vector_macros.hpp>
 
 namespace singularity {
 
@@ -306,318 +307,54 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
   }
 
   // vector implementations
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void
-  TemperatureFromDensityInternalEnergy(const Space &s, const Real *rhos, const Real *sies,
-                                       Real *temperatures, Real *scratch, const int num,
-                                       LambdaIndexer &&lambdas,
-                                       Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    transform.f.apply(inv_temp_unit_);
-    t_.TemperatureFromDensityInternalEnergy(s, rhos, sies, temperatures, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void TemperatureFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    TemperatureFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, temperatures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void PressureFromDensityTemperature(const Space &s, const Real *rhos,
-                                             const Real *temperatures, Real *pressures,
-                                             Real *scratch, const int num,
-                                             LambdaIndexer &&lambdas,
-                                             Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(temp_unit_);
-    transform.f.apply(inv_press_unit_);
-    t_.PressureFromDensityTemperature(s, rhos, temperatures, pressures, scratch, num,
-                                      std::forward<LambdaIndexer>(lambdas),
-                                      std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                             Real *pressures, Real *scratch,
-                                             const int num, LambdaIndexer &&lambdas,
-                                             Transform &&transform = Transform()) const {
-    PressureFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, pressures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void PressureFromDensityInternalEnergy(
-      const Space &s, const Real *rhos, const Real *sies, Real *pressures, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    transform.f.apply(inv_press_unit_);
-    t_.PressureFromDensityInternalEnergy(s, rhos, sies, pressures, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void
-  PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
-                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
-                                    Transform &&transform = Transform()) const {
-    PressureFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, pressures,
-                                      scratch, num, std::forward<LambdaIndexer>(lambdas),
-                                      std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void MinInternalEnergyFromDensity(const Space &s, const Real *rhos, Real *sies,
-                                           Real *scratch, const int num,
-                                           LambdaIndexer &&lambdas,
-                                           Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.f.apply(sie_unit_);
-    t_.MinInternalEnergyFromDensity(s, rhos, sies, scratch, num,
-                                    std::forward<LambdaIndexer>(lambdas),
-                                    std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
-                                           const int num, LambdaIndexer &&lambdas,
-                                           Transform &&transform = Transform()) const {
-    MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(), rhos, sies, scratch, num,
-                                 std::forward<LambdaIndexer>(lambdas),
-                                 std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void
-  SpecificHeatFromDensityTemperature(const Space &s, const Real *rhos,
-                                     const Real *temperatures, Real *cvs, Real *scratch,
-                                     const int num, LambdaIndexer &&lambdas,
-                                     Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(temp_unit_);
-    transform.f.apply(inv_cv_unit_);
-    t_.SpecificHeatFromDensityTemperature(s, rhos, temperatures, cvs, scratch, num,
-                                          std::forward<LambdaIndexer>(lambdas),
-                                          std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void SpecificHeatFromDensityInternalEnergy(
-      const Space &s, const Real *rhos, const Real *sies, Real *cvs, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    transform.f.apply(inv_cv_unit_);
-    t_.SpecificHeatFromDensityInternalEnergy(s, rhos, sies, cvs, scratch, num,
-                                             std::forward<LambdaIndexer>(lambdas),
-                                             std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void
-  BulkModulusFromDensityTemperature(const Space &s, const Real *rhos,
-                                    const Real *temperatures, Real *bmods, Real *scratch,
-                                    const int num, LambdaIndexer &&lambdas,
-                                    Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(temp_unit_);
-    transform.f.apply(inv_bmod_unit_);
-    t_.BulkModulusFromDensityTemperature(s, rhos, temperatures, bmods, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    BulkModulusFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void BulkModulusFromDensityInternalEnergy(
-      const Space &s, const Real *rhos, const Real *sies, Real *bmods, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    transform.f.apply(inv_bmod_unit_);
-    t_.BulkModulusFromDensityInternalEnergy(s, rhos, sies, bmods, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    BulkModulusFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void GruneisenParamFromDensityTemperature(
-      const Space &s, const Real *rhos, const Real *temperatures, Real *gm1s,
-      Real *scratch, const int num, LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(temp_unit_);
-    t_.GruneisenParamFromDensityTemperature(s, rhos, temperatures, gm1s, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void GruneisenParamFromDensityInternalEnergy(
-      const Space &s, const Real *rhos, const Real *sies, Real *gm1s, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    t_.GruneisenParamFromDensityInternalEnergy(s, rhos, sies, gm1s, scratch, num,
-                                               std::forward<LambdaIndexer>(lambdas),
-                                               std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void InternalEnergyFromDensityTemperature(
-      const Space &s, const Real *rhos, const Real *temperatures, Real *sies,
-      Real *scratch, const int num, LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(temp_unit_);
-    transform.f.apply(inv_sie_unit_);
-    t_.InternalEnergyFromDensityTemperature(s, rhos, temperatures, sies, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void InternalEnergyFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    InternalEnergyFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, sies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void EntropyFromDensityTemperature(const Space &s, const Real *rhos,
-                                            const Real *temperatures, Real *entropies,
-                                            Real *scratch, const int num,
-                                            LambdaIndexer &&lambdas,
-                                            Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(temp_unit_);
-    transform.f.apply(inv_entropy_unit_);
-    t_.EntropyFromDensityTemperature(s, rhos, temperatures, entropies, scratch, num,
-                                     std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                            Real *entropies, Real *scratch, const int num,
-                                            LambdaIndexer &&lambdas,
-                                            Transform &&transform = Transform()) const {
-    EntropyFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, entropies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void EntropyFromDensityInternalEnergy(
-      const Space &s, const Real *rhos, const Real *sies, Real *entropies, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    transform.f.apply(inv_entropy_unit_);
-    t_.EntropyFromDensityInternalEnergy(s, rhos, sies, entropies, scratch, num,
-                                        std::forward<LambdaIndexer>(lambdas),
-                                        std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void
-  EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
-                                   Real *scratch, const int num, LambdaIndexer &&lambdas,
-                                   Transform &&transform = Transform()) const {
-    EntropyFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, entropies,
-                                     scratch, num, std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
-  }
+  SG_MODIFIER_FORWARD_2IN_1OUT(TemperatureFromDensityInternalEnergy,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(sie_unit_);
+                               transform.f.apply(inv_temp_unit_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(PressureFromDensityTemperature,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(temp_unit_);
+                               transform.f.apply(inv_press_unit_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(PressureFromDensityInternalEnergy,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(sie_unit_);
+                               transform.f.apply(inv_press_unit_);)
+  SG_MODIFIER_FORWARD_1IN_1OUT(MinInternalEnergyFromDensity, transform.x.apply(rho_unit_);
+                               transform.f.apply(sie_unit_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(SpecificHeatFromDensityTemperature,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(temp_unit_);
+                               transform.f.apply(inv_cv_unit_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(SpecificHeatFromDensityInternalEnergy,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(sie_unit_);
+                               transform.f.apply(inv_cv_unit_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(BulkModulusFromDensityTemperature,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(temp_unit_);
+                               transform.f.apply(inv_bmod_unit_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(BulkModulusFromDensityInternalEnergy,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(sie_unit_);
+                               transform.f.apply(inv_bmod_unit_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(GruneisenParamFromDensityTemperature,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(temp_unit_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(GruneisenParamFromDensityInternalEnergy,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(sie_unit_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(InternalEnergyFromDensityTemperature,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(temp_unit_);
+                               transform.f.apply(inv_sie_unit_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(EntropyFromDensityTemperature,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(temp_unit_);
+                               transform.f.apply(inv_entropy_unit_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(EntropyFromDensityInternalEnergy,
+                               transform.x.apply(rho_unit_);
+                               transform.y.apply(sie_unit_);
+                               transform.f.apply(inv_entropy_unit_);)
 
   constexpr static inline int nlambda() noexcept { return T::nlambda(); }
   template <typename Indexable>

--- a/singularity-eos/eos/modifiers/eos_unitsystem.hpp
+++ b/singularity-eos/eos/modifiers/eos_unitsystem.hpp
@@ -12,6 +12,8 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
+// This file was created in part with generative AI
+
 #ifndef _SINGULARITY_EOS_EOS_EOS_UNITSYSTEM_HPP_
 #define _SINGULARITY_EOS_EOS_EOS_UNITSYSTEM_HPP_
 
@@ -304,16 +306,45 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
   }
 
   // vector implementations
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  TemperatureFromDensityInternalEnergy(const Space &s, const Real *rhos, const Real *sies,
+                                       Real *temperatures, Real *scratch, const int num,
+                                       LambdaIndexer &&lambdas,
+                                       Transform &&transform = Transform()) const {
+    transform.x.apply(rho_unit_);
+    transform.y.apply(sie_unit_);
+    transform.f.apply(inv_temp_unit_);
+    t_.TemperatureFromDensityInternalEnergy(s, rhos, sies, temperatures, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+  }
+
   template <typename LambdaIndexer>
   inline void TemperatureFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    TemperatureFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, temperatures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void PressureFromDensityTemperature(const Space &s, const Real *rhos,
+                                             const Real *temperatures, Real *pressures,
+                                             Real *scratch, const int num,
+                                             LambdaIndexer &&lambdas,
+                                             Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    transform.f.apply(inv_temp_unit_);
-    t_.TemperatureFromDensityInternalEnergy(rhos, sies, temperatures, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    transform.y.apply(temp_unit_);
+    transform.f.apply(inv_press_unit_);
+    t_.PressureFromDensityTemperature(s, rhos, temperatures, pressures, scratch, num,
+                                      std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -321,12 +352,23 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
                                              Real *pressures, Real *scratch,
                                              const int num, LambdaIndexer &&lambdas,
                                              Transform &&transform = Transform()) const {
+    PressureFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, pressures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void PressureFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *pressures, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
-    transform.y.apply(temp_unit_);
+    transform.y.apply(sie_unit_);
     transform.f.apply(inv_press_unit_);
-    t_.PressureFromDensityTemperature(rhos, temperatures, pressures, scratch, num,
-                                      std::forward<LambdaIndexer>(lambdas),
-                                      std::forward<Transform>(transform));
+    t_.PressureFromDensityInternalEnergy(s, rhos, sies, pressures, scratch, num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -334,69 +376,140 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
   PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
                                     Real *scratch, const int num, LambdaIndexer &&lambdas,
                                     Transform &&transform = Transform()) const {
+    PressureFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, pressures,
+                                      scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, const Real *rhos, Real *sies,
+                                           Real *scratch, const int num,
+                                           LambdaIndexer &&lambdas,
+                                           Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    transform.f.apply(inv_press_unit_);
-    t_.PressureFromDensityInternalEnergy(rhos, sies, pressures, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
+    transform.f.apply(sie_unit_);
+    t_.MinInternalEnergyFromDensity(s, rhos, sies, scratch, num,
+                                    std::forward<LambdaIndexer>(lambdas),
+                                    std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
                                            const int num, LambdaIndexer &&lambdas,
                                            Transform &&transform = Transform()) const {
+    MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(), rhos, sies, scratch, num,
+                                 std::forward<LambdaIndexer>(lambdas),
+                                 std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  SpecificHeatFromDensityTemperature(const Space &s, const Real *rhos,
+                                     const Real *temperatures, Real *cvs, Real *scratch,
+                                     const int num, LambdaIndexer &&lambdas,
+                                     Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
-    transform.f.apply(sie_unit_);
-    t_.MinInternalEnergyFromDensity(rhos, sies, scratch, num,
-                                    std::forward<LambdaIndexer>(lambdas),
-                                    std::forward<Transform>(transform));
+    transform.y.apply(temp_unit_);
+    transform.f.apply(inv_cv_unit_);
+    t_.SpecificHeatFromDensityTemperature(s, rhos, temperatures, cvs, scratch, num,
+                                          std::forward<LambdaIndexer>(lambdas),
+                                          std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void SpecificHeatFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    SpecificHeatFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void SpecificHeatFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *cvs, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
-    transform.y.apply(temp_unit_);
+    transform.y.apply(sie_unit_);
     transform.f.apply(inv_cv_unit_);
-    t_.SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, scratch, num,
-                                          std::forward<LambdaIndexer>(lambdas),
-                                          std::forward<Transform>(transform));
+    t_.SpecificHeatFromDensityInternalEnergy(s, rhos, sies, cvs, scratch, num,
+                                             std::forward<LambdaIndexer>(lambdas),
+                                             std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void SpecificHeatFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    SpecificHeatFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  BulkModulusFromDensityTemperature(const Space &s, const Real *rhos,
+                                    const Real *temperatures, Real *bmods, Real *scratch,
+                                    const int num, LambdaIndexer &&lambdas,
+                                    Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    transform.f.apply(inv_cv_unit_);
-    t_.SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, scratch, num,
-                                             std::forward<LambdaIndexer>(lambdas),
-                                             std::forward<Transform>(transform));
+    transform.y.apply(temp_unit_);
+    transform.f.apply(inv_bmod_unit_);
+    t_.BulkModulusFromDensityTemperature(s, rhos, temperatures, bmods, scratch, num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void BulkModulusFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    BulkModulusFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void BulkModulusFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *bmods, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
-    transform.y.apply(temp_unit_);
+    transform.y.apply(sie_unit_);
     transform.f.apply(inv_bmod_unit_);
-    t_.BulkModulusFromDensityTemperature(rhos, temperatures, bmods, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
+    t_.BulkModulusFromDensityInternalEnergy(s, rhos, sies, bmods, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void BulkModulusFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    BulkModulusFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void GruneisenParamFromDensityTemperature(
+      const Space &s, const Real *rhos, const Real *temperatures, Real *gm1s,
+      Real *scratch, const int num, LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    transform.f.apply(inv_bmod_unit_);
-    t_.BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, scratch, num,
+    transform.y.apply(temp_unit_);
+    t_.GruneisenParamFromDensityTemperature(s, rhos, temperatures, gm1s, scratch, num,
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
   }
@@ -405,34 +518,71 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
   inline void GruneisenParamFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    GruneisenParamFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void GruneisenParamFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *gm1s, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
-    transform.y.apply(temp_unit_);
-    t_.GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    transform.y.apply(sie_unit_);
+    t_.GruneisenParamFromDensityInternalEnergy(s, rhos, sies, gm1s, scratch, num,
+                                               std::forward<LambdaIndexer>(lambdas),
+                                               std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void GruneisenParamFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    GruneisenParamFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void InternalEnergyFromDensityTemperature(
+      const Space &s, const Real *rhos, const Real *temperatures, Real *sies,
+      Real *scratch, const int num, LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    t_.GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, scratch, num,
-                                               std::forward<LambdaIndexer>(lambdas),
-                                               std::forward<Transform>(transform));
+    transform.y.apply(temp_unit_);
+    transform.f.apply(inv_sie_unit_);
+    t_.InternalEnergyFromDensityTemperature(s, rhos, temperatures, sies, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void InternalEnergyFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    InternalEnergyFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, sies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void EntropyFromDensityTemperature(const Space &s, const Real *rhos,
+                                            const Real *temperatures, Real *entropies,
+                                            Real *scratch, const int num,
+                                            LambdaIndexer &&lambdas,
+                                            Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
     transform.y.apply(temp_unit_);
-    transform.f.apply(inv_sie_unit_);
-    t_.InternalEnergyFromDensityTemperature(rhos, temperatures, sies, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    transform.f.apply(inv_entropy_unit_);
+    t_.EntropyFromDensityTemperature(s, rhos, temperatures, entropies, scratch, num,
+                                     std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -440,12 +590,23 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
                                             Real *entropies, Real *scratch, const int num,
                                             LambdaIndexer &&lambdas,
                                             Transform &&transform = Transform()) const {
+    EntropyFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, entropies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void EntropyFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *entropies, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     transform.x.apply(rho_unit_);
-    transform.y.apply(temp_unit_);
+    transform.y.apply(sie_unit_);
     transform.f.apply(inv_entropy_unit_);
-    t_.EntropyFromDensityTemperature(rhos, temperatures, entropies, scratch, num,
-                                     std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
+    t_.EntropyFromDensityInternalEnergy(s, rhos, sies, entropies, scratch, num,
+                                        std::forward<LambdaIndexer>(lambdas),
+                                        std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -453,12 +614,9 @@ class UnitSystem : public EosBase<UnitSystem<T>> {
   EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
                                    Transform &&transform = Transform()) const {
-    transform.x.apply(rho_unit_);
-    transform.y.apply(sie_unit_);
-    transform.f.apply(inv_entropy_unit_);
-    t_.EntropyFromDensityInternalEnergy(rhos, sies, entropies, scratch, num,
-                                        std::forward<LambdaIndexer>(lambdas),
-                                        std::forward<Transform>(transform));
+    EntropyFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, entropies,
+                                     scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
   }
 
   constexpr static inline int nlambda() noexcept { return T::nlambda(); }

--- a/singularity-eos/eos/modifiers/floored_energy.hpp
+++ b/singularity-eos/eos/modifiers/floored_energy.hpp
@@ -12,6 +12,8 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
+// This file was created in part with generative AI
+
 #ifndef _SINGULARITY_EOS_EOS_FLOORED_ENERGY_
 #define _SINGULARITY_EOS_EOS_FLOORED_ENERGY_
 
@@ -150,29 +152,58 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
   }
 
   // vector implementations
-  inline void choose_max_sie(const Real *sies, Real *sie_use, const int num) const {
+  template <typename Space, typename EnableIfSpace =
+                                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void choose_max_sie(const Space &s, const Real *sies, Real *sie_use,
+                             const int num) const {
     // This code makes the assumption that `sie_use` is first populated with the
     // apprioriate minimum values
     static auto const name = singularity::mfuncname::member_func_name(
         typeid(FlooredEnergy<T>).name(), __func__);
     static auto const cname = name.c_str();
     portableFor(
-        cname, 0, num,
+        cname, s, 0, num,
         PORTABLE_LAMBDA(const int i) { sie_use[i] = std::max(sies[i], sie_use[i]); });
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  TemperatureFromDensityInternalEnergy(const Space &s, const Real *rhos, const Real *sies,
+                                       Real *temperatures, Real *scratch, const int num,
+                                       LambdaIndexer &&lambdas,
+                                       Transform &&transform = Transform()) const {
+    Real *sie_used = scratch;
+    // First populate sies with minimum energies
+    t_.MinInternalEnergyFromDensity(s, rhos, sie_used, num, lambdas);
+    // Chose the maximum between the input and the minimum energy
+    choose_max_sie(s, sies, sie_used, num);
+    t_.TemperatureFromDensityInternalEnergy(
+        s, rhos, sie_used, temperatures, &scratch[num], num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void TemperatureFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    Real *sie_used = scratch;
-    // First populate sies with minimum energies
-    t_.MinInternalEnergyFromDensity(rhos, sie_used, num, lambdas);
-    // Chose the maximum between the input and the minimum energy
-    choose_max_sie(sies, sie_used, num);
-    t_.TemperatureFromDensityInternalEnergy(rhos, sie_used, temperatures, &scratch[num],
-                                            num, std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    TemperatureFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, temperatures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void PressureFromDensityTemperature(const Space &s, const Real *rhos,
+                                             const Real *temperatures, Real *pressures,
+                                             Real *scratch, const int num,
+                                             LambdaIndexer &&lambdas,
+                                             Transform &&transform = Transform()) const {
+    t_.PressureFromDensityTemperature(s, rhos, temperatures, pressures, scratch, num,
+                                      std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -180,9 +211,25 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
                                              Real *pressures, Real *scratch,
                                              const int num, LambdaIndexer &&lambdas,
                                              Transform &&transform = Transform()) const {
-    t_.PressureFromDensityTemperature(rhos, temperatures, pressures, scratch, num,
-                                      std::forward<LambdaIndexer>(lambdas),
-                                      std::forward<Transform>(transform));
+    PressureFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, pressures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void PressureFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *pressures, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *sie_used = scratch;
+    // First populate sies with minimum energies
+    t_.MinInternalEnergyFromDensity(s, rhos, sie_used, num, lambdas);
+    // Chose the maximum between the input and the minimum energy
+    choose_max_sie(s, sies, sie_used, num);
+    t_.PressureFromDensityInternalEnergy(s, rhos, sie_used, pressures, &scratch[num], num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -190,67 +237,134 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
   PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
                                     Real *scratch, const int num, LambdaIndexer &&lambdas,
                                     Transform &&transform = Transform()) const {
-    Real *sie_used = scratch;
-    // First populate sies with minimum energies
-    t_.MinInternalEnergyFromDensity(rhos, sie_used, num, lambdas);
-    // Chose the maximum between the input and the minimum energy
-    choose_max_sie(sies, sie_used, num);
-    t_.PressureFromDensityInternalEnergy(rhos, sie_used, pressures, &scratch[num], num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
+    PressureFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, pressures,
+                                      scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, const Real *rhos, Real *sies,
+                                           Real *scratch, const int num,
+                                           LambdaIndexer &&lambdas,
+                                           Transform &&transform = Transform()) const {
+    t_.MinInternalEnergyFromDensity(s, rhos, sies, &scratch[num], num,
+                                    std::forward<LambdaIndexer>(lambdas),
+                                    std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
                                            const int num, LambdaIndexer &&lambdas,
                                            Transform &&transform = Transform()) const {
-    t_.MinInternalEnergyFromDensity(rhos, sies, &scratch[num], num,
-                                    std::forward<LambdaIndexer>(lambdas),
-                                    std::forward<Transform>(transform));
+    MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(), rhos, sies, scratch, num,
+                                 std::forward<LambdaIndexer>(lambdas),
+                                 std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  SpecificHeatFromDensityTemperature(const Space &s, const Real *rhos,
+                                     const Real *temperatures, Real *cvs, Real *scratch,
+                                     const int num, LambdaIndexer &&lambdas,
+                                     Transform &&transform = Transform()) const {
+    t_.SpecificHeatFromDensityTemperature(s, rhos, temperatures, cvs, scratch, num,
+                                          std::forward<LambdaIndexer>(lambdas),
+                                          std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void SpecificHeatFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, scratch, num,
-                                          std::forward<LambdaIndexer>(lambdas),
-                                          std::forward<Transform>(transform));
+    SpecificHeatFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void SpecificHeatFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *cvs, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *sie_used = scratch;
+    // First populate sies with minimum energies
+    t_.MinInternalEnergyFromDensity(s, rhos, sie_used, num, lambdas);
+    // Chose the maximum between the input and the minimum energy
+    choose_max_sie(s, sies, sie_used, num);
+    t_.SpecificHeatFromDensityInternalEnergy(s, rhos, sie_used, cvs, &scratch[num], num,
+                                             std::forward<LambdaIndexer>(lambdas),
+                                             std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void SpecificHeatFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    Real *sie_used = scratch;
-    // First populate sies with minimum energies
-    t_.MinInternalEnergyFromDensity(rhos, sie_used, num, lambdas);
-    // Chose the maximum between the input and the minimum energy
-    choose_max_sie(sies, sie_used, num);
-    t_.SpecificHeatFromDensityInternalEnergy(rhos, sie_used, cvs, &scratch[num], num,
-                                             std::forward<LambdaIndexer>(lambdas),
-                                             std::forward<Transform>(transform));
+    SpecificHeatFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  BulkModulusFromDensityTemperature(const Space &s, const Real *rhos,
+                                    const Real *temperatures, Real *bmods, Real *scratch,
+                                    const int num, LambdaIndexer &&lambdas,
+                                    Transform &&transform = Transform()) const {
+    t_.BulkModulusFromDensityTemperature(s, rhos, temperatures, bmods, scratch, num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void BulkModulusFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.BulkModulusFromDensityTemperature(rhos, temperatures, bmods, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
+    BulkModulusFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void BulkModulusFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *bmods, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *sie_used = scratch;
+    // First populate sies with minimum energies
+    t_.MinInternalEnergyFromDensity(s, rhos, sie_used, num, lambdas);
+    // Chose the maximum between the input and the minimum energy
+    choose_max_sie(s, sies, sie_used, num);
+    t_.BulkModulusFromDensityInternalEnergy(s, rhos, sie_used, bmods, &scratch[num], num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void BulkModulusFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    Real *sie_used = scratch;
-    // First populate sies with minimum energies
-    t_.MinInternalEnergyFromDensity(rhos, sie_used, num, lambdas);
-    // Chose the maximum between the input and the minimum energy
-    choose_max_sie(sies, sie_used, num);
-    t_.BulkModulusFromDensityInternalEnergy(rhos, sie_used, bmods, &scratch[num], num,
+    BulkModulusFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void GruneisenParamFromDensityTemperature(
+      const Space &s, const Real *rhos, const Real *temperatures, Real *gm1s,
+      Real *scratch, const int num, LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    t_.GruneisenParamFromDensityTemperature(s, rhos, temperatures, gm1s, scratch, num,
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
   }
@@ -259,32 +373,68 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
   inline void GruneisenParamFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    GruneisenParamFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void GruneisenParamFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *gm1s, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *sie_used = scratch;
+    // First populate sies with minimum energies
+    t_.MinInternalEnergyFromDensity(s, rhos, sie_used, num, lambdas);
+    // Chose the maximum between the input and the minimum energy
+    choose_max_sie(s, sies, sie_used, num);
+    t_.GruneisenParamFromDensityInternalEnergy(s, rhos, sie_used, gm1s, &scratch[num],
+                                               num, std::forward<LambdaIndexer>(lambdas),
+                                               std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void GruneisenParamFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    Real *sie_used = scratch;
-    // First populate sies with minimum energies
-    t_.MinInternalEnergyFromDensity(rhos, sie_used, num, lambdas);
-    // Chose the maximum between the input and the minimum energy
-    choose_max_sie(sies, sie_used, num);
-    t_.GruneisenParamFromDensityInternalEnergy(rhos, sie_used, gm1s, &scratch[num], num,
-                                               std::forward<LambdaIndexer>(lambdas),
-                                               std::forward<Transform>(transform));
+    GruneisenParamFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void InternalEnergyFromDensityTemperature(
+      const Space &s, const Real *rhos, const Real *temperatures, Real *sies,
+      Real *scratch, const int num, LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    t_.InternalEnergyFromDensityTemperature(s, rhos, temperatures, sies, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void InternalEnergyFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.InternalEnergyFromDensityTemperature(rhos, temperatures, sies, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    InternalEnergyFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, sies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void EntropyFromDensityTemperature(const Space &s, const Real *rhos,
+                                            const Real *temperatures, Real *entropies,
+                                            Real *scratch, const int num,
+                                            LambdaIndexer &&lambdas,
+                                            Transform &&transform = Transform()) const {
+    t_.EntropyFromDensityTemperature(s, rhos, temperatures, entropies, scratch, num,
+                                     std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -292,9 +442,25 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
                                             Real *entropies, Real *scratch, const int num,
                                             LambdaIndexer &&lambdas,
                                             Transform &&transform = Transform()) const {
-    t_.EntropyFromDensityTemperature(rhos, temperatures, entropies, scratch, num,
-                                     std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
+    EntropyFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, entropies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void EntropyFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *entropies, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *sie_used = scratch;
+    // First populate sies with minimum energies
+    t_.MinInternalEnergyFromDensity(s, rhos, sie_used, num, lambdas);
+    // Chose the maximum between the input and the minimum energy
+    choose_max_sie(s, sies, sie_used, num);
+    t_.EntropyFromDensityInternalEnergy(s, rhos, sie_used, entropies, &scratch[num], num,
+                                        std::forward<LambdaIndexer>(lambdas),
+                                        std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -302,14 +468,9 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
   EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
                                    Transform &&transform = Transform()) const {
-    Real *sie_used = scratch;
-    // First populate sies with minimum energies
-    t_.MinInternalEnergyFromDensity(rhos, sie_used, num, lambdas);
-    // Chose the maximum between the input and the minimum energy
-    choose_max_sie(sies, sie_used, num);
-    t_.EntropyFromDensityInternalEnergy(rhos, sies, entropies, &scratch[num], num,
-                                        std::forward<LambdaIndexer>(lambdas),
-                                        std::forward<Transform>(transform));
+    EntropyFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, entropies,
+                                     scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
   }
 
   constexpr static inline int nlambda() noexcept { return T::nlambda(); }

--- a/singularity-eos/eos/modifiers/floored_energy.hpp
+++ b/singularity-eos/eos/modifiers/floored_energy.hpp
@@ -24,6 +24,7 @@
 #include <ports-of-call/portability.hpp>
 #include <singularity-eos/base/eos_error.hpp>
 #include <singularity-eos/eos/eos_base.hpp>
+#include <singularity-eos/eos/modifiers/modifier_vector_macros.hpp>
 
 namespace singularity {
 
@@ -184,15 +185,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void TemperatureFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    TemperatureFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, temperatures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -204,16 +196,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
     t_.PressureFromDensityTemperature(s, rhos, temperatures, pressures, scratch, num,
                                       std::forward<LambdaIndexer>(lambdas),
                                       std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                             Real *pressures, Real *scratch,
-                                             const int num, LambdaIndexer &&lambdas,
-                                             Transform &&transform = Transform()) const {
-    PressureFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, pressures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -232,16 +214,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
                                          std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void
-  PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
-                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
-                                    Transform &&transform = Transform()) const {
-    PressureFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, pressures,
-                                      scratch, num, std::forward<LambdaIndexer>(lambdas),
-                                      std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -252,15 +224,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
     t_.MinInternalEnergyFromDensity(s, rhos, sies, &scratch[num], num,
                                     std::forward<LambdaIndexer>(lambdas),
                                     std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
-                                           const int num, LambdaIndexer &&lambdas,
-                                           Transform &&transform = Transform()) const {
-    MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(), rhos, sies, scratch, num,
-                                 std::forward<LambdaIndexer>(lambdas),
-                                 std::forward<Transform>(transform));
   }
 
   template <
@@ -274,15 +237,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
     t_.SpecificHeatFromDensityTemperature(s, rhos, temperatures, cvs, scratch, num,
                                           std::forward<LambdaIndexer>(lambdas),
                                           std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -301,15 +255,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
                                              std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -321,15 +266,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
     t_.BulkModulusFromDensityTemperature(s, rhos, temperatures, bmods, scratch, num,
                                          std::forward<LambdaIndexer>(lambdas),
                                          std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    BulkModulusFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -348,15 +284,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
                                             std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    BulkModulusFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -367,15 +294,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
     t_.GruneisenParamFromDensityTemperature(s, rhos, temperatures, gm1s, scratch, num,
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -394,15 +312,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
                                                std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -413,15 +322,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
     t_.InternalEnergyFromDensityTemperature(s, rhos, temperatures, sies, scratch, num,
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void InternalEnergyFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    InternalEnergyFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, sies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -435,16 +335,6 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
     t_.EntropyFromDensityTemperature(s, rhos, temperatures, entropies, scratch, num,
                                      std::forward<LambdaIndexer>(lambdas),
                                      std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                            Real *entropies, Real *scratch, const int num,
-                                            LambdaIndexer &&lambdas,
-                                            Transform &&transform = Transform()) const {
-    EntropyFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, entropies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -463,15 +353,7 @@ class FlooredEnergy : public EosBase<FlooredEnergy<T>> {
                                         std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void
-  EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
-                                   Real *scratch, const int num, LambdaIndexer &&lambdas,
-                                   Transform &&transform = Transform()) const {
-    EntropyFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, entropies,
-                                     scratch, num, std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
-  }
+  SG_MODIFIER_DEVICE_WRAP_ALL()
 
   constexpr static inline int nlambda() noexcept { return T::nlambda(); }
 

--- a/singularity-eos/eos/modifiers/modifier_vector_macros.hpp
+++ b/singularity-eos/eos/modifiers/modifier_vector_macros.hpp
@@ -21,6 +21,10 @@
 
 #include <singularity-eos/eos/eos_base.hpp>
 
+/* TODO(JMM):
+   These macros shrink the amount of boiler plate overloads necessary
+   for modifiers.
+ */
 #define SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(NAME)                                           \
   template <typename LambdaIndexer>                                                      \
   inline void NAME(const Real *in1, const Real *in2, Real *out, Real *scratch,           \

--- a/singularity-eos/eos/modifiers/modifier_vector_macros.hpp
+++ b/singularity-eos/eos/modifiers/modifier_vector_macros.hpp
@@ -1,0 +1,82 @@
+//------------------------------------------------------------------------------
+// © 2021-2026. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//------------------------------------------------------------------------------
+
+// This file was created in part with generative AI
+
+#ifndef _SINGULARITY_EOS_EOS_MODIFIERS_MODIFIER_VECTOR_MACROS_
+#define _SINGULARITY_EOS_EOS_MODIFIERS_MODIFIER_VECTOR_MACROS_
+
+#include <utility>
+
+#include <singularity-eos/eos/eos_base.hpp>
+
+#define SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(NAME)                                           \
+  template <typename LambdaIndexer>                                                      \
+  inline void NAME(const Real *in1, const Real *in2, Real *out, Real *scratch,           \
+                   const int num, LambdaIndexer &&lambdas,                               \
+                   Transform &&transform = Transform()) const {                          \
+    NAME(PortsOfCall::Exec::Device(), in1, in2, out, scratch, num,                       \
+         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));      \
+  }
+
+#define SG_MODIFIER_DEVICE_WRAP_1IN_1OUT(NAME)                                           \
+  template <typename LambdaIndexer>                                                      \
+  inline void NAME(const Real *in1, Real *out, Real *scratch, const int num,             \
+                   LambdaIndexer &&lambdas, Transform &&transform = Transform()) const { \
+    NAME(PortsOfCall::Exec::Device(), in1, out, scratch, num,                            \
+         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));      \
+  }
+
+#define SG_MODIFIER_DEVICE_WRAP_ALL()                                                    \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(TemperatureFromDensityInternalEnergy)                 \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(PressureFromDensityTemperature)                       \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(PressureFromDensityInternalEnergy)                    \
+  SG_MODIFIER_DEVICE_WRAP_1IN_1OUT(MinInternalEnergyFromDensity)                         \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(SpecificHeatFromDensityTemperature)                   \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(SpecificHeatFromDensityInternalEnergy)                \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(BulkModulusFromDensityTemperature)                    \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(BulkModulusFromDensityInternalEnergy)                 \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(GruneisenParamFromDensityTemperature)                 \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(GruneisenParamFromDensityInternalEnergy)              \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(InternalEnergyFromDensityTemperature)                 \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(EntropyFromDensityTemperature)                        \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(EntropyFromDensityInternalEnergy)
+
+#define SG_MODIFIER_FORWARD_2IN_1OUT(NAME, PREPARE)                                      \
+  template <typename Space, typename LambdaIndexer,                                      \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
+  inline void NAME(const Space &s, const Real *in1, const Real *in2, Real *out,          \
+                   Real *scratch, const int num, LambdaIndexer &&lambdas,                \
+                   Transform &&transform = Transform()) const {                          \
+    PREPARE                                                                              \
+    t_.NAME(s, in1, in2, out, scratch, num, std::forward<LambdaIndexer>(lambdas),        \
+            std::forward<Transform>(transform));                                         \
+  }                                                                                      \
+  SG_MODIFIER_DEVICE_WRAP_2IN_1OUT(NAME)
+
+#define SG_MODIFIER_FORWARD_1IN_1OUT(NAME, PREPARE)                                      \
+  template <typename Space, typename LambdaIndexer,                                      \
+            typename EnableIfSpace =                                                     \
+                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>               \
+  inline void NAME(const Space &s, const Real *in1, Real *out, Real *scratch,            \
+                   const int num, LambdaIndexer &&lambdas,                               \
+                   Transform &&transform = Transform()) const {                          \
+    PREPARE                                                                              \
+    t_.NAME(s, in1, out, scratch, num, std::forward<LambdaIndexer>(lambdas),             \
+            std::forward<Transform>(transform));                                         \
+  }                                                                                      \
+  SG_MODIFIER_DEVICE_WRAP_1IN_1OUT(NAME)
+
+#endif

--- a/singularity-eos/eos/modifiers/ramps_eos.hpp
+++ b/singularity-eos/eos/modifiers/ramps_eos.hpp
@@ -32,6 +32,7 @@
 #include <singularity-eos/base/robust_utils.hpp>
 #include <singularity-eos/base/root-finding-1d/root_finding.hpp>
 #include <singularity-eos/eos/eos_base.hpp>
+#include <singularity-eos/eos/modifiers/modifier_vector_macros.hpp>
 
 namespace singularity {
 
@@ -295,15 +296,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
                                             std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void TemperatureFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    TemperatureFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, temperatures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -326,16 +318,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
         });
   }
 
-  template <typename LambdaIndexer>
-  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                             Real *pressures, Real *scratch,
-                                             const int num, LambdaIndexer &&lambdas,
-                                             Transform &&transform = Transform()) const {
-    PressureFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, pressures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -356,16 +338,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
         });
   }
 
-  template <typename LambdaIndexer>
-  inline void
-  PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
-                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
-                                    Transform &&transform = Transform()) const {
-    PressureFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, pressures,
-                                      scratch, num, std::forward<LambdaIndexer>(lambdas),
-                                      std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -376,15 +348,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
     t_.MinInternalEnergyFromDensity(s, rhos, sies, scratch, num,
                                     std::forward<LambdaIndexer>(lambdas),
                                     std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
-                                           const int num, LambdaIndexer &&lambdas,
-                                           Transform &&transform = Transform()) const {
-    MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(), rhos, sies, scratch, num,
-                                 std::forward<LambdaIndexer>(lambdas),
-                                 std::forward<Transform>(transform));
   }
 
   template <
@@ -400,15 +363,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
                                           std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -418,15 +372,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
     t_.SpecificHeatFromDensityInternalEnergy(s, rhos, sies, cvs, scratch, num,
                                              std::forward<LambdaIndexer>(lambdas),
                                              std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -457,15 +402,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
         });
   }
 
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    BulkModulusFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -492,15 +428,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
         });
   }
 
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    BulkModulusFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -511,15 +438,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
     t_.GruneisenParamFromDensityTemperature(s, rhos, temperatures, gm1s, scratch, num,
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -533,15 +451,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
                                                std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -552,15 +461,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
     t_.InternalEnergyFromDensityTemperature(s, rhos, temperatures, sies, scratch, num,
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void InternalEnergyFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    InternalEnergyFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, sies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -576,16 +476,6 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
                                      std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                            Real *entropies, Real *scratch, const int num,
-                                            LambdaIndexer &&lambdas,
-                                            Transform &&transform = Transform()) const {
-    EntropyFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, entropies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -597,15 +487,7 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
                                         std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void
-  EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
-                                   Real *scratch, const int num, LambdaIndexer &&lambdas,
-                                   Transform &&transform = Transform()) const {
-    EntropyFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, entropies,
-                                     scratch, num, std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
-  }
+  SG_MODIFIER_DEVICE_WRAP_ALL()
 
   constexpr static inline int nlambda() noexcept { return T::nlambda(); }
   template <typename Indexable>

--- a/singularity-eos/eos/modifiers/ramps_eos.hpp
+++ b/singularity-eos/eos/modifiers/ramps_eos.hpp
@@ -12,6 +12,8 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
+// This file was created in part with generative AI
+
 #ifndef _SINGULARITY_EOS_EOS_RAMPS_EOS_
 #define _SINGULARITY_EOS_EOS_RAMPS_EOS_
 
@@ -280,21 +282,37 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
   }
 
   // vector implementations
-  template <typename LambdaIndexer>
-  inline void TemperatureFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.TemperatureFromDensityInternalEnergy(rhos, sies, temperatures, scratch, num,
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  TemperatureFromDensityInternalEnergy(const Space &s, const Real *rhos, const Real *sies,
+                                       Real *temperatures, Real *scratch, const int num,
+                                       LambdaIndexer &&lambdas,
+                                       Transform &&transform = Transform()) const {
+    t_.TemperatureFromDensityInternalEnergy(s, rhos, sies, temperatures, scratch, num,
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
-  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                             Real *pressures, Real *scratch,
-                                             const int num, LambdaIndexer &&lambdas,
+  inline void TemperatureFromDensityInternalEnergy(
+      const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    TemperatureFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, temperatures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void PressureFromDensityTemperature(const Space &s, const Real *rhos,
+                                             const Real *temperatures, Real *pressures,
+                                             Real *scratch, const int num,
+                                             LambdaIndexer &&lambdas,
                                              Transform &&transform = Transform()) const {
-    t_.PressureFromDensityTemperature(rhos, temperatures, pressures, scratch, num,
+    t_.PressureFromDensityTemperature(s, rhos, temperatures, pressures, scratch, num,
                                       std::forward<LambdaIndexer>(lambdas),
                                       std::forward<Transform>(transform));
     static auto const name = singularity::mfuncname::member_func_name(
@@ -302,7 +320,37 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
     static auto const cname = name.c_str();
     auto const copy = *this;
     portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
+          const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
+          pressures[i] = std::max(pressures[i], p_ramp);
+        });
+  }
+
+  template <typename LambdaIndexer>
+  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
+                                             Real *pressures, Real *scratch,
+                                             const int num, LambdaIndexer &&lambdas,
+                                             Transform &&transform = Transform()) const {
+    PressureFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, pressures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void PressureFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *pressures, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    t_.PressureFromDensityInternalEnergy(s, rhos, sies, pressures, scratch, num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
+    static auto const name = singularity::mfuncname::member_func_name(
+        typeid(BilinearRampEOS<T>).name(), __func__);
+    static auto const cname = name.c_str();
+    auto const copy = *this;
+    portableFor(
+        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
           const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
           pressures[i] = std::max(pressures[i], p_ramp);
         });
@@ -313,56 +361,87 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
   PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
                                     Real *scratch, const int num, LambdaIndexer &&lambdas,
                                     Transform &&transform = Transform()) const {
-    t_.PressureFromDensityInternalEnergy(rhos, sies, pressures, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
-    static auto const name = singularity::mfuncname::member_func_name(
-        typeid(BilinearRampEOS<T>).name(), __func__);
-    static auto const cname = name.c_str();
-    auto const copy = *this;
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
-          pressures[i] = std::max(pressures[i], p_ramp);
-        });
+    PressureFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, pressures,
+                                      scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, const Real *rhos, Real *sies,
+                                           Real *scratch, const int num,
+                                           LambdaIndexer &&lambdas,
+                                           Transform &&transform = Transform()) const {
+    t_.MinInternalEnergyFromDensity(s, rhos, sies, scratch, num,
+                                    std::forward<LambdaIndexer>(lambdas),
+                                    std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
                                            const int num, LambdaIndexer &&lambdas,
                                            Transform &&transform = Transform()) const {
-    t_.MinInternalEnergyFromDensity(rhos, sies, scratch, num,
-                                    std::forward<LambdaIndexer>(lambdas),
-                                    std::forward<Transform>(transform));
+    MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(), rhos, sies, scratch, num,
+                                 std::forward<LambdaIndexer>(lambdas),
+                                 std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  SpecificHeatFromDensityTemperature(const Space &s, const Real *rhos,
+                                     const Real *temperatures, Real *cvs, Real *scratch,
+                                     const int num, LambdaIndexer &&lambdas,
+                                     Transform &&transform = Transform()) const {
+    t_.SpecificHeatFromDensityTemperature(s, rhos, temperatures, cvs, scratch, num,
+                                          std::forward<LambdaIndexer>(lambdas),
+                                          std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void SpecificHeatFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, scratch, num,
-                                          std::forward<LambdaIndexer>(lambdas),
-                                          std::forward<Transform>(transform));
+    SpecificHeatFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void SpecificHeatFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *cvs, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    t_.SpecificHeatFromDensityInternalEnergy(s, rhos, sies, cvs, scratch, num,
+                                             std::forward<LambdaIndexer>(lambdas),
+                                             std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void SpecificHeatFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, scratch, num,
-                                             std::forward<LambdaIndexer>(lambdas),
-                                             std::forward<Transform>(transform));
+    SpecificHeatFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  BulkModulusFromDensityTemperature(const Space &s, const Real *rhos,
+                                    const Real *temperatures, Real *bmods, Real *scratch,
+                                    const int num, LambdaIndexer &&lambdas,
+                                    Transform &&transform = Transform()) const {
     Real *pressures = scratch;
-    t_.PressureFromDensityTemperature(rhos, temperatures, pressures, &scratch[num], num,
-                                      std::forward<LambdaIndexer>(lambdas),
+    t_.PressureFromDensityTemperature(s, rhos, temperatures, pressures, &scratch[num],
+                                      num, std::forward<LambdaIndexer>(lambdas),
                                       Transform(transform));
-    t_.BulkModulusFromDensityTemperature(rhos, temperatures, bmods, &scratch[num], num,
+    t_.BulkModulusFromDensityTemperature(s, rhos, temperatures, bmods, &scratch[num], num,
                                          std::forward<LambdaIndexer>(lambdas),
                                          std::forward<Transform>(transform));
     static auto const name = singularity::mfuncname::member_func_name(
@@ -370,7 +449,42 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
     static auto const cname = name.c_str();
     auto const copy = *this;
     portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
+          const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
+          if (pressures[i] < p_ramp) {
+            bmods[i] = rhos[i] * copy.get_ramp_dpdrho(rhos[i]);
+          }
+        });
+  }
+
+  template <typename LambdaIndexer>
+  inline void BulkModulusFromDensityTemperature(
+      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    BulkModulusFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void BulkModulusFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *bmods, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *pressures = scratch;
+    t_.PressureFromDensityInternalEnergy(s, rhos, sies, pressures, &scratch[num], num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         Transform(transform));
+    t_.BulkModulusFromDensityInternalEnergy(s, rhos, sies, bmods, &scratch[num], num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+    static auto const name = singularity::mfuncname::member_func_name(
+        typeid(BilinearRampEOS<T>).name(), __func__);
+    static auto const cname = name.c_str();
+    auto const copy = *this;
+    portableFor(
+        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
           const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
           if (pressures[i] < p_ramp) {
             bmods[i] = rhos[i] * copy.get_ramp_dpdrho(rhos[i]);
@@ -382,51 +496,84 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
   inline void BulkModulusFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    Real *pressures = scratch;
-    t_.PressureFromDensityInternalEnergy(rhos, sies, pressures, &scratch[num], num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         Transform(transform));
-    t_.BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, &scratch[num], num,
+    BulkModulusFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void GruneisenParamFromDensityTemperature(
+      const Space &s, const Real *rhos, const Real *temperatures, Real *gm1s,
+      Real *scratch, const int num, LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    t_.GruneisenParamFromDensityTemperature(s, rhos, temperatures, gm1s, scratch, num,
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
-    static auto const name = singularity::mfuncname::member_func_name(
-        typeid(BilinearRampEOS<T>).name(), __func__);
-    static auto const cname = name.c_str();
-    auto const copy = *this;
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
-          if (pressures[i] < p_ramp) {
-            bmods[i] = rhos[i] * copy.get_ramp_dpdrho(rhos[i]);
-          }
-        });
   }
 
   template <typename LambdaIndexer>
   inline void GruneisenParamFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    GruneisenParamFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void GruneisenParamFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *gm1s, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    t_.GruneisenParamFromDensityInternalEnergy(s, rhos, sies, gm1s, scratch, num,
+                                               std::forward<LambdaIndexer>(lambdas),
+                                               std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void GruneisenParamFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, scratch, num,
-                                               std::forward<LambdaIndexer>(lambdas),
-                                               std::forward<Transform>(transform));
+    GruneisenParamFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void InternalEnergyFromDensityTemperature(
+      const Space &s, const Real *rhos, const Real *temperatures, Real *sies,
+      Real *scratch, const int num, LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    t_.InternalEnergyFromDensityTemperature(s, rhos, temperatures, sies, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void InternalEnergyFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.InternalEnergyFromDensityTemperature(rhos, temperatures, sies, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    InternalEnergyFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, sies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void EntropyFromDensityTemperature(const Space &s, const Real *rhos,
+                                            const Real *temperatures, Real *entropies,
+                                            Real *scratch, const int num,
+                                            LambdaIndexer &&lambdas,
+                                            Transform &&transform = Transform()) const {
+    t_.EntropyFromDensityTemperature(s, rhos, temperatures, entropies, scratch, num,
+                                     std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -434,9 +581,20 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
                                             Real *entropies, Real *scratch, const int num,
                                             LambdaIndexer &&lambdas,
                                             Transform &&transform = Transform()) const {
-    t_.EntropyFromDensityTemperature(rhos, temperatures, entropies, scratch, num,
-                                     std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
+    EntropyFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, entropies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void EntropyFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *entropies, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    t_.EntropyFromDensityInternalEnergy(s, rhos, sies, entropies, scratch, num,
+                                        std::forward<LambdaIndexer>(lambdas),
+                                        std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -444,9 +602,9 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
   EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
                                    Transform &&transform = Transform()) const {
-    t_.EntropyFromDensityInternalEnergy(rhos, sies, entropies, scratch, num,
-                                        std::forward<LambdaIndexer>(lambdas),
-                                        std::forward<Transform>(transform));
+    EntropyFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, entropies,
+                                     scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
   }
 
   constexpr static inline int nlambda() noexcept { return T::nlambda(); }

--- a/singularity-eos/eos/modifiers/scaled_eos.hpp
+++ b/singularity-eos/eos/modifiers/scaled_eos.hpp
@@ -30,6 +30,7 @@
 #include <singularity-eos/base/constants.hpp>
 #include <singularity-eos/base/eos_error.hpp>
 #include <singularity-eos/eos/eos_base.hpp>
+#include <singularity-eos/eos/modifiers/modifier_vector_macros.hpp>
 
 namespace singularity {
 
@@ -189,303 +190,36 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
   }
 
   // vector implementations
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void
-  TemperatureFromDensityInternalEnergy(const Space &s, const Real *rhos, const Real *sies,
-                                       Real *temperatures, Real *scratch, const int num,
-                                       LambdaIndexer &&lambdas,
-                                       Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    t_.TemperatureFromDensityInternalEnergy(s, rhos, sies, temperatures, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void TemperatureFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    TemperatureFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, temperatures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void PressureFromDensityTemperature(const Space &s, const Real *rhos,
-                                             const Real *temperatures, Real *pressures,
-                                             Real *scratch, const int num,
-                                             LambdaIndexer &&lambdas,
-                                             Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    t_.PressureFromDensityTemperature(s, rhos, temperatures, pressures, scratch, num,
-                                      std::forward<LambdaIndexer>(lambdas),
-                                      std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                             Real *pressures, Real *scratch,
-                                             const int num, LambdaIndexer &&lambdas,
-                                             Transform &&transform = Transform()) const {
-    PressureFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, pressures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void PressureFromDensityInternalEnergy(
-      const Space &s, const Real *rhos, const Real *sies, Real *pressures, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    t_.PressureFromDensityInternalEnergy(s, rhos, sies, pressures, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void
-  PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
-                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
-                                    Transform &&transform = Transform()) const {
-    PressureFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, pressures,
-                                      scratch, num, std::forward<LambdaIndexer>(lambdas),
-                                      std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void MinInternalEnergyFromDensity(const Space &s, const Real *rhos, Real *sies,
-                                           Real *scratch, const int num,
-                                           LambdaIndexer &&lambdas,
-                                           Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    t_.MinInternalEnergyFromDensity(s, rhos, sies, scratch, num,
-                                    std::forward<LambdaIndexer>(lambdas),
-                                    std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
-                                           const int num, LambdaIndexer &&lambdas,
-                                           Transform &&transform = Transform()) const {
-    MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(), rhos, sies, scratch, num,
-                                 std::forward<LambdaIndexer>(lambdas),
-                                 std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void
-  SpecificHeatFromDensityTemperature(const Space &s, const Real *rhos,
-                                     const Real *temperatures, Real *cvs, Real *scratch,
-                                     const int num, LambdaIndexer &&lambdas,
-                                     Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    t_.SpecificHeatFromDensityTemperature(s, rhos, temperatures, cvs, scratch, num,
-                                          std::forward<LambdaIndexer>(lambdas),
-                                          std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void SpecificHeatFromDensityInternalEnergy(
-      const Space &s, const Real *rhos, const Real *sies, Real *cvs, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    t_.SpecificHeatFromDensityInternalEnergy(s, rhos, sies, cvs, scratch, num,
-                                             std::forward<LambdaIndexer>(lambdas),
-                                             std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void
-  BulkModulusFromDensityTemperature(const Space &s, const Real *rhos,
-                                    const Real *temperatures, Real *bmods, Real *scratch,
-                                    const int num, LambdaIndexer &&lambdas,
-                                    Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    t_.BulkModulusFromDensityTemperature(s, rhos, temperatures, bmods, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    BulkModulusFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void BulkModulusFromDensityInternalEnergy(
-      const Space &s, const Real *rhos, const Real *sies, Real *bmods, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    t_.BulkModulusFromDensityInternalEnergy(s, rhos, sies, bmods, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    BulkModulusFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void GruneisenParamFromDensityTemperature(
-      const Space &s, const Real *rhos, const Real *temperatures, Real *gm1s,
-      Real *scratch, const int num, LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    t_.GruneisenParamFromDensityTemperature(s, rhos, temperatures, gm1s, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void GruneisenParamFromDensityInternalEnergy(
-      const Space &s, const Real *rhos, const Real *sies, Real *gm1s, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    t_.GruneisenParamFromDensityInternalEnergy(s, rhos, sies, gm1s, scratch, num,
-                                               std::forward<LambdaIndexer>(lambdas),
-                                               std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void InternalEnergyFromDensityTemperature(
-      const Space &s, const Real *rhos, const Real *temperatures, Real *sies,
-      Real *scratch, const int num, LambdaIndexer &&lambdas,
-      Transform &&transform = Transform()) const {
-    transform.f.apply(scale_);
-    t_.InternalEnergyFromDensityTemperature(s, rhos, temperatures, sies, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void InternalEnergyFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    InternalEnergyFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, sies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void EntropyFromDensityTemperature(const Space &s, const Real *rhos,
-                                            const Real *temperatures, Real *entropies,
-                                            Real *scratch, const int num,
-                                            LambdaIndexer &&lambdas,
-                                            Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    transform.f.apply(scale_);
-    t_.EntropyFromDensityTemperature(s, rhos, temperatures, entropies, scratch, num,
-                                     std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                            Real *entropies, Real *scratch, const int num,
-                                            LambdaIndexer &&lambdas,
-                                            Transform &&transform = Transform()) const {
-    EntropyFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, entropies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
-  template <
-      typename Space, typename LambdaIndexer,
-      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
-  inline void EntropyFromDensityInternalEnergy(
-      const Space &s, const Real *rhos, const Real *sies, Real *entropies, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    transform.f.apply(scale_);
-    t_.EntropyFromDensityInternalEnergy(s, rhos, sies, entropies, scratch, num,
-                                        std::forward<LambdaIndexer>(lambdas),
-                                        std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void
-  EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
-                                   Real *scratch, const int num, LambdaIndexer &&lambdas,
-                                   Transform &&transform = Transform()) const {
-    EntropyFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, entropies,
-                                     scratch, num, std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
-  }
+  SG_MODIFIER_FORWARD_2IN_1OUT(TemperatureFromDensityInternalEnergy,
+                               transform.x.apply(scale_);
+                               transform.y.apply(inv_scale_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(PressureFromDensityTemperature, transform.x.apply(scale_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(PressureFromDensityInternalEnergy,
+                               transform.x.apply(scale_);
+                               transform.y.apply(inv_scale_);)
+  SG_MODIFIER_FORWARD_1IN_1OUT(MinInternalEnergyFromDensity, transform.x.apply(scale_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(SpecificHeatFromDensityTemperature,
+                               transform.x.apply(scale_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(SpecificHeatFromDensityInternalEnergy,
+                               transform.x.apply(scale_);
+                               transform.y.apply(inv_scale_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(BulkModulusFromDensityTemperature,
+                               transform.x.apply(scale_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(BulkModulusFromDensityInternalEnergy,
+                               transform.x.apply(scale_);
+                               transform.y.apply(inv_scale_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(GruneisenParamFromDensityTemperature,
+                               transform.x.apply(scale_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(GruneisenParamFromDensityInternalEnergy,
+                               transform.x.apply(scale_);
+                               transform.y.apply(inv_scale_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(InternalEnergyFromDensityTemperature,
+                               transform.f.apply(scale_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(EntropyFromDensityTemperature, transform.x.apply(scale_);
+                               transform.f.apply(scale_);)
+  SG_MODIFIER_FORWARD_2IN_1OUT(EntropyFromDensityInternalEnergy,
+                               transform.x.apply(scale_);
+                               transform.y.apply(inv_scale_); transform.f.apply(scale_);)
 
   constexpr static inline int nlambda() noexcept { return T::nlambda(); }
   template <typename Indexable>

--- a/singularity-eos/eos/modifiers/scaled_eos.hpp
+++ b/singularity-eos/eos/modifiers/scaled_eos.hpp
@@ -12,6 +12,8 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
+// This file was created in part with generative AI
+
 #ifndef _SINGULARITY_EOS_EOS_SCALED_EOS_
 #define _SINGULARITY_EOS_EOS_SCALED_EOS_
 
@@ -187,15 +189,42 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
   }
 
   // vector implementations
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  TemperatureFromDensityInternalEnergy(const Space &s, const Real *rhos, const Real *sies,
+                                       Real *temperatures, Real *scratch, const int num,
+                                       LambdaIndexer &&lambdas,
+                                       Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
+    transform.y.apply(inv_scale_);
+    t_.TemperatureFromDensityInternalEnergy(s, rhos, sies, temperatures, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+  }
+
   template <typename LambdaIndexer>
   inline void TemperatureFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    TemperatureFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, temperatures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void PressureFromDensityTemperature(const Space &s, const Real *rhos,
+                                             const Real *temperatures, Real *pressures,
+                                             Real *scratch, const int num,
+                                             LambdaIndexer &&lambdas,
+                                             Transform &&transform = Transform()) const {
     transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    t_.TemperatureFromDensityInternalEnergy(rhos, sies, temperatures, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    t_.PressureFromDensityTemperature(s, rhos, temperatures, pressures, scratch, num,
+                                      std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -203,10 +232,22 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
                                              Real *pressures, Real *scratch,
                                              const int num, LambdaIndexer &&lambdas,
                                              Transform &&transform = Transform()) const {
+    PressureFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, pressures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void PressureFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *pressures, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     transform.x.apply(scale_);
-    t_.PressureFromDensityTemperature(rhos, temperatures, pressures, scratch, num,
-                                      std::forward<LambdaIndexer>(lambdas),
-                                      std::forward<Transform>(transform));
+    transform.y.apply(inv_scale_);
+    t_.PressureFromDensityInternalEnergy(s, rhos, sies, pressures, scratch, num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -214,61 +255,132 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
   PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
                                     Real *scratch, const int num, LambdaIndexer &&lambdas,
                                     Transform &&transform = Transform()) const {
+    PressureFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, pressures,
+                                      scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, const Real *rhos, Real *sies,
+                                           Real *scratch, const int num,
+                                           LambdaIndexer &&lambdas,
+                                           Transform &&transform = Transform()) const {
     transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    t_.PressureFromDensityInternalEnergy(rhos, sies, pressures, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
+    t_.MinInternalEnergyFromDensity(s, rhos, sies, scratch, num,
+                                    std::forward<LambdaIndexer>(lambdas),
+                                    std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
                                            const int num, LambdaIndexer &&lambdas,
                                            Transform &&transform = Transform()) const {
+    MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(), rhos, sies, scratch, num,
+                                 std::forward<LambdaIndexer>(lambdas),
+                                 std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  SpecificHeatFromDensityTemperature(const Space &s, const Real *rhos,
+                                     const Real *temperatures, Real *cvs, Real *scratch,
+                                     const int num, LambdaIndexer &&lambdas,
+                                     Transform &&transform = Transform()) const {
     transform.x.apply(scale_);
-    t_.MinInternalEnergyFromDensity(rhos, sies, scratch, num,
-                                    std::forward<LambdaIndexer>(lambdas),
-                                    std::forward<Transform>(transform));
+    t_.SpecificHeatFromDensityTemperature(s, rhos, temperatures, cvs, scratch, num,
+                                          std::forward<LambdaIndexer>(lambdas),
+                                          std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void SpecificHeatFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    SpecificHeatFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void SpecificHeatFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *cvs, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     transform.x.apply(scale_);
-    t_.SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, scratch, num,
-                                          std::forward<LambdaIndexer>(lambdas),
-                                          std::forward<Transform>(transform));
+    transform.y.apply(inv_scale_);
+    t_.SpecificHeatFromDensityInternalEnergy(s, rhos, sies, cvs, scratch, num,
+                                             std::forward<LambdaIndexer>(lambdas),
+                                             std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void SpecificHeatFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    SpecificHeatFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  BulkModulusFromDensityTemperature(const Space &s, const Real *rhos,
+                                    const Real *temperatures, Real *bmods, Real *scratch,
+                                    const int num, LambdaIndexer &&lambdas,
+                                    Transform &&transform = Transform()) const {
     transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    t_.SpecificHeatFromDensityInternalEnergy(rhos, sies, cvs, scratch, num,
-                                             std::forward<LambdaIndexer>(lambdas),
-                                             std::forward<Transform>(transform));
+    t_.BulkModulusFromDensityTemperature(s, rhos, temperatures, bmods, scratch, num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void BulkModulusFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    BulkModulusFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void BulkModulusFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *bmods, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     transform.x.apply(scale_);
-    t_.BulkModulusFromDensityTemperature(rhos, temperatures, bmods, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
+    transform.y.apply(inv_scale_);
+    t_.BulkModulusFromDensityInternalEnergy(s, rhos, sies, bmods, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void BulkModulusFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    BulkModulusFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void GruneisenParamFromDensityTemperature(
+      const Space &s, const Real *rhos, const Real *temperatures, Real *gm1s,
+      Real *scratch, const int num, LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
     transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    t_.BulkModulusFromDensityInternalEnergy(rhos, sies, bmods, scratch, num,
+    t_.GruneisenParamFromDensityTemperature(s, rhos, temperatures, gm1s, scratch, num,
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
   }
@@ -277,31 +389,68 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
   inline void GruneisenParamFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    GruneisenParamFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void GruneisenParamFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *gm1s, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     transform.x.apply(scale_);
-    t_.GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    transform.y.apply(inv_scale_);
+    t_.GruneisenParamFromDensityInternalEnergy(s, rhos, sies, gm1s, scratch, num,
+                                               std::forward<LambdaIndexer>(lambdas),
+                                               std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void GruneisenParamFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    t_.GruneisenParamFromDensityInternalEnergy(rhos, sies, gm1s, scratch, num,
-                                               std::forward<LambdaIndexer>(lambdas),
-                                               std::forward<Transform>(transform));
+    GruneisenParamFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void InternalEnergyFromDensityTemperature(
+      const Space &s, const Real *rhos, const Real *temperatures, Real *sies,
+      Real *scratch, const int num, LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    transform.f.apply(scale_);
+    t_.InternalEnergyFromDensityTemperature(s, rhos, temperatures, sies, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void InternalEnergyFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    InternalEnergyFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, sies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void EntropyFromDensityTemperature(const Space &s, const Real *rhos,
+                                            const Real *temperatures, Real *entropies,
+                                            Real *scratch, const int num,
+                                            LambdaIndexer &&lambdas,
+                                            Transform &&transform = Transform()) const {
+    transform.x.apply(scale_);
     transform.f.apply(scale_);
-    t_.InternalEnergyFromDensityTemperature(rhos, temperatures, sies, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    t_.EntropyFromDensityTemperature(s, rhos, temperatures, entropies, scratch, num,
+                                     std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -309,11 +458,23 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
                                             Real *entropies, Real *scratch, const int num,
                                             LambdaIndexer &&lambdas,
                                             Transform &&transform = Transform()) const {
+    EntropyFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, entropies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void EntropyFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *entropies, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
     transform.x.apply(scale_);
+    transform.y.apply(inv_scale_);
     transform.f.apply(scale_);
-    t_.EntropyFromDensityTemperature(rhos, temperatures, entropies, scratch, num,
-                                     std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
+    t_.EntropyFromDensityInternalEnergy(s, rhos, sies, entropies, scratch, num,
+                                        std::forward<LambdaIndexer>(lambdas),
+                                        std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -321,12 +482,9 @@ class ScaledEOS : public EosBase<ScaledEOS<T>> {
   EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
                                    Transform &&transform = Transform()) const {
-    transform.x.apply(scale_);
-    transform.y.apply(inv_scale_);
-    transform.f.apply(scale_);
-    t_.EntropyFromDensityInternalEnergy(rhos, sies, entropies, scratch, num,
-                                        std::forward<LambdaIndexer>(lambdas),
-                                        std::forward<Transform>(transform));
+    EntropyFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, entropies,
+                                     scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
   }
 
   constexpr static inline int nlambda() noexcept { return T::nlambda(); }

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -12,6 +12,8 @@
 // publicly and display publicly, and to permit others to do so.
 //------------------------------------------------------------------------------
 
+// This file was created in part with generative AI
+
 #ifndef _SINGULARITY_EOS_EOS_SHIFTED_EOS_
 #define _SINGULARITY_EOS_EOS_SHIFTED_EOS_
 
@@ -164,34 +166,64 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
   }
 
   // vector implementations
-  inline void shift_sies(const Real *sies, Real *shifted, const int num) const {
+  template <typename Space, typename EnableIfSpace =
+                                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void shift_sies(const Space &s, const Real *sies, Real *shifted,
+                         const int num) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(ShiftedEOS<T>).name(), __func__);
     static auto const cname = name.c_str();
     const auto shift_val = shift_;
     portableFor(
-        cname, 0, num,
+        cname, s, 0, num,
         PORTABLE_LAMBDA(const int i) { shifted[i] = sies[i] - shift_val; });
   }
 
-  inline void unshift_sies(Real *sies, const int num) const {
+  template <typename Space, typename EnableIfSpace =
+                                std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void unshift_sies(const Space &s, Real *sies, const int num) const {
     static auto const name =
         singularity::mfuncname::member_func_name(typeid(ShiftedEOS<T>).name(), __func__);
     static auto const cname = name.c_str();
     const auto shift_val = shift_;
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) { sies[i] += shift_val; });
+    portableFor(cname, s, 0, num, PORTABLE_LAMBDA(const int i) { sies[i] += shift_val; });
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  TemperatureFromDensityInternalEnergy(const Space &s, const Real *rhos, const Real *sies,
+                                       Real *temperatures, Real *scratch, const int num,
+                                       LambdaIndexer &&lambdas,
+                                       Transform &&transform = Transform()) const {
+    Real *shifted_sies = scratch;
+    shift_sies(s, sies, shifted_sies, num);
+    t_.TemperatureFromDensityInternalEnergy(
+        s, rhos, shifted_sies, temperatures, &scratch[num], num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void TemperatureFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    Real *shifted_sies = scratch;
-    shift_sies(sies, shifted_sies, num);
-    t_.TemperatureFromDensityInternalEnergy(
-        rhos, shifted_sies, temperatures, &scratch[num], num,
+    TemperatureFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, temperatures, scratch, num,
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void PressureFromDensityTemperature(const Space &s, const Real *rhos,
+                                             const Real *temperatures, Real *pressures,
+                                             Real *scratch, const int num,
+                                             LambdaIndexer &&lambdas,
+                                             Transform &&transform = Transform()) const {
+    t_.PressureFromDensityTemperature(s, rhos, temperatures, pressures, scratch, num,
+                                      std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -199,9 +231,22 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
                                              Real *pressures, Real *scratch,
                                              const int num, LambdaIndexer &&lambdas,
                                              Transform &&transform = Transform()) const {
-    t_.PressureFromDensityTemperature(rhos, temperatures, pressures, scratch, num,
-                                      std::forward<LambdaIndexer>(lambdas),
-                                      std::forward<Transform>(transform));
+    PressureFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, pressures, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void PressureFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *pressures, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *shifted_sies = scratch;
+    shift_sies(s, sies, shifted_sies, num);
+    t_.PressureFromDensityInternalEnergy(s, rhos, shifted_sies, pressures, &scratch[num],
+                                         num, std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -209,59 +254,129 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
   PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
                                     Real *scratch, const int num, LambdaIndexer &&lambdas,
                                     Transform &&transform = Transform()) const {
-    Real *shifted_sies = scratch;
-    shift_sies(sies, shifted_sies, num);
-    t_.PressureFromDensityInternalEnergy(rhos, shifted_sies, pressures, &scratch[num],
-                                         num, std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
+    PressureFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, pressures,
+                                      scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                      std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void MinInternalEnergyFromDensity(const Space &s, const Real *rhos, Real *sies,
+                                           Real *scratch, const int num,
+                                           LambdaIndexer &&lambdas,
+                                           Transform &&transform = Transform()) const {
+    t_.MinInternalEnergyFromDensity(s, rhos, sies, &scratch[num], num,
+                                    std::forward<LambdaIndexer>(lambdas),
+                                    std::forward<Transform>(transform));
+    unshift_sies(s, sies, num);
   }
 
   template <typename LambdaIndexer>
   inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
                                            const int num, LambdaIndexer &&lambdas,
                                            Transform &&transform = Transform()) const {
-    t_.MinInternalEnergyFromDensity(rhos, sies, &scratch[num], num,
-                                    std::forward<LambdaIndexer>(lambdas),
-                                    std::forward<Transform>(transform));
-    unshift_sies(sies, num);
+    MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(), rhos, sies, scratch, num,
+                                 std::forward<LambdaIndexer>(lambdas),
+                                 std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  SpecificHeatFromDensityTemperature(const Space &s, const Real *rhos,
+                                     const Real *temperatures, Real *cvs, Real *scratch,
+                                     const int num, LambdaIndexer &&lambdas,
+                                     Transform &&transform = Transform()) const {
+    t_.SpecificHeatFromDensityTemperature(s, rhos, temperatures, cvs, scratch, num,
+                                          std::forward<LambdaIndexer>(lambdas),
+                                          std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void SpecificHeatFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.SpecificHeatFromDensityTemperature(rhos, temperatures, cvs, scratch, num,
-                                          std::forward<LambdaIndexer>(lambdas),
-                                          std::forward<Transform>(transform));
+    SpecificHeatFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void SpecificHeatFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *cvs, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *shifted_sies = scratch;
+    shift_sies(s, sies, shifted_sies, num);
+    t_.SpecificHeatFromDensityInternalEnergy(s, rhos, shifted_sies, cvs, &scratch[num],
+                                             num, std::forward<LambdaIndexer>(lambdas),
+                                             std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void SpecificHeatFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    Real *shifted_sies = scratch;
-    shift_sies(sies, shifted_sies, num);
-    t_.SpecificHeatFromDensityInternalEnergy(rhos, shifted_sies, cvs, &scratch[num], num,
-                                             std::forward<LambdaIndexer>(lambdas),
-                                             std::forward<Transform>(transform));
+    SpecificHeatFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, cvs, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void
+  BulkModulusFromDensityTemperature(const Space &s, const Real *rhos,
+                                    const Real *temperatures, Real *bmods, Real *scratch,
+                                    const int num, LambdaIndexer &&lambdas,
+                                    Transform &&transform = Transform()) const {
+    t_.BulkModulusFromDensityTemperature(s, rhos, temperatures, bmods, scratch, num,
+                                         std::forward<LambdaIndexer>(lambdas),
+                                         std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void BulkModulusFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.BulkModulusFromDensityTemperature(rhos, temperatures, bmods, scratch, num,
-                                         std::forward<LambdaIndexer>(lambdas),
-                                         std::forward<Transform>(transform));
+    BulkModulusFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void BulkModulusFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *bmods, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *shifted_sies = scratch;
+    shift_sies(s, sies, shifted_sies, num);
+    t_.BulkModulusFromDensityInternalEnergy(s, rhos, shifted_sies, bmods, &scratch[num],
+                                            num, std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void BulkModulusFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    Real *shifted_sies = scratch;
-    shift_sies(sies, shifted_sies, num);
-    t_.BulkModulusFromDensityInternalEnergy(rhos, shifted_sies, bmods, &scratch[num], num,
+    BulkModulusFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, bmods, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void GruneisenParamFromDensityTemperature(
+      const Space &s, const Real *rhos, const Real *temperatures, Real *gm1s,
+      Real *scratch, const int num, LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    t_.GruneisenParamFromDensityTemperature(s, rhos, temperatures, gm1s, scratch, num,
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
   }
@@ -270,30 +385,66 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
   inline void GruneisenParamFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.GruneisenParamFromDensityTemperature(rhos, temperatures, gm1s, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
+    GruneisenParamFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void GruneisenParamFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *gm1s, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *shifted_sies = scratch;
+    shift_sies(s, sies, shifted_sies, num);
+    t_.GruneisenParamFromDensityInternalEnergy(s, rhos, shifted_sies, gm1s, &scratch[num],
+                                               num, std::forward<LambdaIndexer>(lambdas),
+                                               std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
   inline void GruneisenParamFromDensityInternalEnergy(
       const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
       LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    Real *shifted_sies = scratch;
-    shift_sies(sies, shifted_sies, num);
-    t_.GruneisenParamFromDensityInternalEnergy(rhos, shifted_sies, gm1s, &scratch[num],
-                                               num, std::forward<LambdaIndexer>(lambdas),
-                                               std::forward<Transform>(transform));
+    GruneisenParamFromDensityInternalEnergy(
+        PortsOfCall::Exec::Device(), rhos, sies, gm1s, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void InternalEnergyFromDensityTemperature(
+      const Space &s, const Real *rhos, const Real *temperatures, Real *sies,
+      Real *scratch, const int num, LambdaIndexer &&lambdas,
+      Transform &&transform = Transform()) const {
+    t_.InternalEnergyFromDensityTemperature(s, rhos, temperatures, sies, scratch, num,
+                                            std::forward<LambdaIndexer>(lambdas),
+                                            std::forward<Transform>(transform));
+    unshift_sies(s, sies, num);
   }
 
   template <typename LambdaIndexer>
   inline void InternalEnergyFromDensityTemperature(
       const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
       const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    t_.InternalEnergyFromDensityTemperature(rhos, temperatures, sies, scratch, num,
-                                            std::forward<LambdaIndexer>(lambdas),
-                                            std::forward<Transform>(transform));
-    unshift_sies(sies, num);
+    InternalEnergyFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, sies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void EntropyFromDensityTemperature(const Space &s, const Real *rhos,
+                                            const Real *temperatures, Real *entropies,
+                                            Real *scratch, const int num,
+                                            LambdaIndexer &&lambdas,
+                                            Transform &&transform = Transform()) const {
+    t_.EntropyFromDensityTemperature(s, rhos, temperatures, entropies, scratch, num,
+                                     std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -301,9 +452,22 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
                                             Real *entropies, Real *scratch, const int num,
                                             LambdaIndexer &&lambdas,
                                             Transform &&transform = Transform()) const {
-    t_.EntropyFromDensityTemperature(rhos, temperatures, entropies, scratch, num,
-                                     std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
+    EntropyFromDensityTemperature(
+        PortsOfCall::Exec::Device(), rhos, temperatures, entropies, scratch, num,
+        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
+  }
+
+  template <
+      typename Space, typename LambdaIndexer,
+      typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
+  inline void EntropyFromDensityInternalEnergy(
+      const Space &s, const Real *rhos, const Real *sies, Real *entropies, Real *scratch,
+      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
+    Real *shifted_sies = scratch;
+    shift_sies(s, sies, shifted_sies, num);
+    t_.EntropyFromDensityInternalEnergy(s, rhos, shifted_sies, entropies, &scratch[num],
+                                        num, std::forward<LambdaIndexer>(lambdas),
+                                        std::forward<Transform>(transform));
   }
 
   template <typename LambdaIndexer>
@@ -311,11 +475,9 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
   EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
                                    Transform &&transform = Transform()) const {
-    Real *shifted_sies = scratch;
-    shift_sies(sies, shifted_sies, num);
-    t_.EntropyFromDensityInternalEnergy(rhos, sies, entropies, &scratch[num], num,
-                                        std::forward<LambdaIndexer>(lambdas),
-                                        std::forward<Transform>(transform));
+    EntropyFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, entropies,
+                                     scratch, num, std::forward<LambdaIndexer>(lambdas),
+                                     std::forward<Transform>(transform));
   }
 
   constexpr static inline int nlambda() noexcept { return T::nlambda(); }

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -30,6 +30,7 @@
 #include <singularity-eos/base/constants.hpp>
 #include <singularity-eos/base/eos_error.hpp>
 #include <singularity-eos/eos/eos_base.hpp>
+#include <singularity-eos/eos/modifiers/modifier_vector_macros.hpp>
 
 namespace singularity {
 
@@ -186,8 +187,7 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
         singularity::mfuncname::member_func_name(typeid(ShiftedEOS<T>).name(), __func__);
     static auto const cname = name.c_str();
     const auto shift_val = shift_;
-    portableFor(
-        cname, s, 0, num, PORTABLE_LAMBDA(const int i) { sies[i] += shift_val; });
+    portableFor(cname, s, 0, num, PORTABLE_LAMBDA(const int i) { sies[i] += shift_val; });
   }
 
   template <
@@ -205,15 +205,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
         std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void TemperatureFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *temperatures, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    TemperatureFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, temperatures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -225,16 +216,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
     t_.PressureFromDensityTemperature(s, rhos, temperatures, pressures, scratch, num,
                                       std::forward<LambdaIndexer>(lambdas),
                                       std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void PressureFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                             Real *pressures, Real *scratch,
-                                             const int num, LambdaIndexer &&lambdas,
-                                             Transform &&transform = Transform()) const {
-    PressureFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, pressures, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -250,16 +231,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
                                          std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void
-  PressureFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *pressures,
-                                    Real *scratch, const int num, LambdaIndexer &&lambdas,
-                                    Transform &&transform = Transform()) const {
-    PressureFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, pressures,
-                                      scratch, num, std::forward<LambdaIndexer>(lambdas),
-                                      std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -271,15 +242,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
                                     std::forward<LambdaIndexer>(lambdas),
                                     std::forward<Transform>(transform));
     unshift_sies(s, sies, num);
-  }
-
-  template <typename LambdaIndexer>
-  inline void MinInternalEnergyFromDensity(const Real *rhos, Real *sies, Real *scratch,
-                                           const int num, LambdaIndexer &&lambdas,
-                                           Transform &&transform = Transform()) const {
-    MinInternalEnergyFromDensity(PortsOfCall::Exec::Device(), rhos, sies, scratch, num,
-                                 std::forward<LambdaIndexer>(lambdas),
-                                 std::forward<Transform>(transform));
   }
 
   template <
@@ -295,15 +257,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
                                           std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -315,15 +268,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
     t_.SpecificHeatFromDensityInternalEnergy(s, rhos, shifted_sies, cvs, &scratch[num],
                                              num, std::forward<LambdaIndexer>(lambdas),
                                              std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void SpecificHeatFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *cvs, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    SpecificHeatFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, cvs, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -339,15 +283,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
                                          std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *bmods, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    BulkModulusFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -361,15 +296,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
                                             std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void BulkModulusFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *bmods, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    BulkModulusFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, bmods, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -380,15 +306,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
     t_.GruneisenParamFromDensityTemperature(s, rhos, temperatures, gm1s, scratch, num,
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
-  }
-
-  template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *gm1s, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -404,15 +321,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
                                                std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void GruneisenParamFromDensityInternalEnergy(
-      const Real *rhos, const Real *sies, Real *gm1s, Real *scratch, const int num,
-      LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    GruneisenParamFromDensityInternalEnergy(
-        PortsOfCall::Exec::Device(), rhos, sies, gm1s, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -424,15 +332,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
                                             std::forward<LambdaIndexer>(lambdas),
                                             std::forward<Transform>(transform));
     unshift_sies(s, sies, num);
-  }
-
-  template <typename LambdaIndexer>
-  inline void InternalEnergyFromDensityTemperature(
-      const Real *rhos, const Real *temperatures, Real *sies, Real *scratch,
-      const int num, LambdaIndexer &&lambdas, Transform &&transform = Transform()) const {
-    InternalEnergyFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, sies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
   }
 
   template <
@@ -448,16 +347,6 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
                                      std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void EntropyFromDensityTemperature(const Real *rhos, const Real *temperatures,
-                                            Real *entropies, Real *scratch, const int num,
-                                            LambdaIndexer &&lambdas,
-                                            Transform &&transform = Transform()) const {
-    EntropyFromDensityTemperature(
-        PortsOfCall::Exec::Device(), rhos, temperatures, entropies, scratch, num,
-        std::forward<LambdaIndexer>(lambdas), std::forward<Transform>(transform));
-  }
-
   template <
       typename Space, typename LambdaIndexer,
       typename EnableIfSpace = std::enable_if_t<!variadic_utils::has_int_index_v<Space>>>
@@ -471,15 +360,7 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
                                         std::forward<Transform>(transform));
   }
 
-  template <typename LambdaIndexer>
-  inline void
-  EntropyFromDensityInternalEnergy(const Real *rhos, const Real *sies, Real *entropies,
-                                   Real *scratch, const int num, LambdaIndexer &&lambdas,
-                                   Transform &&transform = Transform()) const {
-    EntropyFromDensityInternalEnergy(PortsOfCall::Exec::Device(), rhos, sies, entropies,
-                                     scratch, num, std::forward<LambdaIndexer>(lambdas),
-                                     std::forward<Transform>(transform));
-  }
+  SG_MODIFIER_DEVICE_WRAP_ALL()
 
   constexpr static inline int nlambda() noexcept { return T::nlambda(); }
   template <typename Indexable>

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -187,7 +187,8 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
         singularity::mfuncname::member_func_name(typeid(ShiftedEOS<T>).name(), __func__);
     static auto const cname = name.c_str();
     const auto shift_val = shift_;
-    portableFor(cname, s, 0, num, PORTABLE_LAMBDA(const int i) { sies[i] += shift_val; });
+    portableFor(
+        cname, s, 0, num, PORTABLE_LAMBDA(const int i) { sies[i] += shift_val; });
   }
 
   template <

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -186,7 +186,8 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
         singularity::mfuncname::member_func_name(typeid(ShiftedEOS<T>).name(), __func__);
     static auto const cname = name.c_str();
     const auto shift_val = shift_;
-    portableFor(cname, s, 0, num, PORTABLE_LAMBDA(const int i) { sies[i] += shift_val; });
+    portableFor(
+        cname, s, 0, num, PORTABLE_LAMBDA(const int i) { sies[i] += shift_val; });
   }
 
   template <

--- a/test/test_eos_gruneisen.cpp
+++ b/test/test_eos_gruneisen.cpp
@@ -485,7 +485,7 @@ SCENARIO("Gruneisen EOS density limit") {
         const Real beyond_max = eos.PressureFromDensityTemperature(rho, temperature);
         INFO("Pressure at rho_max: " << at_max << ", Pressure beyond rho_max"
                                      << beyond_max);
-        REQUIRE(at_max == beyond_max);
+        REQUIRE(isClose(at_max, beyond_max));
       }
     }
     WHEN("The rho_max parameter is not specified") {

--- a/test/test_eos_gruneisen.cpp
+++ b/test/test_eos_gruneisen.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2026. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/test/test_eos_vector.cpp
+++ b/test/test_eos_vector.cpp
@@ -33,7 +33,7 @@ using EOS = singularity::Variant<IdealGas>;
 
 namespace {
 template <typename EosType>
-void CheckHostExecVectorApi(const EOS &eos) {
+void CheckHostExecVectorApi(const EosType &eos) {
   constexpr Real Cv = 5.0;
   constexpr Real gm1 = 0.4;
   constexpr int num = 3;

--- a/test/test_eos_vector.cpp
+++ b/test/test_eos_vector.cpp
@@ -13,6 +13,7 @@
 //------------------------------------------------------------------------------
 
 #include <array>
+#include <vector>
 
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
@@ -21,6 +22,7 @@
 
 #ifndef CATCH_CONFIG_FAST_COMPILE
 #define CATCH_CONFIG_FAST_COMPILE
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #endif
 
@@ -28,6 +30,67 @@
 
 using singularity::IdealGas;
 using EOS = singularity::Variant<IdealGas>;
+
+namespace {
+template <typename EosType>
+void CheckHostExecVectorApi(const EOS &eos) {
+  constexpr Real Cv = 5.0;
+  constexpr Real gm1 = 0.4;
+  constexpr int num = 3;
+
+  std::vector<Real> density{1.0, 2.0, 5.0};
+  std::vector<Real> energy{5.0, 10.0, 15.0};
+  std::vector<Real> temperature(num, -1.0);
+  std::vector<Real> pressure(num, -1.0);
+  std::vector<Real> min_energy(num, -1.0);
+  std::vector<Real> fill_temperature(num, -1.0);
+  std::vector<Real> fill_pressure(num, -1.0);
+  std::vector<Real> fill_cv(num, -1.0);
+  std::vector<Real> fill_bmod(num, -1.0);
+  std::vector<Real> scratch(num, -1.0);
+  singularity::NullIndexer lambdas{};
+
+  constexpr std::array<Real, num> temperature_true{1.0, 2.0, 3.0};
+  constexpr std::array<Real, num> pressure_true{2.0, 8.0, 30.0};
+  constexpr std::array<Real, num> min_energy_true{0.0, 0.0, 0.0};
+  constexpr std::array<Real, num> cv_true{Cv, Cv, Cv};
+  constexpr std::array<Real, num> bmod_true{2.8, 11.2, 42.0};
+
+  eos.TemperatureFromDensityInternalEnergy(PortsOfCall::Exec::Host(), density.data(),
+                                           energy.data(), temperature.data(),
+                                           scratch.data(), num, lambdas);
+  eos.PressureFromDensityInternalEnergy(PortsOfCall::Exec::Host(), density.data(),
+                                        energy.data(), pressure.data(), scratch.data(),
+                                        num, lambdas);
+  eos.MinInternalEnergyFromDensity(PortsOfCall::Exec::Host(), density.data(),
+                                   min_energy.data(), scratch.data(), num, lambdas);
+  eos.FillEos(PortsOfCall::Exec::Host(), density.data(), fill_temperature.data(),
+              energy.data(), fill_pressure.data(), fill_cv.data(), fill_bmod.data(), num,
+              singularity::thermalqs::temperature | singularity::thermalqs::pressure |
+                  singularity::thermalqs::specific_heat |
+                  singularity::thermalqs::bulk_modulus,
+              lambdas);
+
+  for (int i = 0; i < num; ++i) {
+    REQUIRE(temperature[i] == Catch::Approx(temperature_true[i]));
+    REQUIRE(pressure[i] == Catch::Approx(pressure_true[i]));
+    REQUIRE(min_energy[i] == Catch::Approx(min_energy_true[i]));
+    REQUIRE(fill_temperature[i] == Catch::Approx(temperature_true[i]));
+    REQUIRE(fill_pressure[i] == Catch::Approx(pressure_true[i]));
+    REQUIRE(fill_cv[i] == Catch::Approx(cv_true[i]));
+    REQUIRE(fill_bmod[i] == Catch::Approx(bmod_true[i]));
+  }
+
+  const Real expected_pressure_from_temperature = gm1 * density[1] * Cv * 4.0;
+  std::vector<Real> host_temperature{2.0, 4.0, 6.0};
+  std::vector<Real> pressure_from_temperature(num, -1.0);
+  eos.PressureFromDensityTemperature(
+      PortsOfCall::Exec::Host(), density.data(), host_temperature.data(),
+      pressure_from_temperature.data(), scratch.data(), num, lambdas);
+  REQUIRE(pressure_from_temperature[1] ==
+          Catch::Approx(expected_pressure_from_temperature));
+}
+} // namespace
 
 SCENARIO("Vector EOS", "[VectorEOS][IdealGas]") {
 
@@ -376,6 +439,29 @@ SCENARIO("Vector EOS", "[VectorEOS][IdealGas]") {
           array_compare(num, density, temperature, h_gruneisen, gruneisen_true, "Density",
                         "Temperature");
         }
+      }
+    }
+  }
+}
+
+SCENARIO("Vector EOS host execution space", "[VectorEOS][IdealGas][HostExec]") {
+  constexpr Real Cv = 5.0;
+  constexpr Real gm1 = 0.4;
+
+  GIVEN("An ideal gas concrete EOS") {
+    IdealGas eos(gm1, Cv);
+    WHEN("The vector API is called with PortsOfCall::Exec::Host()") {
+      THEN("The concrete EOS host path should return the expected answers") {
+        CheckHostExecVectorApi(eos);
+      }
+    }
+  }
+
+  GIVEN("An ideal gas wrapped in a variant") {
+    EOS eos = IdealGas(gm1, Cv);
+    WHEN("The vector API is called with PortsOfCall::Exec::Host()") {
+      THEN("The variant host path should return the expected answers") {
+        CheckHostExecVectorApi(eos);
       }
     }
   }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This MR resolves issue #628 and pulls in https://github.com/lanl/ports-of-call/pull/109 from `ports-of-call`. Here I expose the ability to select an execution space in the `singularity-eos` vector API:
- Each vector API call now optionally accepts an execution space argument. The default is `PortsOfCall::Exec::Device()` which is (when Kokkos is enabled) an alias to kokkos default execution space.
- To handle the huge number of overloads, I heavily leverage #629 so that the changes are relatively minimal.
- I did need to heavily use SFINAE/concepts to ensure that all the different template specializations played nice.
- The *python* API now explicitly calls the `PortsOfCall::Exec::Host()` execution space.
- As usual, EOSPAC is a bit of an odd one out. As far as I know, EOSPAC does not have the ability to select an execution space like this. For now, I simply document that explicitly requesting an execution space with EOSPAC is undefined behavior. It will do whatever the backend decides to do. We should resolve this at some point down the road in collaboration with the EOSPAC devs if we need to.

This MR used generative AI, but agents weren't set loose, so there's no proposed change plan. I made changes by hand and then had the robots copy my changes by example. 

I am still getting the CI to pass, but this is ready for review.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
- [x] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [x] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Maintainers: ensure spackages are up to date:
  - [ ] LANL-internal team, update XCAP spackages
  - [ ] Current maintainer of upstream spackages, submit MR to spack
