### PR TITLE
[trivial] sgn for unsigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR633]](https://github.com/lanl/singularity-eos/pull/633) Make robust::sgn handle unsigned properly
 - [[PR629]](https://github.com/lanl/singularity-eos/pull/629) Use macros and eos_base and eos_variant to reduce boiler plate
 - [[PR626]](https://github.com/lanl/singularity-eos/pull/626) Fix C++20 warnings related to lambdas
 

--- a/singularity-eos/base/robust_utils.hpp
+++ b/singularity-eos/base/robust_utils.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2026. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/base/robust_utils.hpp
+++ b/singularity-eos/base/robust_utils.hpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <limits>
 #include <ports-of-call/portability.hpp>
+#include <type_traits>
 
 namespace singularity {
 namespace robust {
@@ -53,8 +54,12 @@ Real make_bounded(const Real val, const Real vmin, const Real vmax) {
 }
 
 template <typename T>
-PORTABLE_FORCEINLINE_FUNCTION int sgn(const T &val) {
-  return (T(0) <= val) - (val < T(0));
+PORTABLE_FORCEINLINE_FUNCTION auto sgn(const T &val) {
+  if constexpr (std::is_unsigned_v<T>) {
+    return 1;
+  } else {
+    return (T(0) <= val) - (val < T(0));
+  }
 }
 
 template <typename A, typename B>

--- a/singularity-eos/base/robust_utils.hpp
+++ b/singularity-eos/base/robust_utils.hpp
@@ -54,7 +54,7 @@ Real make_bounded(const Real val, const Real vmin, const Real vmax) {
 }
 
 template <typename T>
-PORTABLE_FORCEINLINE_FUNCTION auto sgn(const T &val) {
+PORTABLE_FORCEINLINE_FUNCTION int sgn(const T &val) {
   if constexpr (std::is_unsigned_v<T>) {
     return 1;
   } else {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(
   test_eos_modifiers_minimal.cpp
   test_eos_vector.cpp
   test_math_utils.cpp
+  test_robust_utils.cpp
   test_modifier_floored_energy.cpp
   test_variadic_utils.cpp
   test_bounds.cpp

--- a/test/test_robust_utils.cpp
+++ b/test/test_robust_utils.cpp
@@ -1,0 +1,77 @@
+//------------------------------------------------------------------------------
+// © 2021-2026. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S. Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//------------------------------------------------------------------------------
+
+// This file is made in part with generative AI
+
+#include <cmath>
+#include <limits>
+
+#include <singularity-eos/base/robust_utils.hpp>
+
+#ifndef CATCH_CONFIG_FAST_COMPILE
+#define CATCH_CONFIG_FAST_COMPILE
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#endif
+
+namespace robust = singularity::robust;
+
+SCENARIO("Robust utilities expose scaled floating-point limits", "[RobustUtils]") {
+  REQUIRE(robust::SMALL<Real>() == 10 * std::numeric_limits<Real>::min());
+  REQUIRE(robust::EPS<Real>() == 10 * std::numeric_limits<Real>::epsilon());
+  REQUIRE(robust::min_exp_arg<Real>() ==
+          Catch::Approx((std::numeric_limits<Real>::min_exponent - 1) * M_LN2));
+  REQUIRE(robust::max_exp_arg<Real>() ==
+          Catch::Approx(std::numeric_limits<Real>::max_exponent * M_LN2));
+}
+
+SCENARIO("Robust utilities bound scalar values away from unsafe regions",
+         "[RobustUtils]") {
+  constexpr Real vmin = 0.0;
+  constexpr Real vmax = 1.0;
+
+  REQUIRE(robust::make_positive(-1.0) == robust::EPS<Real>());
+  REQUIRE(robust::make_positive(2.5) == Catch::Approx(2.5));
+
+  REQUIRE(robust::make_bounded(-1.0, vmin, vmax) == Catch::Approx(vmin + robust::EPS()));
+  REQUIRE(robust::make_bounded(0.5, vmin, vmax) == Catch::Approx(0.5));
+  REQUIRE(robust::make_bounded(2.0, vmin, vmax) ==
+          Catch::Approx(vmax * (1.0 - robust::EPS())));
+}
+
+SCENARIO("Robust utilities preserve sign information and regularize ratios",
+         "[RobustUtils]") {
+  REQUIRE(robust::sgn(-3.0) == -1);
+  REQUIRE(robust::sgn(0.0) == 1);
+  REQUIRE(robust::sgn(4.0) == 1);
+  REQUIRE(robust::sgn(-3) == -1);
+  REQUIRE(robust::sgn(0) == 1);
+  REQUIRE(robust::sgn(4) == 1);
+  REQUIRE(robust::sgn(0u) == 1);
+  REQUIRE(robust::sgn(4u) == 1);
+
+  REQUIRE(robust::ratio(12.0, 3.0) == Catch::Approx(4.0));
+  REQUIRE(robust::ratio(12.0, -3.0) == Catch::Approx(-4.0));
+
+  const Real ratio_with_zero = robust::ratio(1.0, 0.0);
+  REQUIRE(std::isfinite(ratio_with_zero));
+  REQUIRE(ratio_with_zero == Catch::Approx(1.0 / robust::SMALL<Real>()));
+}
+
+SCENARIO("Robust utilities clamp exponential evaluation to a safe range",
+         "[RobustUtils]") {
+  REQUIRE(robust::safe_arg_exp(1.5) == Catch::Approx(std::exp(1.5)));
+  REQUIRE(robust::safe_arg_exp(robust::min_exp_arg<Real>() - 1.0) == 0.0);
+  REQUIRE(std::isinf(robust::safe_arg_exp(robust::max_exp_arg<Real>() + 1.0)));
+}


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This MR just eliminates a warning for comparison against zero for unsigned integral types when calling `robust::sgn`. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
- [ ] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [ ] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Maintainers: ensure spackages are up to date:
  - [ ] LANL-internal team, update XCAP spackages
  - [ ] Current maintainer of upstream spackages, submit MR to spack
