### PR TITLE
sanitize python more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR634]](https://github.com/lanl/singularity-eos/pull/634) Disable device lambda when on host execution space
 - [[PR633]](https://github.com/lanl/singularity-eos/pull/633) Make robust::sgn handle unsigned properly
 - [[PR629]](https://github.com/lanl/singularity-eos/pull/629) Use macros and eos_base and eos_variant to reduce boiler plate
 - [[PR626]](https://github.com/lanl/singularity-eos/pull/626) Fix C++20 warnings related to lambdas

--- a/python/module.hpp
+++ b/python/module.hpp
@@ -34,12 +34,12 @@ using singularity::variadic_utils::np;
 
 // Helper function to convert lambda numpy array to double* buffer
 // With std::optional we would add support for a default value of lambda=None
-template<typename T, PORTABLE_FUNCTION Real(T::*Func)(const Real, const Real, Real*&&) const>
+template<typename T, Real(T::*Func)(const Real, const Real, Real*&&) const>
 Real two_params(const T& self, const Real a, const Real b, py::array_t<Real> lambda) {
   return (self.*Func)(a, b, lambda.mutable_data());
 }
 
-template<typename T, PORTABLE_FUNCTION Real(T::*Func)(const Real, const Real, Real*&&) const>
+template<typename T, Real(T::*Func)(const Real, const Real, Real*&&) const>
 Real two_params_no_lambda(const T& self, const Real a, const Real b) {
   return (self.*Func)(a, b, np<Real>());
 }

--- a/singularity-eos/eos/eos_base.hpp
+++ b/singularity-eos/eos/eos_base.hpp
@@ -176,10 +176,15 @@ char *StrCat(char *destination, const char *source) {
     static auto const name = SG_MEMBER_FUNC_NAME();                                      \
     static auto const cname = name.c_str();                                              \
     const CRTP &copy = *(static_cast<CRTP const *>(this));                               \
-    portableFor(                                                                         \
-        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {                                 \
-          OUT[i] = copy.NAME(IN1[i], IN2[i], lambdas[i]);                                \
-        });                                                                              \
+    if constexpr (std::is_same_v<Space, PortsOfCall::Exec::Host>) {                      \
+      portableFor(cname, s, 0, num,                                                      \
+                  [=](const int i) { OUT[i] = copy.NAME(IN1[i], IN2[i], lambdas[i]); }); \
+    } else {                                                                             \
+      portableFor(                                                                       \
+          cname, s, 0, num, PORTABLE_LAMBDA(const int i) {                               \
+            OUT[i] = copy.NAME(IN1[i], IN2[i], lambdas[i]);                              \
+          });                                                                            \
+    }                                                                                    \
   }                                                                                      \
   template <typename Space, typename RealIndexer, typename ConstRealIndexer,             \
             typename LambdaIndexer,                                                      \
@@ -435,10 +440,16 @@ class EosBase {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
     const CRTP &copy = *(static_cast<CRTP const *>(this));
-    portableFor(
-        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
-          sies[i] = copy.MinInternalEnergyFromDensity(rhos[i], lambdas[i]);
-        });
+    if constexpr (std::is_same_v<Space, PortsOfCall::Exec::Host>) {
+      portableFor(cname, s, 0, num, [=](const int i) {
+        sies[i] = copy.MinInternalEnergyFromDensity(rhos[i], lambdas[i]);
+      });
+    } else {
+      portableFor(
+          cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
+            sies[i] = copy.MinInternalEnergyFromDensity(rhos[i], lambdas[i]);
+          });
+    }
   }
   template <
       typename Space, typename RealIndexer, typename ConstRealIndexer,
@@ -510,11 +521,18 @@ class EosBase {
     static auto const name = SG_MEMBER_FUNC_NAME();
     static auto const cname = name.c_str();
     const CRTP &copy = *(static_cast<CRTP const *>(this));
-    portableFor(
-        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
-          copy.FillEos(rhos[i], temps[i], energies[i], presses[i], cvs[i], bmods[i],
-                       output, lambdas[i]);
-        });
+    if constexpr (std::is_same_v<Space, PortsOfCall::Exec::Host>) {
+      portableFor(cname, s, 0, num, [=](const int i) {
+        copy.FillEos(rhos[i], temps[i], energies[i], presses[i], cvs[i], bmods[i], output,
+                     lambdas[i]);
+      });
+    } else {
+      portableFor(
+          cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
+            copy.FillEos(rhos[i], temps[i], energies[i], presses[i], cvs[i], bmods[i],
+                         output, lambdas[i]);
+          });
+    }
   }
   template <typename RealIndexer, typename LambdaIndexer,
             typename EnableIfIndexed =

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -586,33 +586,31 @@ class EOSPAC : public EosBase<EOSPAC> {
       // BMOD = rho*dx[0]*CV/(CV-T[0]/(rho*rho)*dy[0]*dy[0]/dx[0]);
     }
     if (output & thermalqs::specific_heat) {
-      portableFor(
-          cname, 0, num, PORTABLE_LAMBDA(const int i) {
-            cvs[i] = std::max(DEDT[i], 0.0); // Here we do something to the data!
-          });
+      portableFor(cname, s, 0, num, [=](const int i) {
+        cvs[i] = std::max(DEDT[i], 0.0); // Here we do something to the data!
+      });
     }
     if (output & thermalqs::bulk_modulus) {
-      portableFor(
-          cname, 0, num, PORTABLE_LAMBDA(const int i) {
-            const Real rho = R[i];
-            Real BMOD = 0.0;
-            if (DEDT[i] > 0.0 && rho > 0.0) {
-              const Real DPDE = DPDT[i] / DEDT[i];
-              BMOD = rho * DPDR[i] + DPDE * (P[i] / rho - rho * DEDR[i]);
-            } else if (rho > 0.0) { // Case: DEDT <= 0
-              // We need a different DPDE call apparently????
-              // In xRAGE, they call out to P(rho,e) in this case to get the
-              // derivative directly from the half-inverted table.
-              // But upon further review,
-              // I think it will end up evaluating to BMOD_T in any case because cv will
-              // be zero! See eos_eospac.f90 line 1261 BMOD =
-              // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-              // BMOD_T = std::max(rho * DPDR[i], 0.0);
-              // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-              BMOD = std::max(rho * DPDR[i], 0.0);
-            }
-            bmods[i] = std::max(BMOD, 0.0);
-          });
+      portableFor(cname, s, 0, num, [=](const int i) {
+        const Real rho = R[i];
+        Real BMOD = 0.0;
+        if (DEDT[i] > 0.0 && rho > 0.0) {
+          const Real DPDE = DPDT[i] / DEDT[i];
+          BMOD = rho * DPDR[i] + DPDE * (P[i] / rho - rho * DEDR[i]);
+        } else if (rho > 0.0) { // Case: DEDT <= 0
+          // We need a different DPDE call apparently????
+          // In xRAGE, they call out to P(rho,e) in this case to get the
+          // derivative directly from the half-inverted table.
+          // But upon further review,
+          // I think it will end up evaluating to BMOD_T in any case because cv will
+          // be zero! See eos_eospac.f90 line 1261 BMOD =
+          // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+          // BMOD_T = std::max(rho * DPDR[i], 0.0);
+          // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+          BMOD = std::max(rho * DPDR[i], 0.0);
+        }
+        bmods[i] = std::max(BMOD, 0.0);
+      });
     }
   }
   template <typename LambdaIndexer>
@@ -775,12 +773,10 @@ class EOSPAC : public EosBase<EOSPAC> {
     const Real y = transform.y.is_set() ? (1.0 / transform.y.get()) : 1.0;
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          cvs[i] =
-              f * y *
-              cvFromSesame(std::max(DEDT[i], 0.0)); // Here we do something to the data!
-        });
+    portableFor(cname, s, 0, num, [=](const int i) {
+      cvs[i] = f * y *
+               cvFromSesame(std::max(DEDT[i], 0.0)); // Here we do something to the data!
+    });
   }
   template <typename LambdaIndexer>
   inline void
@@ -851,11 +847,10 @@ class EOSPAC : public EosBase<EOSPAC> {
 
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          cvs[i] = f * cvFromSesame(
-                           std::max(DEDT[i], 0.0)); // Here we do something to the data!
-        });
+    portableFor(cname, s, 0, num, [=](const int i) {
+      cvs[i] =
+          f * cvFromSesame(std::max(DEDT[i], 0.0)); // Here we do something to the data!
+    });
   }
   template <typename LambdaIndexer>
   inline void
@@ -917,27 +912,26 @@ class EOSPAC : public EosBase<EOSPAC> {
     const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          const Real rho = R[i];
-          Real BMOD = 0.0;
-          if (DEDT[i] > 0.0 && rho > 0.0) {
-            const Real DPDE = DPDT[i] / DEDT[i];
-            BMOD = rho * DPDR[i] + DPDE * (P[i] / (rho * x) - rho * DEDR[i]);
-          } else if (rho > 0.0) { // Case: DEDT <= 0
-            // We need a different DPDE call apparently????
-            // In xRAGE, they call out to P(rho,e) in this case to get the
-            // derivative directly from the half-inverted table.
-            // But upon further review,
-            // I think it will end up evaluating to BMOD_T in any case because cv will
-            // be zero! See eos_eospac.f90 line 1261 BMOD =
-            // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-            // BMOD_T = std::max(rho * DPDR[i], 0.0);
-            // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-            BMOD = std::max(rho * DPDR[i], 0.0);
-          }
-          bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
-        });
+    portableFor(cname, s, 0, num, [=](const int i) {
+      const Real rho = R[i];
+      Real BMOD = 0.0;
+      if (DEDT[i] > 0.0 && rho > 0.0) {
+        const Real DPDE = DPDT[i] / DEDT[i];
+        BMOD = rho * DPDR[i] + DPDE * (P[i] / (rho * x) - rho * DEDR[i]);
+      } else if (rho > 0.0) { // Case: DEDT <= 0
+        // We need a different DPDE call apparently????
+        // In xRAGE, they call out to P(rho,e) in this case to get the
+        // derivative directly from the half-inverted table.
+        // But upon further review,
+        // I think it will end up evaluating to BMOD_T in any case because cv will
+        // be zero! See eos_eospac.f90 line 1261 BMOD =
+        // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+        // BMOD_T = std::max(rho * DPDR[i], 0.0);
+        // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+        BMOD = std::max(rho * DPDR[i], 0.0);
+      }
+      bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
+    });
   }
   template <typename LambdaIndexer>
   inline void
@@ -1016,27 +1010,26 @@ class EOSPAC : public EosBase<EOSPAC> {
     const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          const Real rho = R[i];
-          Real BMOD = 0.0;
-          if (DEDT[i] > 0.0 && rho > 0.0) {
-            const Real DPDE = DPDT[i] / DEDT[i];
-            BMOD = rho * DPDR[i] + DPDE * (P[i] / (rho * x) - rho * DEDR[i]);
-          } else if (rho > 0.0) { // Case: DEDT <= 0
-            // We need a different DPDE call apparently????
-            // In xRAGE, they call out to P(rho,e) in this case to get the
-            // derivative directly from the half-inverted table.
-            // But upon further review,
-            // I think it will end up evaluating to BMOD_T in any case because cv will
-            // be zero! See eos_eospac.f90 line 1261 BMOD =
-            // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-            // BMOD_T = std::max(rho * DPDR[i], 0.0);
-            // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-            BMOD = std::max(rho * DPDR[i], 0.0);
-          }
-          bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
-        });
+    portableFor(cname, s, 0, num, [=](const int i) {
+      const Real rho = R[i];
+      Real BMOD = 0.0;
+      if (DEDT[i] > 0.0 && rho > 0.0) {
+        const Real DPDE = DPDT[i] / DEDT[i];
+        BMOD = rho * DPDR[i] + DPDE * (P[i] / (rho * x) - rho * DEDR[i]);
+      } else if (rho > 0.0) { // Case: DEDT <= 0
+        // We need a different DPDE call apparently????
+        // In xRAGE, they call out to P(rho,e) in this case to get the
+        // derivative directly from the half-inverted table.
+        // But upon further review,
+        // I think it will end up evaluating to BMOD_T in any case because cv will
+        // be zero! See eos_eospac.f90 line 1261 BMOD =
+        // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+        // BMOD_T = std::max(rho * DPDR[i], 0.0);
+        // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+        BMOD = std::max(rho * DPDR[i], 0.0);
+      }
+      bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
+    });
   }
   template <typename LambdaIndexer>
   inline void
@@ -1089,11 +1082,10 @@ class EOSPAC : public EosBase<EOSPAC> {
     const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          const Real DPDE = DPDT[i] / DEDT[i];
-          gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
-        });
+    portableFor(cname, s, 0, num, [=](const int i) {
+      const Real DPDE = DPDT[i] / DEDT[i];
+      gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
+    });
   }
   template <typename LambdaIndexer>
   inline void
@@ -1165,11 +1157,10 @@ class EOSPAC : public EosBase<EOSPAC> {
     const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(
-        cname, 0, num, PORTABLE_LAMBDA(const int i) {
-          const Real DPDE = DPDT[i] / DEDT[i];
-          gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
-        });
+    portableFor(cname, s, 0, num, [=](const int i) {
+      const Real DPDE = DPDT[i] / DEDT[i];
+      gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
+    });
   }
   template <typename LambdaIndexer>
   inline void

--- a/singularity-eos/eos/eos_eospac.hpp
+++ b/singularity-eos/eos/eos_eospac.hpp
@@ -586,31 +586,33 @@ class EOSPAC : public EosBase<EOSPAC> {
       // BMOD = rho*dx[0]*CV/(CV-T[0]/(rho*rho)*dy[0]*dy[0]/dx[0]);
     }
     if (output & thermalqs::specific_heat) {
-      portableFor(cname, s, 0, num, [=](const int i) {
-        cvs[i] = std::max(DEDT[i], 0.0); // Here we do something to the data!
-      });
+      portableFor(
+          cname, 0, num, PORTABLE_LAMBDA(const int i) {
+            cvs[i] = std::max(DEDT[i], 0.0); // Here we do something to the data!
+          });
     }
     if (output & thermalqs::bulk_modulus) {
-      portableFor(cname, s, 0, num, [=](const int i) {
-        const Real rho = R[i];
-        Real BMOD = 0.0;
-        if (DEDT[i] > 0.0 && rho > 0.0) {
-          const Real DPDE = DPDT[i] / DEDT[i];
-          BMOD = rho * DPDR[i] + DPDE * (P[i] / rho - rho * DEDR[i]);
-        } else if (rho > 0.0) { // Case: DEDT <= 0
-          // We need a different DPDE call apparently????
-          // In xRAGE, they call out to P(rho,e) in this case to get the
-          // derivative directly from the half-inverted table.
-          // But upon further review,
-          // I think it will end up evaluating to BMOD_T in any case because cv will
-          // be zero! See eos_eospac.f90 line 1261 BMOD =
-          // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-          // BMOD_T = std::max(rho * DPDR[i], 0.0);
-          // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-          BMOD = std::max(rho * DPDR[i], 0.0);
-        }
-        bmods[i] = std::max(BMOD, 0.0);
-      });
+      portableFor(
+          cname, 0, num, PORTABLE_LAMBDA(const int i) {
+            const Real rho = R[i];
+            Real BMOD = 0.0;
+            if (DEDT[i] > 0.0 && rho > 0.0) {
+              const Real DPDE = DPDT[i] / DEDT[i];
+              BMOD = rho * DPDR[i] + DPDE * (P[i] / rho - rho * DEDR[i]);
+            } else if (rho > 0.0) { // Case: DEDT <= 0
+              // We need a different DPDE call apparently????
+              // In xRAGE, they call out to P(rho,e) in this case to get the
+              // derivative directly from the half-inverted table.
+              // But upon further review,
+              // I think it will end up evaluating to BMOD_T in any case because cv will
+              // be zero! See eos_eospac.f90 line 1261 BMOD =
+              // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+              // BMOD_T = std::max(rho * DPDR[i], 0.0);
+              // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+              BMOD = std::max(rho * DPDR[i], 0.0);
+            }
+            bmods[i] = std::max(BMOD, 0.0);
+          });
     }
   }
   template <typename LambdaIndexer>
@@ -773,10 +775,12 @@ class EOSPAC : public EosBase<EOSPAC> {
     const Real y = transform.y.is_set() ? (1.0 / transform.y.get()) : 1.0;
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(cname, s, 0, num, [=](const int i) {
-      cvs[i] = f * y *
-               cvFromSesame(std::max(DEDT[i], 0.0)); // Here we do something to the data!
-    });
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+          cvs[i] =
+              f * y *
+              cvFromSesame(std::max(DEDT[i], 0.0)); // Here we do something to the data!
+        });
   }
   template <typename LambdaIndexer>
   inline void
@@ -847,10 +851,11 @@ class EOSPAC : public EosBase<EOSPAC> {
 
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(cname, s, 0, num, [=](const int i) {
-      cvs[i] =
-          f * cvFromSesame(std::max(DEDT[i], 0.0)); // Here we do something to the data!
-    });
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+          cvs[i] = f * cvFromSesame(
+                           std::max(DEDT[i], 0.0)); // Here we do something to the data!
+        });
   }
   template <typename LambdaIndexer>
   inline void
@@ -912,26 +917,27 @@ class EOSPAC : public EosBase<EOSPAC> {
     const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(cname, s, 0, num, [=](const int i) {
-      const Real rho = R[i];
-      Real BMOD = 0.0;
-      if (DEDT[i] > 0.0 && rho > 0.0) {
-        const Real DPDE = DPDT[i] / DEDT[i];
-        BMOD = rho * DPDR[i] + DPDE * (P[i] / (rho * x) - rho * DEDR[i]);
-      } else if (rho > 0.0) { // Case: DEDT <= 0
-        // We need a different DPDE call apparently????
-        // In xRAGE, they call out to P(rho,e) in this case to get the
-        // derivative directly from the half-inverted table.
-        // But upon further review,
-        // I think it will end up evaluating to BMOD_T in any case because cv will
-        // be zero! See eos_eospac.f90 line 1261 BMOD =
-        // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-        // BMOD_T = std::max(rho * DPDR[i], 0.0);
-        // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-        BMOD = std::max(rho * DPDR[i], 0.0);
-      }
-      bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
-    });
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+          const Real rho = R[i];
+          Real BMOD = 0.0;
+          if (DEDT[i] > 0.0 && rho > 0.0) {
+            const Real DPDE = DPDT[i] / DEDT[i];
+            BMOD = rho * DPDR[i] + DPDE * (P[i] / (rho * x) - rho * DEDR[i]);
+          } else if (rho > 0.0) { // Case: DEDT <= 0
+            // We need a different DPDE call apparently????
+            // In xRAGE, they call out to P(rho,e) in this case to get the
+            // derivative directly from the half-inverted table.
+            // But upon further review,
+            // I think it will end up evaluating to BMOD_T in any case because cv will
+            // be zero! See eos_eospac.f90 line 1261 BMOD =
+            // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+            // BMOD_T = std::max(rho * DPDR[i], 0.0);
+            // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+            BMOD = std::max(rho * DPDR[i], 0.0);
+          }
+          bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
+        });
   }
   template <typename LambdaIndexer>
   inline void
@@ -1010,26 +1016,27 @@ class EOSPAC : public EosBase<EOSPAC> {
     const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(cname, s, 0, num, [=](const int i) {
-      const Real rho = R[i];
-      Real BMOD = 0.0;
-      if (DEDT[i] > 0.0 && rho > 0.0) {
-        const Real DPDE = DPDT[i] / DEDT[i];
-        BMOD = rho * DPDR[i] + DPDE * (P[i] / (rho * x) - rho * DEDR[i]);
-      } else if (rho > 0.0) { // Case: DEDT <= 0
-        // We need a different DPDE call apparently????
-        // In xRAGE, they call out to P(rho,e) in this case to get the
-        // derivative directly from the half-inverted table.
-        // But upon further review,
-        // I think it will end up evaluating to BMOD_T in any case because cv will
-        // be zero! See eos_eospac.f90 line 1261 BMOD =
-        // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-        // BMOD_T = std::max(rho * DPDR[i], 0.0);
-        // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
-        BMOD = std::max(rho * DPDR[i], 0.0);
-      }
-      bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
-    });
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+          const Real rho = R[i];
+          Real BMOD = 0.0;
+          if (DEDT[i] > 0.0 && rho > 0.0) {
+            const Real DPDE = DPDT[i] / DEDT[i];
+            BMOD = rho * DPDR[i] + DPDE * (P[i] / (rho * x) - rho * DEDR[i]);
+          } else if (rho > 0.0) { // Case: DEDT <= 0
+            // We need a different DPDE call apparently????
+            // In xRAGE, they call out to P(rho,e) in this case to get the
+            // derivative directly from the half-inverted table.
+            // But upon further review,
+            // I think it will end up evaluating to BMOD_T in any case because cv will
+            // be zero! See eos_eospac.f90 line 1261 BMOD =
+            // BMOD_T+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+            // BMOD_T = std::max(rho * DPDR[i], 0.0);
+            // BMOD = BMOD_T; //+DPDE*DPDE*std::max(DEDT,0.0)*T[0]/rho;
+            BMOD = std::max(rho * DPDR[i], 0.0);
+          }
+          bmods[i] = f * bulkModulusFromSesame(std::max(BMOD, 0.0));
+        });
   }
   template <typename LambdaIndexer>
   inline void
@@ -1082,10 +1089,11 @@ class EOSPAC : public EosBase<EOSPAC> {
     const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(cname, s, 0, num, [=](const int i) {
-      const Real DPDE = DPDT[i] / DEDT[i];
-      gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
-    });
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+          const Real DPDE = DPDT[i] / DEDT[i];
+          gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
+        });
   }
   template <typename LambdaIndexer>
   inline void
@@ -1157,10 +1165,11 @@ class EOSPAC : public EosBase<EOSPAC> {
     const Real x = transform.x.is_set() ? transform.x.get() : 1.0;
     const Real f = transform.f.is_set() ? transform.f.get() : 1.0;
 
-    portableFor(cname, s, 0, num, [=](const int i) {
-      const Real DPDE = DPDT[i] / DEDT[i];
-      gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
-    });
+    portableFor(
+        cname, 0, num, PORTABLE_LAMBDA(const int i) {
+          const Real DPDE = DPDT[i] / DEDT[i];
+          gm1s[i] = f * robust::ratio(pressureFromSesame(sieToSesame(DPDE)), x * R[i]);
+        });
   }
   template <typename LambdaIndexer>
   inline void

--- a/singularity-eos/eos/modifiers/ramps_eos.hpp
+++ b/singularity-eos/eos/modifiers/ramps_eos.hpp
@@ -311,11 +311,18 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
         typeid(BilinearRampEOS<T>).name(), __func__);
     static auto const cname = name.c_str();
     auto const copy = *this;
-    portableFor(
-        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
-          const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
-          pressures[i] = std::max(pressures[i], p_ramp);
-        });
+    if constexpr (std::is_same_v<Space, PortsOfCall::Exec::Host>) {
+      portableFor(cname, s, 0, num, [=](const int i) {
+        const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
+        pressures[i] = std::max(pressures[i], p_ramp);
+      });
+    } else {
+      portableFor(
+          cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
+            const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
+            pressures[i] = std::max(pressures[i], p_ramp);
+          });
+    }
   }
 
   template <
@@ -331,11 +338,18 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
         typeid(BilinearRampEOS<T>).name(), __func__);
     static auto const cname = name.c_str();
     auto const copy = *this;
-    portableFor(
-        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
-          const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
-          pressures[i] = std::max(pressures[i], p_ramp);
-        });
+    if constexpr (std::is_same_v<Space, PortsOfCall::Exec::Host>) {
+      portableFor(cname, s, 0, num, [=](const int i) {
+        const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
+        pressures[i] = std::max(pressures[i], p_ramp);
+      });
+    } else {
+      portableFor(
+          cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
+            const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
+            pressures[i] = std::max(pressures[i], p_ramp);
+          });
+    }
   }
 
   template <
@@ -393,13 +407,22 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
         typeid(BilinearRampEOS<T>).name(), __func__);
     static auto const cname = name.c_str();
     auto const copy = *this;
-    portableFor(
-        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
-          const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
-          if (pressures[i] < p_ramp) {
-            bmods[i] = rhos[i] * copy.get_ramp_dpdrho(rhos[i]);
-          }
-        });
+    if constexpr (std::is_same_v<Space, PortsOfCall::Exec::Host>) {
+      portableFor(cname, s, 0, num, [=](const int i) {
+        const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
+        if (pressures[i] < p_ramp) {
+          bmods[i] = rhos[i] * copy.get_ramp_dpdrho(rhos[i]);
+        }
+      });
+    } else {
+      portableFor(
+          cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
+            const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
+            if (pressures[i] < p_ramp) {
+              bmods[i] = rhos[i] * copy.get_ramp_dpdrho(rhos[i]);
+            }
+          });
+    }
   }
 
   template <
@@ -419,13 +442,22 @@ class BilinearRampEOS : public EosBase<BilinearRampEOS<T>> {
         typeid(BilinearRampEOS<T>).name(), __func__);
     static auto const cname = name.c_str();
     auto const copy = *this;
-    portableFor(
-        cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
-          const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
-          if (pressures[i] < p_ramp) {
-            bmods[i] = rhos[i] * copy.get_ramp_dpdrho(rhos[i]);
-          }
-        });
+    if constexpr (std::is_same_v<Space, PortsOfCall::Exec::Host>) {
+      portableFor(cname, s, 0, num, [=](const int i) {
+        const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
+        if (pressures[i] < p_ramp) {
+          bmods[i] = rhos[i] * copy.get_ramp_dpdrho(rhos[i]);
+        }
+      });
+    } else {
+      portableFor(
+          cname, s, 0, num, PORTABLE_LAMBDA(const int i) {
+            const Real p_ramp = copy.get_ramp_pressure(rhos[i]);
+            if (pressures[i] < p_ramp) {
+              bmods[i] = rhos[i] * copy.get_ramp_dpdrho(rhos[i]);
+            }
+          });
+    }
   }
 
   template <

--- a/singularity-eos/eos/modifiers/shifted_eos.hpp
+++ b/singularity-eos/eos/modifiers/shifted_eos.hpp
@@ -175,9 +175,14 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
         singularity::mfuncname::member_func_name(typeid(ShiftedEOS<T>).name(), __func__);
     static auto const cname = name.c_str();
     const auto shift_val = shift_;
-    portableFor(
-        cname, s, 0, num,
-        PORTABLE_LAMBDA(const int i) { shifted[i] = sies[i] - shift_val; });
+    if constexpr (std::is_same_v<Space, PortsOfCall::Exec::Host>) {
+      portableFor(cname, s, 0, num,
+                  [=](const int i) { shifted[i] = sies[i] - shift_val; });
+    } else {
+      portableFor(
+          cname, s, 0, num,
+          PORTABLE_LAMBDA(const int i) { shifted[i] = sies[i] - shift_val; });
+    }
   }
 
   template <typename Space, typename EnableIfSpace =
@@ -187,8 +192,12 @@ class ShiftedEOS : public EosBase<ShiftedEOS<T>> {
         singularity::mfuncname::member_func_name(typeid(ShiftedEOS<T>).name(), __func__);
     static auto const cname = name.c_str();
     const auto shift_val = shift_;
-    portableFor(
-        cname, s, 0, num, PORTABLE_LAMBDA(const int i) { sies[i] += shift_val; });
+    if constexpr (std::is_same_v<Space, PortsOfCall::Exec::Host>) {
+      portableFor(cname, s, 0, num, [=](const int i) { sies[i] += shift_val; });
+    } else {
+      portableFor(
+          cname, s, 0, num, PORTABLE_LAMBDA(const int i) { sies[i] += shift_val; });
+    }
   }
 
   template <


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This MR is a follow up of #630 and issue #628 . I found I was still seeing compilation errors on GPU builds with python active, and the reason was that the lambda was marked `__host__ __device__` even though the execution space was host. This MR adds a constexpr branch to switch to a host-only lambda when appropriate.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
- [ ] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [ ] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Maintainers: ensure spackages are up to date:
  - [ ] LANL-internal team, update XCAP spackages
  - [ ] Current maintainer of upstream spackages, submit MR to spack
