### PR TITLE
[trivial] silence the warning about this pointer

### DIFF
--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -768,7 +768,7 @@ class Variant {
   }
   std::size_t DeSerialize(char *src,
                           const SharedMemSettings &stngs = DEFAULT_SHMEM_STNGS) {
-    memcpy(static_cast<void*>(this), src, sizeof(*this));
+    memcpy(static_cast<void *>(this), src, sizeof(*this));
     std::size_t offst = sizeof(*this);
     std::size_t dyn_size = DynamicMemorySizeInBytes();
     if (dyn_size > 0) {

--- a/singularity-eos/eos/eos_variant.hpp
+++ b/singularity-eos/eos/eos_variant.hpp
@@ -768,7 +768,7 @@ class Variant {
   }
   std::size_t DeSerialize(char *src,
                           const SharedMemSettings &stngs = DEFAULT_SHMEM_STNGS) {
-    memcpy(this, src, sizeof(*this));
+    memcpy(static_cast<void*>(this), src, sizeof(*this));
     std::size_t offst = sizeof(*this);
     std::size_t dyn_size = DynamicMemorySizeInBytes();
     if (dyn_size > 0) {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Tiny, trivial change. It is safe to copy the `this` pointer in variant, due to how the recursive serialization routines work. However, C++20 warns. This makes the compiler happy.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
- [ ] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [ ] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Maintainers: ensure spackages are up to date:
  - [ ] LANL-internal team, update XCAP spackages
  - [ ] Current maintainer of upstream spackages, submit MR to spack
