### PR TITLE
Jmm/python numpy wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR636]](https://github.com/lanl/singularity-eos/pull/636) Wrap numpy arrays in a simple wrapper to make GPU compilers happy.
 - [[PR633]](https://github.com/lanl/singularity-eos/pull/633) Make robust::sgn handle unsigned properly
 - [[PR629]](https://github.com/lanl/singularity-eos/pull/629) Use macros and eos_base and eos_variant to reduce boiler plate
 - [[PR626]](https://github.com/lanl/singularity-eos/pull/626) Fix C++20 warnings related to lambdas

--- a/python/module.hpp
+++ b/python/module.hpp
@@ -34,12 +34,12 @@ using singularity::variadic_utils::np;
 
 // Helper function to convert lambda numpy array to double* buffer
 // With std::optional we would add support for a default value of lambda=None
-template<typename T, PORTABLE_FUNCTION Real(T::*Func)(const Real, const Real, Real*&&) const>
+template<typename T, Real(T::*Func)(const Real, const Real, Real*&&) const>
 Real two_params(const T& self, const Real a, const Real b, py::array_t<Real> lambda) {
   return (self.*Func)(a, b, lambda.mutable_data());
 }
 
-template<typename T, PORTABLE_FUNCTION Real(T::*Func)(const Real, const Real, Real*&&) const>
+template<typename T, Real(T::*Func)(const Real, const Real, Real*&&) const>
 Real two_params_no_lambda(const T& self, const Real a, const Real b) {
   return (self.*Func)(a, b, np<Real>());
 }
@@ -48,6 +48,7 @@ class LambdaHelper {
   py::array_t<Real> & lambdas;
 public:
   LambdaHelper(py::array_t<Real> & lambdas) : lambdas(lambdas) {}
+  PORTABLE_INLINE_FUNCTION
   Real * operator[](const int i) const {
     return lambdas.mutable_data(i,0);
   }

--- a/python/module.hpp
+++ b/python/module.hpp
@@ -45,17 +45,23 @@ Real two_params_no_lambda(const T& self, const Real a, const Real b) {
 }
 
 class LambdaHelper {
-  py::array_t<Real> & lambdas;
+  Real *data_;
+  const std::size_t stride_;
 public:
-  LambdaHelper(py::array_t<Real> & lambdas) : lambdas(lambdas) {}
+  LambdaHelper(py::array_t<Real> & lambdas)
+    : data_(lambdas.mutable_data(0,0))
+    , stride_(lambdas.mutable_data(1,0) - lambdas.mutable_data(0,0))
+  {}
+    
   PORTABLE_INLINE_FUNCTION
   Real * operator[](const int i) const {
-    return lambdas.mutable_data(i,0);
+    return data_[i*stride_];
   }
 };
 
 class NoLambdaHelper {
 public:
+  PORTABLE_INLINE_FUNCTION
   Real * operator[](const int i) const {
     return nullptr;
   }
@@ -93,6 +99,7 @@ private:
   Real *data_;
   const std::size_t stride_;
 };
+
 
 // so far didn't find a good way of working with template member function pointers
 // to generalize this without the preprocessor.

--- a/python/module.hpp
+++ b/python/module.hpp
@@ -75,6 +75,7 @@ public:
     : data_(t.mutable_data(0))
     , stride_(t.mutable_data(1) - t.mutable_data(0))
   {}
+  PORTABLE_INLINE_FUNCTION
   Real &operator[](const std::size_t i) const {
     return data_[i*stride_];
   }
@@ -102,8 +103,8 @@ void func(const T & self, py::array_t<Real> a, py::array_t<Real> b,             
   if (lambdas_info.ndim != 2)                                                     \
       throw std::runtime_error("lambdas dimension must be 2!");                   \
                                                                                   \
-  auto av = a.unchecked<1>();                                                     \
-  auto bv = b.unchecked<1>();                                                     \
+  auto av = PyArrayHelper(a.mutable_unchecked<1>());                              \
+  auto bv = PyArrayHelper(b.mutable_unchecked<1>());                              \
   auto outv = PyArrayHelper(out.mutable_unchecked<1>());                          \
   PortsOfCall::Exec::Host host;                                                   \
   if(lambdas_info.shape[1] > 0) {                                                 \
@@ -141,8 +142,8 @@ void func##WithScratch(const T & self, py::array_t<Real> a, py::array_t<Real> b,
 template<typename T>                                                              \
 void func##NoLambda(const T & self, py::array_t<Real> a, py::array_t<Real> b,     \
           py::array_t<Real> out){                                                 \
-  auto av = a.unchecked<1>();                                                     \
-  auto bv = b.unchecked<1>();                                                     \
+  auto av = PyArrayHelper(a.mutable_unchecked<1>());                              \
+  auto bv = PyArrayHelper(b.mutable_unchecked<1>());                              \
   auto outv = PyArrayHelper(out.mutable_unchecked<1>());                          \
   PortsOfCall::Exec::Host host;                                                   \
   self.func(host, av, bv, outv, a.size(), NoLambdaHelper());                      \

--- a/python/module.hpp
+++ b/python/module.hpp
@@ -55,7 +55,7 @@ public:
     
   PORTABLE_INLINE_FUNCTION
   Real * operator[](const int i) const {
-    return data_[i*stride_];
+    return &data_[i*stride_];
   }
 };
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This MR supersedes #634 . The issue is that, despite Python calling only host code (thanks to #630 ), the loops are still marked with `PORTABLE_LAMBDA`s which means the compiler detects that host only code (numpy arrays `operator[]`) is called from a function marked `__host__ __device__` (the portable lambda). #634 fixed this by adding a switch on the lambda making it either `PORTABLE_LAMBDA` or `[=]` depending on execution space. 

This MR instead wraps `numpy` arrays in a very thin wrapper. @jdolence and I actually already wrote this wrapper for a prior MR, so almost no changes needed to be made. The wrapper lies to the compiler by marking the `operator[]` as `PORTABLE_INLINE_FUNCTION` despite the memory always being host memory. Nevertheless, this is safe, because we always call the python explicitly on host.

This MR eliminates warnings on GPU architectures related to calling host functions from device. It also is required for the python code to compile on AMD GPU architectures, if a non-host backend is active.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
- [ ] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [ ] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Maintainers: ensure spackages are up to date:
  - [ ] LANL-internal team, update XCAP spackages
  - [ ] Current maintainer of upstream spackages, submit MR to spack
