### PR TITLE
Fix bugs in Davis EOS's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [[PR623]](https://github.com/lanl/singularity-eos/pull/623) Expanded the sesame2spiner syntax to support multiple material definitions in one input file.
 - [[PR618]](https://github.com/lanl/singularity-eos/pull/618) Add PTDerivativesFromPreferred for computing derivatives of a mixture  in a cell
 - [[PR630]](https://github.com/lanl/singularity-eos/pull/630) Thread execution spaces through vector API.
+- [[PR638]](https://github.com/lanl/singularity-eos/pull/638) Fix Bugs in Davis Reactants and Products.  Bulk modulus is now isentropic.
 
 ### Fixed (Repair bugs, etc)
 

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2026. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -463,11 +463,14 @@ PORTABLE_INLINE_FUNCTION Real DavisReactants::BulkModulusFromDensityInternalEner
                  3 * robust::ratio(y, pow<4>(1 - y)) +
                  4 * robust::ratio(pow<2>(y), pow<5>(1 - y)))
           : -phat * 4 * _B * _rho0 * std::exp(b4y);
-  const Real gammav = (rho >= _rho0) ? _Z * _rho0 : 0.0;
+  const Real gammav = (rho >= _rho0) ? -_Z * _rho0 : 0.0;
+  const Real es = Es(rho);
   const Real numerator =
-      -(psv + (sie - Es(rho)) * std::max(rho, 0.) * (gammav - gamma * std::max(rho, 0.)) -
+      -(psv + (sie - es) * std::max(rho, 0.) * (gammav - gamma * std::max(rho, 0.)) -
         gamma * std::max(rho, 0.) * esv);
-  return robust::ratio(numerator, std::max(rho, 0.));
+  const Real ke = robust::ratio(numerator, std::max(rho, 0.));
+  const Real p = -esv + rho*gamma * (sie - es);
+  return ke + gamma * p;
 }
 
 template <typename Indexer_t>
@@ -535,7 +538,7 @@ PORTABLE_INLINE_FUNCTION Real DavisProducts::BulkModulusFromDensityInternalEnerg
   }
   const Real vvc = robust::ratio(1.0, rho * _vc);
   const Real Fx =
-      -4 * _a *
+      -4 * _a * _n *
       robust::ratio(std::pow(vvc, 2 * _n - 1), pow<2>(1 + std::pow(vvc, 2 * _n)));
   const Real tmp =
       robust::ratio(std::pow(0.5 * (std::pow(vvc, _n) + std::pow(vvc, -_n)), _aon),
@@ -551,9 +554,12 @@ PORTABLE_INLINE_FUNCTION Real DavisProducts::BulkModulusFromDensityInternalEnerg
   // const Real esv = _pc*_vc/(_k-1+_a)*(tmp+vvc*tmp_x)/_vc;
   const Real esv = robust::ratio(_pc, _k - 1 + _a) * (tmp + vvc * tmp_x);
   const Real gamma = Gamma(rho);
-  const Real gammav = (1 - _b) * Fx * _vc;
-  return -robust::ratio(
-      psv + (sie - Es(rho)) * rho * (gammav - gamma * rho) - gamma * rho * esv, rho);
+  const Real es = Es(rho);
+  const Real gammav = (1 - _b) * Fx / _vc;
+  const Real ke =  -robust::ratio(
+      psv + (sie - es) * rho * (gammav - gamma * rho) - gamma * rho * esv, rho);
+  const Real p = Ps(rho) + rho * gamma * (sie - es);
+  return ke + gamma * p;
 }
 template <typename Indexer_t>
 PORTABLE_INLINE_FUNCTION void DavisProducts::DensityEnergyFromPressureTemperature(

--- a/singularity-eos/eos/eos_davis.hpp
+++ b/singularity-eos/eos/eos_davis.hpp
@@ -469,7 +469,7 @@ PORTABLE_INLINE_FUNCTION Real DavisReactants::BulkModulusFromDensityInternalEner
       -(psv + (sie - es) * std::max(rho, 0.) * (gammav - gamma * std::max(rho, 0.)) -
         gamma * std::max(rho, 0.) * esv);
   const Real ke = robust::ratio(numerator, std::max(rho, 0.));
-  const Real p = -esv + rho*gamma * (sie - es);
+  const Real p = -esv + rho * gamma * (sie - es);
   return ke + gamma * p;
 }
 
@@ -556,7 +556,7 @@ PORTABLE_INLINE_FUNCTION Real DavisProducts::BulkModulusFromDensityInternalEnerg
   const Real gamma = Gamma(rho);
   const Real es = Es(rho);
   const Real gammav = (1 - _b) * Fx / _vc;
-  const Real ke =  -robust::ratio(
+  const Real ke = -robust::ratio(
       psv + (sie - es) * rho * (gammav - gamma * rho) - gamma * rho * esv, rho);
   const Real p = Ps(rho) + rho * gamma * (sie - es);
   return ke + gamma * p;

--- a/test/test_eos_davis.cpp
+++ b/test/test_eos_davis.cpp
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// © 2021-2025. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2026. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -110,27 +110,26 @@ SCENARIO("Davis reactants EOS basic calls", "[DavisReactants]") {
       THEN("The Bulk modulus is isentropic") {
         int nwrong = 0;
         portableReduce(
-          "Compare Derivative to finite difference", 0, N,
-          PORTABLE_LAMBDA(const int i, int &nw) {
-            const Real rho = rho0;
-            const Real sie = e0 + (-N/2 + i) * 4.115e-8;
-            const Real Gamma = eos.GruneisenParamFromDensityInternalEnergy(rho, sie);
-            const Real bmod = eos.BulkModulusFromDensityInternalEnergy(rho, sie);
-            const Real P = eos.PressureFromDensityInternalEnergy(rho, sie);
-            const Real dpdr = (bmod - P*Gamma)/rho; //correct answer
-            const Real rplus = rho0*(1.0 + 1e-6);
-            const Real rminus = rho0*(1.0 - 1e-6);
-            const Real Pplus = eos.PressureFromDensityInternalEnergy(rplus, sie);
-            const Real Pminus = eos.PressureFromDensityInternalEnergy(rminus, sie);
-            const Real dpdr_fd = (Pplus - Pminus)/(rho*2e-6);
-            nw += !(isClose(dpdr/dpdr_fd, 1.0, 1e-4));
-          },
-          nwrong);
+            "Compare Derivative to finite difference", 0, N,
+            PORTABLE_LAMBDA(const int i, int &nw) {
+              const Real rho = rho0;
+              const Real sie = e0 + (-N / 2 + i) * 4.115e-8;
+              const Real Gamma = eos.GruneisenParamFromDensityInternalEnergy(rho, sie);
+              const Real bmod = eos.BulkModulusFromDensityInternalEnergy(rho, sie);
+              const Real P = eos.PressureFromDensityInternalEnergy(rho, sie);
+              const Real dpdr = (bmod - P * Gamma) / rho; // correct answer
+              const Real rplus = rho0 * (1.0 + 1e-6);
+              const Real rminus = rho0 * (1.0 - 1e-6);
+              const Real Pplus = eos.PressureFromDensityInternalEnergy(rplus, sie);
+              const Real Pminus = eos.PressureFromDensityInternalEnergy(rminus, sie);
+              const Real dpdr_fd = (Pplus - Pminus) / (rho * 2e-6);
+              nw += !(isClose(dpdr / dpdr_fd, 1.0, 1e-4));
+            },
+            nwrong);
         REQUIRE(nwrong == 0);
       }
     }
-  
-  
+
     eos_host.Finalize();
     eos.Finalize();
   }
@@ -175,22 +174,22 @@ SCENARIO("Davis products EOS basic calls", "[DavisProducts]") {
       THEN("The Bulk modulus is isentropic") {
         int nwrong = 0;
         portableReduce(
-          "Compare Derivative to finite difference", 0, N,
-          PORTABLE_LAMBDA(const int i, int &nw) {
-            const Real rho = rho0;
-            const Real sie = e0 + (-N/2 + i) * 4.115e-8;
-            const Real Gamma = eos.GruneisenParamFromDensityInternalEnergy(rho, sie);
-            const Real bmod = eos.BulkModulusFromDensityInternalEnergy(rho, sie);
-            const Real P = eos.PressureFromDensityInternalEnergy(rho, sie);
-            const Real dpdr = (bmod - P*Gamma)/rho; //correct answer
-            const Real rplus = rho0*(1.0 + 1e-6);
-            const Real rminus = rho0*(1.0 - 1e-6);
-            const Real Pplus = eos.PressureFromDensityInternalEnergy(rplus, sie);
-            const Real Pminus = eos.PressureFromDensityInternalEnergy(rminus, sie);
-            const Real dpdr_fd = (Pplus - Pminus)/(rho*2e-6);
-            nw += !(isClose(dpdr/dpdr_fd, 1.0, 1e-4));
-          },
-          nwrong);
+            "Compare Derivative to finite difference", 0, N,
+            PORTABLE_LAMBDA(const int i, int &nw) {
+              const Real rho = rho0;
+              const Real sie = e0 + (-N / 2 + i) * 4.115e-8;
+              const Real Gamma = eos.GruneisenParamFromDensityInternalEnergy(rho, sie);
+              const Real bmod = eos.BulkModulusFromDensityInternalEnergy(rho, sie);
+              const Real P = eos.PressureFromDensityInternalEnergy(rho, sie);
+              const Real dpdr = (bmod - P * Gamma) / rho; // correct answer
+              const Real rplus = rho0 * (1.0 + 1e-6);
+              const Real rminus = rho0 * (1.0 - 1e-6);
+              const Real Pplus = eos.PressureFromDensityInternalEnergy(rplus, sie);
+              const Real Pminus = eos.PressureFromDensityInternalEnergy(rminus, sie);
+              const Real dpdr_fd = (Pplus - Pminus) / (rho * 2e-6);
+              nw += !(isClose(dpdr / dpdr_fd, 1.0, 1e-4));
+            },
+            nwrong);
         REQUIRE(nwrong == 0);
       }
     }

--- a/test/test_eos_davis.cpp
+++ b/test/test_eos_davis.cpp
@@ -95,7 +95,7 @@ SCENARIO("Davis reactants EOS basic calls", "[DavisReactants]") {
               Real rho = 0;
               Real P = eos.PressureFromDensityTemperature(rho, T);
               Real E = eos.InternalEnergyFromDensityTemperature(rho, T);
-              Real bmod = eos.BulkModulusFromDensityInternalEnergy(rho, T);
+              Real bmod = eos.BulkModulusFromDensityInternalEnergy(rho, E);
               nw += std::isnan(P);
               nw += std::isnan(E);
               nw += std::isnan(bmod);
@@ -106,13 +106,40 @@ SCENARIO("Davis reactants EOS basic calls", "[DavisReactants]") {
       }
     }
 
+    WHEN("The sie of the EOS is varied") {
+      THEN("The Bulk modulus is isentropic") {
+        int nwrong = 0;
+        portableReduce(
+          "Compare Derivative to finite difference", 0, N,
+          PORTABLE_LAMBDA(const int i, int &nw) {
+            const Real rho = rho0;
+            const Real sie = e0 + (-N/2 + i) * 4.115e-8;
+            const Real Gamma = eos.GruneisenParamFromDensityInternalEnergy(rho, sie);
+            const Real bmod = eos.BulkModulusFromDensityInternalEnergy(rho, sie);
+            const Real P = eos.PressureFromDensityInternalEnergy(rho, sie);
+            const Real dpdr = (bmod - P*Gamma)/rho; //correct answer
+            const Real rplus = rho0*(1.0 + 1e-6);
+            const Real rminus = rho0*(1.0 - 1e-6);
+            const Real Pplus = eos.PressureFromDensityInternalEnergy(rplus, sie);
+            const Real Pminus = eos.PressureFromDensityInternalEnergy(rminus, sie);
+            const Real dpdr_fd = (Pplus - Pminus)/(rho*2e-6);
+            nw += !(isClose(dpdr/dpdr_fd, 1.0, 1e-4));
+          },
+          nwrong);
+        REQUIRE(nwrong == 0);
+      }
+    }
+  
+  
     eos_host.Finalize();
     eos.Finalize();
   }
 }
 
 SCENARIO("Davis products EOS basic calls", "[DavisProducts]") {
-  GIVEN("A davis reactants equation of state") {
+  GIVEN("A davis productss equation of state") {
+    constexpr Real rho0 = 1.890;
+    constexpr Real e0 = 4.115e10;
     constexpr Real a = 0.798311;
     constexpr Real b = 0.58;
     constexpr Real k = 1.35;
@@ -133,13 +160,37 @@ SCENARIO("Davis products EOS basic calls", "[DavisProducts]") {
               Real rho = 0;
               Real P = eos.PressureFromDensityTemperature(rho, T);
               Real E = eos.InternalEnergyFromDensityTemperature(rho, T);
-              Real bmod = eos.BulkModulusFromDensityInternalEnergy(rho, T);
+              Real bmod = eos.BulkModulusFromDensityInternalEnergy(rho, E);
               nw += std::isnan(P);
               nw += std::isnan(E);
               nw += std::isnan(bmod);
               nw += (bmod < 0);
             },
             nwrong);
+        REQUIRE(nwrong == 0);
+      }
+    }
+
+    WHEN("The sie of the EOS is varied") {
+      THEN("The Bulk modulus is isentropic") {
+        int nwrong = 0;
+        portableReduce(
+          "Compare Derivative to finite difference", 0, N,
+          PORTABLE_LAMBDA(const int i, int &nw) {
+            const Real rho = rho0;
+            const Real sie = e0 + (-N/2 + i) * 4.115e-8;
+            const Real Gamma = eos.GruneisenParamFromDensityInternalEnergy(rho, sie);
+            const Real bmod = eos.BulkModulusFromDensityInternalEnergy(rho, sie);
+            const Real P = eos.PressureFromDensityInternalEnergy(rho, sie);
+            const Real dpdr = (bmod - P*Gamma)/rho; //correct answer
+            const Real rplus = rho0*(1.0 + 1e-6);
+            const Real rminus = rho0*(1.0 - 1e-6);
+            const Real Pplus = eos.PressureFromDensityInternalEnergy(rplus, sie);
+            const Real Pminus = eos.PressureFromDensityInternalEnergy(rminus, sie);
+            const Real dpdr_fd = (Pplus - Pminus)/(rho*2e-6);
+            nw += !(isClose(dpdr/dpdr_fd, 1.0, 1e-4));
+          },
+          nwrong);
         REQUIRE(nwrong == 0);
       }
     }


### PR DESCRIPTION
Fix a couple of bugs in the Davis Eos's.

## PR Summary

There were a few minor mistakes, but most notably, it was returning something like an isoenergy bulk modulus.  It now returns the isentropic bulk modulus

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
- [x] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [x] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Maintainers: ensure spackages are up to date:
  - [ ] LANL-internal team, update XCAP spackages
  - [ ] Current maintainer of upstream spackages, submit MR to spack
