### PR TITLE
Save my sanity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,6 +589,9 @@ target_compile_options(
          # `-Wclass-memaccess now default with -Wall but we explicitly
          # manage this ourselves in our serialization routines.
          $<$<AND:$<CXX_COMPILER_ID:GNU>,$<COMPILE_LANGUAGE:CXX>>:-Wno-class-memaccess>
+         # Intel compilers enable -ffast-math even in Debug builds. This disables finite-math-only in 
+         # Debug builds to allow NaN/Inf checks without pages of warnings
+         $<$<AND:$<CONFIG:Debug>,$<OR:$<CXX_COMPILER_ID:IntelLLVM>,$<CXX_COMPILER_ID:Intel>>>:-fno-finite-math-only>
 )
 if (SINGULARITY_STRICT_WARNINGS)
   target_compile_options(singularity-eos_Interface INTERFACE


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

On one of the systems I'm building on, I'm using an intel compiler, and for `Debug` builds there are literal thousands of lines of compiler warnings related to tautological comparisons for nan and inf checks. This is because even in Debug mode, intel will enable `-ffast-math` which assumes your code will not produce nans/infs. 

This adds a compile flag to disable some piece of this in Debug Intel builds.

Not sure if this needs a changelog

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
- [ ] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [ ] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Maintainers: ensure spackages are up to date:
  - [ ] LANL-internal team, update XCAP spackages
  - [ ] Current maintainer of upstream spackages, submit MR to spack
