### PR TITLE
only require library component if it is built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR634]](https://github.com/lanl/singularity-eos/pull/643) Fixed `find_package(singularity-eos)` failures when built without closure variant. The CMake config now automatically detects which components were built and only requires those that exist, enabling header-only usage without the compiled library.
 - [[PR632]](https://github.com/lanl/singularity-eos/pull/632) Added generic constructors to SpinerEOSDependsRhoSie and SpinerEOSDependsRhoT that build tables from any EOS object.
 - [[PR623]](https://github.com/lanl/singularity-eos/pull/623) Expanded the sesame2spiner syntax to support multiple material definitions in one input file.
 - [[PR618]](https://github.com/lanl/singularity-eos/pull/618) Add PTDerivativesFromPreferred for computing derivatives of a mixture  in a cell

--- a/config/singularity-eosConfig.cmake.in
+++ b/config/singularity-eosConfig.cmake.in
@@ -31,6 +31,13 @@ endif()
 # ------------------------------------------------------------------------------#
 # check for selected components
 # ------------------------------------------------------------------------------#
+
+# Determine which components were actually built and installed
+set(${CMAKE_FIND_PACKAGE_NAME}_available_components Interface)
+if(@SINGULARITY_BUILD_CLOSURE@)
+  list(APPEND ${CMAKE_FIND_PACKAGE_NAME}_available_components Library)
+endif()
+
 if(${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
   set(${CMAKE_FIND_PACKAGE_NAME}_known_components Interface Library)
   foreach(comp IN LISTS ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
@@ -42,7 +49,8 @@ if(${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
   endforeach()
   set(${CMAKE_FIND_PACKAGE_NAME}_comps ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS})
 else()
-  set(${CMAKE_FIND_PACKAGE_NAME}_comps Interface Library)
+  # Default to all available components (only what was actually built)
+  set(${CMAKE_FIND_PACKAGE_NAME}_comps ${${CMAKE_FIND_PACKAGE_NAME}_available_components})
 endif()
 
 foreach(comp IN LISTS ${CMAKE_FIND_PACKAGE_NAME}_comps)


### PR DESCRIPTION
This changes cmake so that when the archive library isn't built it isn't required by default either.  Please review vigorously as I'm not really a cmake expert.
## PR Summary

When closure isn't built an archive file isn't created.  This makes it so that users don't have a default requirement for an archive that doesn't exist.  There is a work around on their part, if we don't like my solution here.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by using the `make format` command after configuring with `cmake`.
- [x] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [x] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
- [x] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [x] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [x] Update the version in cmake.
- [x] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [x] Maintainers: ensure spackages are up to date:
  - [x ] LANL-internal team, update XCAP spackages
  - [x] Current maintainer of upstream spackages, submit MR to spack
