### PR TITLE
Add missing headers from registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added (new features/APIs/variables/...)
 
 ### Fixed (Repair bugs, etc)
-
+- [[PR647]](https://github.com/lanl/singularity-eos/pull/647) Add missing headers to the registration in singularity-eos/CMakeLists.txt
 ### Changed (changing behavior/API/variables/...)
 
 ### Infrastructure (changes irrelevant to downstream codes)

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -28,6 +28,8 @@ register_headers(
     base/spiner_table_utils.hpp
     base/constants.hpp
     base/eos_error.hpp
+    base/eos_concepts.hpp
+    base/finite_diff.hpp
     eos/default_variant.hpp
     eos/eos_variant.hpp
     eos/eos_stellar_collapse.hpp
@@ -39,6 +41,7 @@ register_headers(
     eos/eos_spiner_rho_sie.hpp
     eos/eos_spiner_rho_temp.hpp
     eos/eos_spiner_common.hpp
+    eos/eos_spiner_constructor.hpp
     eos/eos_spiner_sie_transforms.hpp
     eos/eos_davis.hpp
     eos/eos_gruneisen.hpp

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -75,6 +75,7 @@ if (SINGULARITY_BUILD_CLOSURE)
     closure/kinetic_phasetransition_models.hpp
     closure/kinetic_phasetransition_utils.hpp
     closure/kinetic_phasetransition_methods.hpp
+    closure/multiphase_material.hpp
   )
   if (SINGULARITY_BUILD_FORTRAN_BACKEND OR SINGULARITY_BUILD_TESTS)
     # while these are C++ files, they

--- a/singularity-eos/CMakeLists.txt
+++ b/singularity-eos/CMakeLists.txt
@@ -41,7 +41,7 @@ register_headers(
     eos/eos_spiner_rho_sie.hpp
     eos/eos_spiner_rho_temp.hpp
     eos/eos_spiner_common.hpp
-    eos/eos_spiner_constructor.hpp
+    eos/eos_spiner_construction.hpp
     eos/eos_spiner_sie_transforms.hpp
     eos/eos_davis.hpp
     eos/eos_gruneisen.hpp


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
Several header files were missing from the singularity-eos/CMakeLists.txt file.  This MR adds them.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
Without registration, the headers aren't installed and codes depending on singularity-eos will fail to build.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
- [ ] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [ ] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Maintainers: ensure spackages are up to date:
  - [ ] LANL-internal team, update XCAP spackages
  - [ ] Current maintainer of upstream spackages, submit MR to spack
