### PR TITLE
[potentially breaking] update to use pybind11 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "utils/kokkos-kernels"]
 	path = utils/kokkos-kernels
 	url = https://github.com/kokkos/kokkos-kernels.git
+[submodule "utils/pybind11"]
+	path = utils/pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR653]](https://github.com/lanl/singularity-eos/pull/653) Move pybind11 to a submodule rather than fetching it via cmake fetchcontent
 
 ### Deprecated (soon to be removed behavior/API/variables/...)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ include(singularity-eos/hdf5)
 include(singularity-eos/kokkos)
 include(singularity-eos/spiner)
 include(singularity-eos/ports-of-call)
+include(singularity-eos/pybind11)
 
 add_library(singularity-eos INTERFACE)
 add_library(singularity-eos::singularity-eos ALIAS singularity-eos)
@@ -294,6 +295,10 @@ endif()
 # Must happen before building singularity-utils (which needs ports-of-call and spiner)
 # Dependency order: Kokkos -> ports-of-call -> spiner -> singularity-utils
 
+if (SINGULARITY_BUILD_PYTHON)
+  find_package(Python COMPONENTS Interpreter Development REQUIRED)
+endif()
+
 if(SINGULARITY_SUBMODULE_MODE)
   # add all submodules
   message(STATUS "singularity-eos configuring in submodule mode.")
@@ -318,6 +323,11 @@ if(SINGULARITY_SUBMODULE_MODE)
   if(SINGULARITY_USE_EIGEN)
     singularity_import_eigen()
   endif()
+
+  # And pybind11 (if needed)
+  if (SINGULARITY_BUILD_PYTHON)
+    singularity_import_pybind11()
+  endif()
 else()
   # use system packages
 
@@ -340,6 +350,11 @@ else()
   # Eigen (if needed)
   if(SINGULARITY_USE_EIGEN)
     singularity_find_eigen()
+  endif()
+
+  # And pybind11 (if needed)
+  if (SINGULARITY_BUILD_PYTHON)
+    singularity_find_pybind11()
   endif()
 endif()
 

--- a/cmake/singularity-eos/pybind11.cmake
+++ b/cmake/singularity-eos/pybind11.cmake
@@ -1,3 +1,16 @@
+# ------------------------------------------------------------------------------#
+# © 2021-2026. Triad National Security, LLC. All rights reserved.  This program
+# was produced under U.S. Government contract 89233218CNA000001 for Los Alamos
+# National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S.  Department of Energy/National Nuclear Security Administration.
+# All rights in the program are reserved by Triad National Security, LLC, and
+# the U.S. Department of Energy/National Nuclear Security Administration. The
+# Government is granted for itself and others acting on its behalf a
+# nonexclusive, paid-up, irrevocable worldwide license in this material to
+# reproduce, prepare derivative works, distribute copies to the public, perform
+# publicly and display publicly, and to permit others to do so.
+# ------------------------------------------------------------------------------#
+
 macro(singularity_import_pybind11)
   if(NOT TARGET pybind11::headers)
     message(STATUS "Using pybind11 submodule")

--- a/cmake/singularity-eos/pybind11.cmake
+++ b/cmake/singularity-eos/pybind11.cmake
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------#
-# © 2021-2026. Triad National Security, LLC. All rights reserved.  This program
+# © 2026. Triad National Security, LLC. All rights reserved.  This program
 # was produced under U.S. Government contract 89233218CNA000001 for Los Alamos
 # National Laboratory (LANL), which is operated by Triad National Security, LLC
 # for the U.S.  Department of Energy/National Nuclear Security Administration.

--- a/cmake/singularity-eos/pybind11.cmake
+++ b/cmake/singularity-eos/pybind11.cmake
@@ -1,0 +1,11 @@
+macro(singularity_import_pybind11)
+  if(NOT TARGET pybind11::headers)
+    message(STATUS "Using pybind11 submodule")
+    add_subdirectory(utils/pybind11)
+  endif()
+endmacro()
+
+macro(singularity_find_pybind11)
+  message(STATUS "Searching for system pybind11")
+  find_package(pybind11 REQUIRED)
+endmacro()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,3 +1,16 @@
+# ------------------------------------------------------------------------------#
+# © 2021-2026. Triad National Security, LLC. All rights reserved.  This program
+# was produced under U.S. Government contract 89233218CNA000001 for Los Alamos
+# National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S.  Department of Energy/National Nuclear Security Administration.
+# All rights in the program are reserved by Triad National Security, LLC, and
+# the U.S. Department of Energy/National Nuclear Security Administration. The
+# Government is granted for itself and others acting on its behalf a
+# nonexclusive, paid-up, irrevocable worldwide license in this material to
+# reproduce, prepare derivative works, distribute copies to the public, perform
+# publicly and display publicly, and to permit others to do so.
+# ------------------------------------------------------------------------------#
+
 pybind11_add_module(singularity_eos
   module.cpp
   modifier_shifted.cpp

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,20 +1,3 @@
-find_package(Python COMPONENTS Interpreter Development REQUIRED)
-find_package(pybind11 CONFIG QUIET)
-
-if(NOT pybind11_FOUND)
-  message(STATUS "No pybind11 installation found, fetching from GitHub.")
-  include(FetchContent)
-  FetchContent_Declare(pybind11
-    GIT_REPOSITORY https://github.com/pybind/pybind11
-    GIT_TAG        v2.9.2
-  )
-  FetchContent_GetProperties(pybind11)
-  if(NOT pybind11_POPULATED)
-    FetchContent_Populate(pybind11)
-    add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
-  endif()
-endif()
-
 pybind11_add_module(singularity_eos
   module.cpp
   modifier_shifted.cpp

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------#
-# © 2021-2026. Triad National Security, LLC. All rights reserved.  This program
+# © 2022-2026. Triad National Security, LLC. All rights reserved.  This program
 # was produced under U.S. Government contract 89233218CNA000001 for Los Alamos
 # National Laboratory (LANL), which is operated by Triad National Security, LLC
 # for the U.S.  Department of Energy/National Nuclear Security Administration.


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I am setting up CI for riot, which does not use spack, and I am finding that including pybind11 via git submodules is less painful than via pybind11. I *think* because we do everything via spack or via git submodules this should not be breaking but we should double check by making sure all the CI passes.

This does make pybind11 more in-line with how we treat other dependencies in singularity-eos so I think it's reasonable.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `make format` command after configuring with `cmake`.
- [ ] Document any new features, update documentation for changes made.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [x] After creating a pull request, note it in the CHANGELOG.md file.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
- [ ] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [ ] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Move the changes in the CHANGELOG.md file under a new header for the new release, and reset the categories.
- [ ] Maintainers: ensure spackages are up to date:
  - [ ] LANL-internal team, update XCAP spackages
  - [ ] Current maintainer of upstream spackages, submit MR to spack
